### PR TITLE
Fix dodge direction

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/engine/ControllEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControllEngine.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import net.minecraft.util.MovementInput;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWCursorPosCallbackI;
 
@@ -270,6 +271,10 @@ public class ControllEngine {
 	public void setKeyBind(KeyBinding key, boolean setter) {
 		KeyBinding.setKeyBindState(key.getKey(), setter);
 	}
+
+    public MovementInput getMovementInput() {
+        return player != null ? player.movementInput : new MovementInput();
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	@Mod.EventBusSubscriber(modid = EpicFightMod.MODID, value = Dist.CLIENT)

--- a/src/main/java/yesman/epicfight/skill/DodgeSkill.java
+++ b/src/main/java/yesman/epicfight/skill/DodgeSkill.java
@@ -1,8 +1,8 @@
 package yesman.epicfight.skill;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.client.GameSettings;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.MovementInput;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -79,11 +79,11 @@ public class DodgeSkill extends Skill {
 	@OnlyIn(Dist.CLIENT)
 	@Override
 	public PacketBuffer gatherArguments(ClientPlayerData executer, ControllEngine controllEngine) {
-		GameSettings gamesetting = controllEngine.gameSettings;
-		int forward = gamesetting.keyBindForward.isKeyDown() ? 1 : 0;
-		int backward = gamesetting.keyBindBack.isKeyDown() ? -1 : 0;
-		int left = gamesetting.keyBindLeft.isKeyDown() ? 1 : 0;
-		int right = gamesetting.keyBindRight.isKeyDown() ? -1 : 0;
+        MovementInput input = controllEngine.getMovementInput();
+        int forward = input.forwardKeyDown ? 1 : 0;
+        int backward = input.backKeyDown ? -1 : 0;
+        int left = input.leftKeyDown ? 1 : 0;
+        int right = input.rightKeyDown ? -1 : 0;
 		
 		PacketBuffer buf = new PacketBuffer(Unpooled.buffer());
 		


### PR DESCRIPTION
Movement input that was calculated by keybind reading can be modified by event listeners from other mods. It will be better to use player movement input as a source for dodge direction. Just more compat with other mods!