### PR TITLE
Fix usage of AnimationRegistryEvent for other mods

### DIFF
--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -110,10 +110,6 @@ public class EpicFightMod {
     	Style.ENUM_MANAGER.load(Styles.class);
     	WeaponCategory.ENUM_MANAGER.load(WeaponCategories.class);
     	
-    	this.animationManager.registerAnimations();
-    	Skills.registerSkills();
-    	SkillArgument.registerArgumentTypes();
-    	
     	EpicFightMobEffects.EFFECTS.register(bus);
     	EpicFightPotions.POTIONS.register(bus);
         EpicFightAttributes.ATTRIBUTES.register(bus);
@@ -162,6 +158,9 @@ public class EpicFightMod {
 	}
 	
 	private void doCommonStuff(final FMLCommonSetupEvent event) {
+		event.enqueueWork(this.animationManager::registerAnimations);
+		event.enqueueWork(Skills::registerSkills);
+		event.enqueueWork(SkillArgument::registerArgumentTypes);
 		event.enqueueWork(EpicFightPotions::addRecipes);
 		event.enqueueWork(EpicFightNetworkManager::registerPackets);
 		event.enqueueWork(ProviderItem::registerWeaponTypesByClass);


### PR DESCRIPTION
This moves the animation registration to the FMLCommonSetupEvent so it's possible for other mods to register a listener to the event, without this the event is posted before other mods can register a listener as the dependency load order doesn't do anything when they initially load in parallel. I also moved the Skill registry as that relies on the animations being registered first and the SkillRegistryEvent should work for other mods too with this change.

As far as I can tell nothing is broken by this change and testing with Kingdom Keys I was able to register a new animation.