### PR TITLE
Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,2 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:


### PR DESCRIPTION
# Why
One thing you guys seem to be forgetting is that GitHub Issues can be created for feature requests/suggestions as well.

There has been a feature request template idk why it's removed, but at least I don't think it's a good idea to fill in the bug report with things that are completely useless for Suggestion/Feature Requests