### PR TITLE
Update PlayerEvents.java

### DIFF
--- a/src/main/java/yesman/epicfight/events/PlayerEvents.java
+++ b/src/main/java/yesman/epicfight/events/PlayerEvents.java
@@ -151,11 +151,14 @@ public class PlayerEvents {
 	public static void attackEntityEvent(AttackEntityEvent event) {
 		boolean isLivingTarget = event.getTarget() instanceof LivingEntity livingEntity && livingEntity.attackable();
 		PlayerPatch<?> playerpatch = EpicFightCapabilities.getEntityPatch(event.getEntity(), PlayerPatch.class);
-		
+
 		if (playerpatch != null) {
-			if (!event.getEntity().level().getGameRules().getBoolean(EpicFightGamerules.DO_VANILLA_ATTACK) && isLivingTarget && playerpatch.getEpicFightDamageSource() == null) {
+			if (!event.getEntity().level().getGameRules().getBoolean(EpicFightGamerules.DO_VANILLA_ATTACK) && isLivingTarget && playerpatch.getEpicFightDamageSource() == null && !fakePlayerCheck(event.getEntity())) {
 				event.setCanceled(true);
 			}
 		}
+	}
+	public static boolean fakePlayerCheck(Player source) {
+		return source instanceof FakePlayer;
 	}
 }


### PR DESCRIPTION
Adds a check to see if an attack is from a fake player before cancelling it when doVanillaAttack is off. Allows deployers from create, turtles from computercraft, and other FakePlayer based things to attack while vanilla attack is turned off.

I'm a very novice programmer so I wouldn't be surprised if this could be cleaned up a bit, but it works, is very simple, and increases compatibility with tons of mods. Create and ComputerCraft are the reason I decided to try and fix it but I'm sure lots of mods rely on FakePlayer attacks. But even if those are the only two I think compat with Create is a plenty good reason to fix this very simple issue.