### PR TITLE
Fixed incompatibility with playerAnimator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,8 @@ dependencies {
     
     implementation fg.deobf("curse.maven:ice-and-fire-dragons-264231:5633453")
     implementation fg.deobf("curse.maven:citadel-331936:5559513")
+
+    implementation fg.deobf("curse.maven:playeranimator-658587:4587214")
     
     // These mods don't allow 3rd party distribution
     compileOnly fg.deobf("local:skinlayers3d:1.6.6")

--- a/src/main/java/yesman/epicfight/compat/PlayerAnimatorCompat.java
+++ b/src/main/java/yesman/epicfight/compat/PlayerAnimatorCompat.java
@@ -1,0 +1,31 @@
+package yesman.epicfight.compat;
+
+import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
+import dev.kosmx.playerAnim.impl.animation.AnimationApplier;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.eventbus.api.IEventBus;
+import yesman.epicfight.api.client.forgeevent.RenderEpicFightPlayerEvent;
+
+public class PlayerAnimatorCompat implements ICompatModule {
+    @Override
+    public void onModEventBus(IEventBus eventBus) {}
+
+    @Override
+    public void onForgeEventBus(IEventBus eventBus) {}
+
+    @Override
+    public void onModEventBusClient(IEventBus eventBus) {}
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public void onForgeEventBusClient(IEventBus eventBus) {
+        eventBus.addListener(this::renderEvent);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private void renderEvent(RenderEpicFightPlayerEvent event) {
+        AnimationApplier emote = ((IAnimatedPlayer) event.getPlayerPatch().getPlayer()).playerAnimator_getAnimation();
+        if (emote.isActive()) event.setShouldRender(false);
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/PlayerAnimatorCompat.java
+++ b/src/main/java/yesman/epicfight/compat/PlayerAnimatorCompat.java
@@ -25,7 +25,7 @@ public class PlayerAnimatorCompat implements ICompatModule {
 
     @OnlyIn(Dist.CLIENT)
     private void renderEvent(RenderEpicFightPlayerEvent event) {
-        AnimationApplier emote = ((IAnimatedPlayer) event.getPlayerPatch().getPlayer()).playerAnimator_getAnimation();
+        AnimationApplier emote = ((IAnimatedPlayer) event.getPlayerPatch().getOriginal()).playerAnimator_getAnimation();
         if (emote.isActive()) event.setShouldRender(false);
     }
 }

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -50,16 +50,7 @@ import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.config.IngameConfigurationScreen;
 import yesman.epicfight.client.renderer.patched.item.EpicFightItemProperties;
-import yesman.epicfight.compat.AzureLibArmorCompat;
-import yesman.epicfight.compat.AzureLibCompat;
-import yesman.epicfight.compat.FirstPersonCompat;
-import yesman.epicfight.compat.GeckolibCompat;
-import yesman.epicfight.compat.ICompatModule;
-import yesman.epicfight.compat.IRISCompat;
-import yesman.epicfight.compat.IceAndFireCompat;
-import yesman.epicfight.compat.SkinLayer3DCompat;
-import yesman.epicfight.compat.VampirismCompat;
-import yesman.epicfight.compat.WerewolvesCompat;
+import yesman.epicfight.compat.*;
 import yesman.epicfight.config.ConfigManager;
 import yesman.epicfight.config.EpicFightOptions;
 import yesman.epicfight.data.conditions.EpicFightConditions;
@@ -236,6 +227,10 @@ public class EpicFightMod {
         
         if (ModList.get().isLoaded("iceandfire")) {
 			ICompatModule.loadCompatModule(IceAndFireCompat.class);
+		}
+
+		if (ModList.get().isLoaded("playeranimator")) {
+			ICompatModule.loadCompatModule(PlayerAnimatorCompat.class);
 		}
 	}
     

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
@@ -80,6 +80,8 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 	protected int lastChargingTick;
 	protected int chargingAmount;
 	protected ChargeableSkill chargingSkill;
+
+	protected Player player;
 	
 	// Manage the previous position here because playerpatch#tick called before entity#travel method.
 	protected double xo;
@@ -220,6 +222,7 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 	
 	@Override
 	public void tick(LivingEvent.LivingTickEvent event) {
+		this.player = (Player) event.getEntity();
 		if (this.playerMode == PlayerMode.BATTLE || this.battleModeRestricted) {
 			BattleModeSustainableEvent battleModeSustainableEvent = new BattleModeSustainableEvent(this);
 			MinecraftForge.EVENT_BUS.post(battleModeSustainableEvent);
@@ -661,6 +664,10 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 				default -> null;
 			};
 		}
+	}
+
+	public Player getPlayer() {
+		return this.player;
 	}
 	
 	public enum PlayerMode {

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
@@ -80,8 +80,6 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 	protected int lastChargingTick;
 	protected int chargingAmount;
 	protected ChargeableSkill chargingSkill;
-
-	protected Player player;
 	
 	// Manage the previous position here because playerpatch#tick called before entity#travel method.
 	protected double xo;
@@ -222,7 +220,6 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 	
 	@Override
 	public void tick(LivingEvent.LivingTickEvent event) {
-		this.player = (Player) event.getEntity();
 		if (this.playerMode == PlayerMode.BATTLE || this.battleModeRestricted) {
 			BattleModeSustainableEvent battleModeSustainableEvent = new BattleModeSustainableEvent(this);
 			MinecraftForge.EVENT_BUS.post(battleModeSustainableEvent);
@@ -664,10 +661,6 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 				default -> null;
 			};
 		}
-	}
-
-	public Player getPlayer() {
-		return this.player;
 	}
 	
 	public enum PlayerMode {

--- a/src/main/resources/mixins.epicfight.json
+++ b/src/main/resources/mixins.epicfight.json
@@ -32,7 +32,7 @@
 		"MixinThrownTrident",
 		"MixinServerGamePacketListenerImpl"
 	],
-	"injector": {
+	"injectors": {
 		"defaultRequire": 1
 	},
 	"refmap": "mixins.epicfight.refmap.json"


### PR DESCRIPTION
Fixed issue #1331 and playerAnimator animations not playing.
Currently every playerAnimator emote will override epic fight ones, but for 1.21+ and beyond I will make it so that epic fight abides by playerAnimator's animation priority system, so that important epic fight attack anims can't be overriden by smth stupid, and idle anims don't stop playerAnimator anims.

Also I would really appreciate it if you added me as a contributor to the CurseForge page so I can get more downloads. :P
https://www.curseforge.com/members/zigythebird/projects