### PR TITLE
fix: game crash with some patched custom entities

### DIFF
--- a/src/main/java/yesman/epicfight/world/entity/ai/brain/BrainRecomposer.java
+++ b/src/main/java/yesman/epicfight/world/entity/ai/brain/BrainRecomposer.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.ai.behavior.RunOne;
 import net.minecraft.world.entity.ai.behavior.declarative.BehaviorBuilder;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.item.CrossbowItem;
+import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.world.entity.ai.behavior.AnimatedCombatBehavior;
 import yesman.epicfight.world.entity.ai.behavior.BackUpIfTooCloseStopInaction;
 import yesman.epicfight.world.entity.ai.behavior.MoveToTargetSinkStopInaction;
@@ -28,7 +29,12 @@ public final class BrainRecomposer {
 	);
 	
 	public static void recomposeBrainByType(EntityType<?> entityType, Brain<?> brain, AnimatedCombatBehavior<?> animatedCombatBehavior, MoveToTargetSinkStopInaction chaseBehavior) {
-		BRAIN_REPLACE_DEST_MAPPER.get(entityType).recomposeBrain(brain, animatedCombatBehavior, chaseBehavior);
+		BrainRecomposeFunction brainRecomposeFunction = BRAIN_REPLACE_DEST_MAPPER.get(entityType);
+		if (brainRecomposeFunction == null) {
+			EpicFightMod.LOGGER.error("Failed to find brain recompose function for entity type: {}", entityType);
+			return;
+		}
+		brainRecomposeFunction.recomposeBrain(brain, animatedCombatBehavior, chaseBehavior);
 	}
 	
 	public static void recomposePiglinBrain(Brain<?> brain, AnimatedCombatBehavior<?> animatedCombatBehavior, MoveToTargetSinkStopInaction chaseBehavior) {


### PR DESCRIPTION
Instead of crash or causing the entity to not render at all or disappear, print the error to the log and return, it work now as expected same as [20.8.10](https://www.curseforge.com/minecraft/mc-mods/epic-fight-mod/files/5639974) but using the latest version.

```console
[11:50:02] [Server thread/ERROR] [epicfight/]: Failed to find brain recompose function for entity type: entity.mca.male_villager
```

https://github.com/user-attachments/assets/974cc4d3-ad26-4d6a-bb08-166e8234ecd6

* Fix #1934

Maybe additional changes are needed to handle the regression in https://github.com/Epic-Fight/epicfightmod/commit/d821a4b49aebafc54fa98b267a6da5e8cdaea0c1#diff-66cb1ed73fcd0389db94fd8e391edf91df529869ea7b6d57bcc3a2e8e3366368L3-L45 ? My guess is MCA reborn have custom AI behavior that is being overridden by Epic fight (refer to [`VillagerBrain` from MCA reborn](https://github.com/Luke100000/minecraft-comes-alive/blob/07b52523172ff846076c96093f6d469154eafbe9/common/src/main/java/net/mca/entity/ai/brain/VillagerBrain.java#L30)).

As a side note, the sword animation is still broke (it doesn't appear) and the entity doesn't dodge regardless of `combat_behavior`, likely a conflict with MCA reborn AI.