### PR TITLE
Fix the NullPointerException crash that broke Selective Animations.

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/types/SelectiveAnimation.java
+++ b/src/main/java/yesman/epicfight/api/animation/types/SelectiveAnimation.java
@@ -34,9 +34,14 @@ public class SelectiveAnimation extends StaticAnimation {
 			subAnimations.get().addEvents(SimpleEvent.create((entitypatch, animation, params) -> {
 				int result = this.selector.apply(entitypatch);
 				
-				if (entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != result) {
+				if (entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != null && entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != result) {
 					entitypatch.getAnimator().playAnimation(this.selectOptions.get(result), 0.0F);
 					entitypatch.getAnimator().getVariables().put(PREVIOUS_STATE, this.getAccessor(), result);
+				}
+				else
+				{
+					entitypatch.getAnimator().playAnimation(this.selectOptions.get(0), 0.0F);
+					entitypatch.getAnimator().getVariables().put(PREVIOUS_STATE, this.getAccessor(), 0);
 				}
 				
 			}, AnimationEvent.Side.BOTH));


### PR DESCRIPTION
This is a quick fix to solve the issue regarding the NullPointerException that is thrown when SelectiveAnimation is played, the behavior is rather erratic but via certain scenarios such as jumping, idling, or even walking the animation will cause a crash due to the integer being null.

The solution I've posted is a null check, that checks if the int from the if statement is null then defaults to the base animation.