### PR TITLE
Add a try-catch statement wrapping loadAnimationClip for debugging purposes

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
@@ -98,14 +98,23 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 	}
 	
 	public AnimationClip loadAnimationClip(StaticAnimation animation, BiFunction<JsonAssetLoader, StaticAnimation, AnimationClip> clipLoader) {
-		if (getAnimationResourceManager() == null) {
-			return null;
+
+		try
+		{
+			if (getAnimationResourceManager() == null) {
+				return null;
+			}
+
+			JsonAssetLoader modelLoader = new JsonAssetLoader(getAnimationResourceManager(), animation.getLocation());
+			AnimationClip loadedClip = clipLoader.apply(modelLoader, animation);
+
+			return loadedClip;
 		}
-		
-		JsonAssetLoader modelLoader = new JsonAssetLoader(getAnimationResourceManager(), animation.getLocation());
-		AnimationClip loadedClip = clipLoader.apply(modelLoader, animation);
-		
-		return loadedClip;
+		catch (AssetLoadingException e)
+		{
+			throw new AssetLoadingException("Failed to load animation clip from: " + animation, e);
+		}
+
 	}
 	
 	public static void readAnimationProperties(StaticAnimation animation) {

--- a/src/main/java/yesman/epicfight/api/animation/types/SelectiveAnimation.java
+++ b/src/main/java/yesman/epicfight/api/animation/types/SelectiveAnimation.java
@@ -34,9 +34,14 @@ public class SelectiveAnimation extends StaticAnimation {
 			subAnimations.get().addEvents(SimpleEvent.create((entitypatch, animation, params) -> {
 				int result = this.selector.apply(entitypatch);
 				
-				if (entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != result) {
+				if (entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != null && entitypatch.getAnimator().getVariables().get(PREVIOUS_STATE, this.getAccessor()) != result) {
 					entitypatch.getAnimator().playAnimation(this.selectOptions.get(result), 0.0F);
 					entitypatch.getAnimator().getVariables().put(PREVIOUS_STATE, this.getAccessor(), result);
+				}
+				else
+				{
+					entitypatch.getAnimator().playAnimation(this.selectOptions.get(0), 0.0F);
+					entitypatch.getAnimator().getVariables().put(PREVIOUS_STATE, this.getAccessor(), 0);
 				}
 				
 			}, AnimationEvent.Side.BOTH));


### PR DESCRIPTION
One of the exceptions I've read was a weird one.
![image](https://github.com/user-attachments/assets/6c186e92-3f53-4e31-be0f-4b321baf143b)
This exception message was almost undebuggable since the exception didn't give what animation file caused the error.

So I've wrapped the code that the exception was thrown from with a try-catch statement that rethrows the exception except with a message that points what animation file caused the error. That way, it is significantly easier to find the erroring animation and apply fixes.