### PR TITLE
Disable mouse inputs when target lock-on is active

### DIFF
--- a/src/main/java/yesman/epicfight/mixin/client/MixinMouseHandler.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinMouseHandler.java
@@ -1,0 +1,20 @@
+package yesman.epicfight.mixin.client;
+
+import net.minecraft.client.MouseHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+
+@Mixin(value = MouseHandler.class)
+public abstract class MixinMouseHandler {
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V", shift = At.Shift.BEFORE), method = "turnPlayer()V", cancellable = true)
+	private void epicfight_turnPlayer(CallbackInfo callbackInfo) {
+		LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+		if (localPlayerPatch != null && localPlayerPatch.isTargetLockedOn()) {
+			callbackInfo.cancel();
+		}
+	}
+}

--- a/src/main/resources/mixins.epicfight.json
+++ b/src/main/resources/mixins.epicfight.json
@@ -16,6 +16,7 @@
 		"client.MixinLivingEntityRenderer",
 		"client.MixinLocalPlayer",
 		"client.MixinMinecraft",
+		"client.MixinMouseHandler",
 		"client.MixinThrownTridentRenderer",
 		"iris.MixinExtendedShader",
 		"iris.MixinPipelineManager",


### PR DESCRIPTION
This PR fixes a bug where mouse inputs remain enabled when target lock-on is active, causing visual jitter in third person. You can view an example video of the bug by @JustDudeIt123 [here](https://www.youtube.com/watch?v=6VpznTb3RNY). They originally reported the bug [here](https://github.com/Exopandora/ShoulderSurfing/issues/310).