### PR TITLE
feat: add support for Shoulder Surfing Reloaded mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,18 @@ dependencies {
     
     // First-person compatibility (optional) (Warn: this mod file will cause crash, as it references obfuscated names)
     compileOnly "local:firstperson:2.5.0"
+
+    // Shoulder Surfing Reloaded compatibility (optional)
+    compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993797" // API only (https://www.curseforge.com/minecraft/mc-mods/shoulder-surfing-reloaded/files/6993797)
+    localRuntime "curse.maven:shoulder-surfing-reloaded-243190:6993795" // Full mod at runtime (https://www.curseforge.com/minecraft/mc-mods/shoulder-surfing-reloaded/files/6993795/)
+
+    // Uncomment to test Controllable compatibility
+    /*localRuntime "curse.maven:controllable-317269:6850105"
+    localRuntime "curse.maven:framework-549225:6531439"*/
+
+    // Uncomment to test Controlify compatibility
+    /*localRuntime "curse.maven:controlify-835847:6674779"
+    localRuntime "curse.maven:yacl-667299:6662857"*/
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/src/main/java/yesman/epicfight/compat/ShoulderSurfingCompat.java
+++ b/src/main/java/yesman/epicfight/compat/ShoulderSurfingCompat.java
@@ -1,0 +1,72 @@
+package yesman.epicfight.compat;
+
+import com.github.exopandora.shouldersurfing.api.callback.ICameraCouplingCallback;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingPlugin;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistrar;
+import net.minecraft.client.Minecraft;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.events.engine.ControlEngine;
+import yesman.epicfight.client.input.EpicFightKeyMappings;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+
+/**
+ * Background:
+ * The Shoulder Surfing Reloaded mod includes a camera decoupling feature, allowing the player to rotate the camera 360°
+ * without rotating their controlled character. When the vanilla Attack key is pressed,
+ * Shoulder Surfing automatically detects it and rotates the player to face the crosshair target as needed to attack
+ * enemies.
+ * <p>
+ * <p>
+ * The Epic Fight mod added a custom Attack keybind in this commit: <a href="https://github.com/Epic-Fight/epicfight/compare/e963d283e2ec...35e8aa9ea4ba#diff-9dc988ba2888a8eece19c042d1412fc79025c1c46370f5c0b5974a597c56ba5bL76">...</a>
+ * to support controller mods (more details: <a href="https://github.com/Epic-Fight/epicfight/issues/1297">...</a>).
+ * However, Shoulder Surfing Reloaded cannot detect this custom keybind if the vanilla Attack key
+ * differs from the Epic Fight Attack key, which is usually the case when using a controller.
+ * This means players must always disable the camera decoupling feature to make the mod playable with a controller
+ * and are forced to use the same Attack key as in vanilla and Epic Fight.
+ * <p>
+ * <p>
+ * This Shoulder Surfing plugin works around the issue by bypassing the
+ * <a href="https://github.com/Exopandora/ShoulderSurfing/blob/7f0df83beb4f7158810e188150eb7e9812981529/common/src/main/java/com/github/exopandora/shouldersurfing/client/ShoulderSurfingImpl.java#L188-L191">
+ * ShoulderSurfingImpl.isAttacking
+ * </a> method,
+ * allowing the Shoulder Surfing mod to support the Epic Fight Attack keybind as well.
+ * <p>
+ * <p>
+ * This plugin always forces the player to turn when attacking, regardless of the Shoulder Surfing "player.turning" config.
+ * By default, Shoulder Surfing only turns the player when a target is detected ("REQUIRES_TARGET"),
+ * which works for vanilla mechanics but is incompatible with Epic Fight.
+ * Overriding it to always turn ensures proper behavior with the Epic Fight Attack keybind and controller input.
+ * <p>
+ */
+@OnlyIn(Dist.CLIENT)
+@SuppressWarnings("unused") // Referenced in src/main/resources/shouldersurfing_plugin.json
+public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
+    @Override
+    public void register(IShoulderSurfingRegistrar registrar) {
+        registrar.registerCameraCouplingCallback(new ForceCameraCouplingWhenAttackingCallback());
+        registrar.registerCameraCouplingCallback(new ForceCameraCouplingWhenHoldingSkillCallback());
+    }
+
+    private static class ForceCameraCouplingWhenAttackingCallback implements ICameraCouplingCallback {
+        @Override
+        public boolean isForcingCameraCoupling(Minecraft minecraft) {
+            return ControlEngine.isKeyDown(EpicFightKeyMappings.ATTACK) || minecraft.options.keyAttack.isDown();
+        }
+    }
+
+    private static class ForceCameraCouplingWhenHoldingSkillCallback implements ICameraCouplingCallback {
+        @Override
+        public boolean isForcingCameraCoupling(Minecraft minecraft) {
+            LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+            if (localPlayerPatch == null) {
+                return false;
+            }
+
+            // Forces camera coupling when the player is holding any holdable skill,
+            // including Demolition Leap, without directly referencing specific skills.
+            return localPlayerPatch.isHoldingAny();
+        }
+    }
+}

--- a/src/main/resources/shouldersurfing_plugin.json
+++ b/src/main/resources/shouldersurfing_plugin.json
@@ -1,0 +1,3 @@
+{
+  "entrypoint": "yesman.epicfight.compat.ShoulderSurfingCompat"
+}


### PR DESCRIPTION
**See the related issue or JavaDoc comment in the PR code for more details (#2111).**

### Related Issues

- *Fix #2111*
- *Fix #2113*
- *Fix #2114*
- *Related #1297*
- *Related Commit https://github.com/Epic-Fight/epicfight/compare/e963d283e2ec...35e8aa9ea4ba#diff-9dc988ba2888a8eece19c042d1412fc79025c1c46370f5c0b5974a597c56ba5bL76*
- *Related https://github.com/Exopandora/ShoulderSurfing/issues/345*

### Videos

Tested with both [Controllable](https://www.curseforge.com/minecraft/mc-mods/controllable) and [Controlify](https://modrinth.com/mod/controlify) mods (should work with any controller mods, the fix is independent).

<details><summary>Before</summary>
<p>


https://github.com/user-attachments/assets/b4488859-c5bb-4ad2-b72b-fe4ac35a1214


</p>
</details> 

<details><summary>After</summary>
<p>

Steel whirlwind works well now:

https://github.com/user-attachments/assets/f460c3fc-b81e-47e7-9bf7-d998147cbaa0

Demolition leap is now compatible too:

https://github.com/user-attachments/assets/f51f1a94-eca1-4510-b715-5d2228be92e7


With controllable mod:

https://github.com/user-attachments/assets/53235a3b-5124-49b1-b096-0adc4dc78ab1

With Controlify mod:

https://github.com/user-attachments/assets/02cb0ca5-db95-4a7a-a7c1-dbc813b1a8ca


</p>
</details> 

Refer to [Shoulder Surfing API docs](https://github.com/Exopandora/ShoulderSurfing/wiki/API-Documentation-Plugins#creating-a-plugin-class)
