### PR TITLE
Refactor Epic Fight Input System

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/types/BasicAttackAnimation.java
+++ b/src/main/java/yesman/epicfight/api/animation/types/BasicAttackAnimation.java
@@ -7,6 +7,8 @@ import javax.annotation.Nullable;
 
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.animation.property.AnimationProperty.ActionAnimationProperty;
@@ -16,6 +18,8 @@ import yesman.epicfight.api.animation.types.EntityState.StateFactor;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.animation.Layer;
 import yesman.epicfight.api.client.animation.property.JointMaskEntry;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.collider.Collider;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.api.utils.datastruct.TypeFlexibleHashMap;
@@ -137,12 +141,16 @@ public class BasicAttackAnimation extends AttackAnimation {
 	public boolean shouldPlayerMove(LocalPlayerPatch playerpatch) {
 		if (playerpatch.isLogicalClient()) {
 			if (!EpicFightGameRules.STIFF_COMBO_ATTACKS.getRuleValue(playerpatch.getOriginal().level())) {
-				if (playerpatch.getOriginal().input.forwardImpulse != 0.0F || playerpatch.getOriginal().input.leftImpulse != 0.0F) {
-					return false;
-				}
+                return !isPlayerMoving(playerpatch);
 			}
 		}
 		
 		return true;
 	}
+
+    @OnlyIn(Dist.CLIENT)
+    private static boolean isPlayerMoving(LocalPlayerPatch localPlayerPatch) {
+        final PlayerInputState inputState = InputManager.getInputState(localPlayerPatch.getOriginal());
+        return inputState.forwardImpulse() != 0.0F || inputState.leftImpulse() != 0.0F;
+    }
 }

--- a/src/main/java/yesman/epicfight/api/client/input/InputMode.java
+++ b/src/main/java/yesman/epicfight/api/client/input/InputMode.java
@@ -1,0 +1,45 @@
+package yesman.epicfight.api.client.input;
+
+/**
+ * Represents the type of input mode a player can use in the game.
+ */
+public enum InputMode {
+    /**
+     * Input is limited to the keyboard and mouse.
+     */
+    KEYBOARD_MOUSE,
+
+    /**
+     * Input is limited to a controller or gamepad.
+     */
+    CONTROLLER,
+
+    /**
+     * Input from both the keyboard and mouse, and a controller or gamepad.
+     */
+    MIXED;
+
+    /**
+     * Returns whether this mode supports keyboard and mouse input.
+     *
+     * @return {@code true} if keyboard and mouse input is supported.
+     */
+    public boolean supportsKeyboardAndMouse() {
+        return switch (this) {
+            case KEYBOARD_MOUSE, MIXED -> true;
+            case CONTROLLER -> false;
+        };
+    }
+
+    /**
+     * Returns whether this mode supports controller or gamepad input.
+     *
+     * @return {@code true} if controller input is supported.
+     */
+    public boolean supportsController() {
+        return switch (this) {
+            case CONTROLLER, MIXED -> true;
+            case KEYBOARD_MOUSE -> false;
+        };
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/MovementDirection.java
+++ b/src/main/java/yesman/epicfight/api/client/input/MovementDirection.java
@@ -1,0 +1,42 @@
+package yesman.epicfight.api.client.input;
+
+/**
+ * Represents player movement direction based on input.
+ * <p>
+ * forward, backward, left, right indicate the player’s intended movement:
+ * <ul>
+ *     <li>1 if that direction key is pressed (forward or left)</li>
+ *     <li>-1 if the opposite key is pressed (backward or right)</li>
+ *     <li>0 if neither key is pressed</li>
+ * </ul>
+ * <p>
+ * Example uses:
+ * <ul>
+ *     <li>Dodge skill: calculate dash direction from input</li>
+ *     <li>Phantom ascent double jump: move and rotate player based on input direction</li>
+ * </ul>
+ */
+public record MovementDirection(int forward, int backward, int left, int right) {
+    public int vertical() {
+        return forward + backward;
+    }
+
+    public int horizontal() {
+        return left + right;
+    }
+
+    public static MovementDirection fromBooleans(boolean up, boolean down, boolean left, boolean right) {
+        return new MovementDirection(
+                up ? 1 : 0,
+                down ? -1 : 0,
+                left ? 1 : 0,
+                right ? -1 : 0
+        );
+    }
+
+    public static MovementDirection fromInputState(PlayerInputState inputState) {
+        return fromBooleans(
+                inputState.up(), inputState.down(), inputState.left(), inputState.right()
+        );
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/PlayerInputState.java
+++ b/src/main/java/yesman/epicfight/api/client/input/PlayerInputState.java
@@ -1,0 +1,113 @@
+package yesman.epicfight.api.client.input;
+
+import net.minecraft.client.player.Input;
+import net.minecraft.world.phys.Vec2;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents the abstract state of the player input (client-side).
+ * <p>
+ * Mirrors the vanilla Minecraft {@link Input} class.
+ * </p>
+ */
+public record PlayerInputState(
+        float leftImpulse,
+        float forwardImpulse,
+        boolean up,
+        boolean down,
+        boolean left,
+        boolean right,
+        boolean jumping,
+        boolean sneaking
+) {
+    public static PlayerInputState fromVanillaInput(Input input) {
+        return new PlayerInputState(
+                input.leftImpulse, input.forwardImpulse,
+                input.up, input.down,
+                input.left, input.right,
+                input.jumping, input.shiftKeyDown
+        );
+    }
+
+    /**
+     * Applies the values from a {@link PlayerInputState} to a vanilla {@link Input} instance.
+     * **Note:** Updating the vanilla {@link Input} fields has side effects, so this change is **not immutable**.
+     *
+     * @param updated the new input state to apply
+     * @param input   the existing vanilla Input instance to update
+     */
+    public static Input applyToVanillaInput(@NotNull PlayerInputState updated, @NotNull Input input) {
+        if (input.leftImpulse != updated.leftImpulse()) input.leftImpulse = updated.leftImpulse();
+        if (input.forwardImpulse != updated.forwardImpulse()) input.forwardImpulse = updated.forwardImpulse();
+        if (input.up != updated.up()) input.up = updated.up();
+        if (input.down != updated.down()) input.down = updated.down();
+        if (input.left != updated.left()) input.left = updated.left();
+        if (input.right != updated.right()) input.right = updated.right();
+        if (input.jumping != updated.jumping()) input.jumping = updated.jumping();
+        if (input.shiftKeyDown != updated.sneaking()) input.shiftKeyDown = updated.sneaking();
+        return input;
+    }
+
+    public Vec2 getMoveVector() {
+        return new Vec2(this.leftImpulse, this.forwardImpulse);
+    }
+
+    public boolean hasForwardImpulse() {
+        return this.forwardImpulse > 1.0E-5F;
+    }
+
+    public @NotNull PlayerInputState copyWith(
+            @Nullable Float leftImpulse,
+            @Nullable Float forwardImpulse,
+            @Nullable Boolean up,
+            @Nullable Boolean down,
+            @Nullable Boolean left,
+            @Nullable Boolean right,
+            @Nullable Boolean jumping,
+            @Nullable Boolean sneaking
+    ) {
+        return new PlayerInputState(
+                leftImpulse != null ? leftImpulse : this.leftImpulse,
+                forwardImpulse != null ? forwardImpulse : this.forwardImpulse,
+                up != null ? up : this.up,
+                down != null ? down : this.down,
+                left != null ? left : this.left,
+                right != null ? right : this.right,
+                jumping != null ? jumping : this.jumping,
+                sneaking != null ? sneaking : this.sneaking
+        );
+    }
+
+    public @NotNull PlayerInputState withLeftImpulse(float leftImpulse) {
+        return copyWith(leftImpulse, null, null, null, null, null, null, null);
+    }
+
+    public @NotNull PlayerInputState withForwardImpulse(float forwardImpulse) {
+        return copyWith(null, forwardImpulse, null, null, null, null, null, null);
+    }
+
+    public @NotNull PlayerInputState withUp(boolean up) {
+        return copyWith(null, null, up, null, null, null, null, null);
+    }
+
+    public @NotNull PlayerInputState withDown(boolean down) {
+        return copyWith(null, null, null, down, null, null, null, null);
+    }
+
+    public @NotNull PlayerInputState withLeft(boolean left) {
+        return copyWith(null, null, null, null, left, null, null, null);
+    }
+
+    public @NotNull PlayerInputState withRight(boolean right) {
+        return copyWith(null, null, null, null, null, right, null, null);
+    }
+
+    public @NotNull PlayerInputState withJumping(boolean jumping) {
+        return copyWith(null, null, null, null, null, null, jumping, null);
+    }
+
+    public @NotNull PlayerInputState withSneaking(boolean sneaking) {
+        return copyWith(null, null, null, null, null, null, null, sneaking);
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
@@ -1,0 +1,143 @@
+package yesman.epicfight.api.client.input.action;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.client.input.EpicFightKeyMappings;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+// TODO: (INPUT_SYSTEM_REFACTOR) EpicFightInputActions must be registered
+//  in the EpicFightMod class constructor. Registration is not done yet because
+//  any modifications to the Epic Fight existing files must not be done in the first commit.
+
+/**
+ * Represents a default set of input actions used in the Epic Fight mod.
+ * <p>
+ * Each action is linked to a corresponding Minecraft vanilla {@link KeyMapping} or
+ * an Epic Fight custom key mapping. These mappings only support keyboard and mouse input.
+ * Controller input is not directly supported to avoid dependencies on third-party controller mods.
+ * <p>
+ * For implementation details, refer to {@link EpicFightInputActions#keyMapping()}.
+ */
+@ApiStatus.Experimental
+public enum EpicFightInputActions implements InputAction {
+    /**
+     * Corresponds to Minecraft's default "Attack/Destroy" action.
+     * <p>
+     * This uses the vanilla {@link net.minecraft.client.Options#keyAttack} key mapping,
+     * which is bound to the left mouse button by default. It handles both attacking entities
+     * and breaking blocks in the base game.
+     */
+    VANILLA_ATTACK_DESTROY(true),
+    USE(true),
+    SWAP_OFF_HAND(true),
+    DROP(true),
+    TOGGLE_PERSPECTIVE(true),
+    ATTACK(false),
+    JUMP(true),
+    MOBILITY(false),
+    GUARD(false),
+    DODGE(false),
+    LOCK_ON(false),
+    SWITCH_MODE(false),
+    WEAPON_INNATE_SKILL(false),
+    WEAPON_INNATE_SKILL_TOOLTIP(false),
+    MOVE_FORWARD(true),
+    MOVE_BACKWARD(true),
+    MOVE_LEFT(true),
+    MOVE_RIGHT(true),
+    SPRINT(true),
+    SNEAK(true),
+    OPEN_SKILL_SCREEN(false),
+    OPEN_CONFIG_SCREEN(false),
+    SWITCH_VANILLA_MODEL_DEBUGGING(false);
+
+    final private int id;
+
+    /**
+     * Indicates whether this input action corresponds to a standard
+     * Minecraft vanilla key mapping.
+     * <p>
+     * Vanilla actions are those defined by the base game (e.g., attack, jump, move),
+     * while non-vanilla actions are custom Epic Fight actions introduced by the mod.
+     */
+    final private boolean isVanilla;
+
+    /**
+     * Returns whether this input action corresponds to a vanilla
+     * Minecraft key mapping.
+     *
+     * @return {@code true} if this action is linked to a vanilla key mapping,
+     * {@code false} if it is defined by the Epic Fight mod.
+     */
+    public boolean isVanilla() {
+        return isVanilla;
+    }
+
+    EpicFightInputActions(final boolean isVanilla) {
+        this.id = InputAction.ENUM_MANAGER.assign(this);
+        this.isVanilla = isVanilla;
+    }
+
+    @Override
+    public int universalOrdinal() {
+        return id;
+    }
+
+    @Override
+    @NotNull
+    public KeyMapping keyMapping() {
+        final Options options = Minecraft.getInstance().options;
+        return switch (this) {
+            case VANILLA_ATTACK_DESTROY -> options.keyAttack;
+            case USE -> options.keyUse;
+            case SWAP_OFF_HAND -> options.keySwapOffhand;
+            case DROP -> options.keyDrop;
+            case TOGGLE_PERSPECTIVE -> options.keyTogglePerspective;
+            case ATTACK -> EpicFightKeyMappings.ATTACK;
+            case JUMP -> options.keyJump;
+            case MOBILITY -> EpicFightKeyMappings.MOVER_SKILL;
+            case GUARD -> EpicFightKeyMappings.GUARD;
+            case DODGE -> EpicFightKeyMappings.DODGE;
+            case LOCK_ON -> EpicFightKeyMappings.LOCK_ON;
+            case SWITCH_MODE -> EpicFightKeyMappings.SWITCH_MODE;
+            case WEAPON_INNATE_SKILL -> EpicFightKeyMappings.WEAPON_INNATE_SKILL;
+            case WEAPON_INNATE_SKILL_TOOLTIP -> EpicFightKeyMappings.WEAPON_INNATE_SKILL_TOOLTIP;
+            case MOVE_FORWARD -> options.keyUp;
+            case MOVE_BACKWARD -> options.keyDown;
+            case MOVE_LEFT -> options.keyLeft;
+            case MOVE_RIGHT -> options.keyRight;
+            case SPRINT -> options.keySprint;
+            case SNEAK -> options.keyShift;
+            case OPEN_SKILL_SCREEN -> EpicFightKeyMappings.SKILL_EDIT;
+            case OPEN_CONFIG_SCREEN -> EpicFightKeyMappings.OPEN_CONFIG_SCREEN;
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> EpicFightKeyMappings.SWITCH_VANILLA_MODEL_DEBUGGING;
+        };
+    }
+
+    private static final @NotNull Map<KeyMapping, EpicFightInputActions> BY_KEY_MAPPING;
+
+    static {
+        Map<KeyMapping, EpicFightInputActions> map = new HashMap<>();
+        for (EpicFightInputActions action : values()) {
+            map.put(action.keyMapping(), action);
+        }
+        BY_KEY_MAPPING = Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Gets the input action corresponding to a {@link KeyMapping}.
+     *
+     * @param keyMapping the key mapping; must not be {@code null}
+     * @return the corresponding action, or null if none matches
+     */
+    public static @Nullable EpicFightInputActions fromKeyMapping(@NotNull KeyMapping keyMapping) {
+        return BY_KEY_MAPPING.get(keyMapping);
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
@@ -12,10 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-// TODO: (INPUT_SYSTEM_REFACTOR) EpicFightInputActions must be registered
-//  in the EpicFightMod class constructor. Registration is not done yet because
-//  any modifications to the Epic Fight existing files must not be done in the first commit.
-
 /**
  * Represents a default set of input actions used in the Epic Fight mod.
  * <p>

--- a/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
@@ -1,0 +1,37 @@
+package yesman.epicfight.api.client.input.action;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.utils.ExtendableEnum;
+import yesman.epicfight.api.utils.ExtendableEnumManager;
+
+/**
+ * Represents a client-side input action in Epic Fight mod.
+ * <p>
+ * Each action is associated with a Minecraft vanilla {@link KeyMapping}, which
+ * only supports keyboard and mouse input. Controller input is not directly
+ * supported to avoid depending on third-party controller mods.
+ */
+@OnlyIn(Dist.CLIENT)
+@ApiStatus.Experimental
+public interface InputAction extends ExtendableEnum {
+    ExtendableEnumManager<InputAction> ENUM_MANAGER = new ExtendableEnumManager<>("input_action");
+
+    /**
+     * Returns the Minecraft vanilla {@link KeyMapping} associated with this action.
+     * <p>
+     * Note: This mapping only supports keyboard and mouse input and does not support controllers.
+     * Consumers should consider using a different API when possible to take advantage of
+     * the current supported controller mod implementation.
+     * <p>
+     * <b>Important:</b> This method must be called <b>only on the client</b>.
+     *
+     * @return the vanilla {@link KeyMapping} for this action
+     */
+    @NotNull
+    @OnlyIn(Dist.CLIENT)
+    KeyMapping keyMapping();
+}

--- a/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
@@ -1,0 +1,134 @@
+package yesman.epicfight.api.client.input.controller;
+
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a controller button or analogue stick axis.
+ * Provides current and previous state, analogue/digital values, and metadata.
+ * <p>
+ * Serves a similar role to Minecraft's vanilla {@link net.minecraft.client.KeyMapping},
+ * but for controller input instead of keyboard or mouse.
+ */
+@ApiStatus.Experimental
+public interface ControllerBinding {
+    /**
+     * The ID of the binding (e.g., `epicfight:attack).
+     *
+     * @return the ID
+     */
+    ResourceLocation id();
+
+    /**
+     * Defines the type of input represented by a {@link ControllerBinding}.
+     * <p>
+     * Inputs can be either analogue or digital:
+     * <ul>
+     *      <li>{@link #ANALOGUE} – Inputs with a continuous range of values, such as the movement axes of a stick or triggers (e.g., 0.0 to 1.0).</li>
+     *     <li>{@link #DIGITAL} – Inputs that are binary, such as buttons or stick presses (e.g., L3/R3), which are either pressed or released.</li>
+     * </ul>
+     * <p>
+     * Note: A single physical control can produce multiple input types. For example:
+     * <ul>
+     *     <li>moving a left stick generates analogue signals (X/Y axes)</li>
+     *     <li>pressing the stick down generates a separate digital input</li>
+     * </ul>
+     */
+    enum InputType {
+        ANALOGUE,
+        DIGITAL
+    }
+
+    /**
+     * Returns the type of this controller binding.
+     *
+     * @return the {@link InputType} of this binding.
+     */
+    @NotNull
+    InputType getInputType();
+
+    /**
+     * Returns whether this binding represents an analogue input.
+     * <p>
+     *
+     * @return true if analogue, false if digital.
+     * @see InputType
+     */
+    default boolean isAnalogueType() {
+        return switch (getInputType()) {
+            case ANALOGUE -> true;
+            case DIGITAL -> false;
+        };
+    }
+
+    /**
+     * Returns whether the digital state is currently active in this tick.
+     * <p>
+     * This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
+     * </p>
+     *
+     * @return the current digital state, this tick.
+     * @see InputType#DIGITAL
+     */
+    boolean isDigitalActiveNow();
+
+    /**
+     * Returns whether the digital state was active in the previous tick.
+     * <p>
+     * This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
+     * </p>
+     *
+     * @return the previous digital state, 1 tick ago.
+     * @see InputType#DIGITAL
+     */
+    boolean wasDigitalActivePreviously();
+
+    /**
+     * Returns whether the digital state was just pressed.
+     * <p>
+     * This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
+     * </p>
+     *
+     * @return true if the binding is pressed this tick and not pressed the previous tick.
+     * @see InputType#DIGITAL
+     */
+    boolean isDigitalJustPressed();
+
+    /**
+     * Returns whether the digital state was just released.
+     * <p>
+     * This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
+     * </p>
+     *
+     * @return true if the binding is not pressed this tick and pressed the previous tick.
+     * @see InputType#DIGITAL
+     */
+    boolean isDigitalJustReleased();
+
+    /**
+     * Returns the current analogue input value.
+     * <p>
+     * This method is only applicable to analogue inputs (e.g., left stick, right trigger).
+     * For more details, refer to {@link InputType#ANALOGUE}.
+     * </p>
+     *
+     * @return the current analogue value in the range {@code 0.0}–{@code 1.0}, representing this tick's state.
+     * @see InputType#ANALOGUE
+     */
+    float getAnalogueNow();
+
+    // TODO: (INPUT_SYSTEM_REFACTOR): We need to add a new method that perform functionality equivalent to setKeyBind in ControlEngine:
+    //  https://github.com/Epic-Fight/epicfight/blob/432ecafe79a025322e3492a02c57eda95f6385d0/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java#L509-L511
+    //  However, the Controlify mod only provides fakePress() AFAIK (so we only added emulatePress), other controller mods do provide them.
+    //  The real question is: why are these even needed, and what purpose do they serve?
+    //  It appears it's used to just disable sprint. We should explore alternative
+    //  approaches to achieve this without relying on these vanilla APIs.
+
+    /**
+     * Simulates a press of this binding.
+     * <p>
+     * Can be used for GUI interactions or synthetic input from other systems.
+     */
+    void emulatePress();
+}

--- a/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
@@ -118,13 +118,6 @@ public interface ControllerBinding {
      */
     float getAnalogueNow();
 
-    // TODO: (INPUT_SYSTEM_REFACTOR): We need to add a new method that perform functionality equivalent to setKeyBind in ControlEngine:
-    //  https://github.com/Epic-Fight/epicfight/blob/432ecafe79a025322e3492a02c57eda95f6385d0/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java#L509-L511
-    //  However, the Controlify mod only provides fakePress() AFAIK (so we only added emulatePress), other controller mods do provide them.
-    //  The real question is: why are these even needed, and what purpose do they serve?
-    //  It appears it's used to just disable sprint. We should explore alternative
-    //  approaches to achieve this without relying on these vanilla APIs.
-
     /**
      * Simulates a press of this binding.
      * <p>

--- a/src/main/java/yesman/epicfight/api/client/input/controller/EpicFightControllerModProvider.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/EpicFightControllerModProvider.java
@@ -1,0 +1,62 @@
+package yesman.epicfight.api.client.input.controller;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.main.EpicFightMod;
+
+/**
+ * Provides access to the active {@link IEpicFightControllerMod} implementation.
+ * <p>
+ * Only one mod can register an implementation at a time. If multiple mods register, a warning is logged
+ * and the last one takes effect.
+ *
+ * @see IEpicFightControllerMod
+ */
+@ApiStatus.Experimental
+public final class EpicFightControllerModProvider {
+    private EpicFightControllerModProvider() {
+    }
+
+    @Nullable
+    @javax.annotation.Nullable
+    private static IEpicFightControllerMod instance = null;
+
+    /**
+     * True if a mod other than Epic Fight has already registered an implementation
+     */
+    private static boolean overriddenByOtherMod;
+
+    /**
+     * Registers a controller mod implementation.
+     * Logs a warning if another mod has already registered.
+     */
+    public static void set(@NotNull String registrantModId, @NotNull IEpicFightControllerMod modInstance) {
+        if (overriddenByOtherMod) {
+            EpicFightMod.LOGGER.warn(
+                    "Mod '{}' is overriding the Epic Fight controller implementation, which was already set by another mod. "
+                            + "Only the last registered implementation will be used. "
+                            + "This may occur if multiple controller mods are installed.",
+                    registrantModId
+            );
+        }
+        EpicFightControllerModProvider.instance = modInstance;
+
+        if (registrantModId.equals(EpicFightMod.MODID)) {
+            EpicFightMod.LOGGER.info(
+                    "Epic Fight detected and registered supported controller mod: '{}'.",
+                    modInstance.getModName()
+            );
+        } else {
+            overriddenByOtherMod = true;
+        }
+    }
+
+    /**
+     * Returns the current controller implementation, or null if none
+     */
+    @Nullable
+    public static IEpicFightControllerMod get() {
+        return EpicFightControllerModProvider.instance;
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -1,0 +1,84 @@
+package yesman.epicfight.api.client.input.controller;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.input.InputMode;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+
+/**
+ * Represents an integration layer for third-party controller mods used by Epic Fight.
+ * <p>
+ * This interface must be implemented by any external controller mod to provide
+ * controller input support for Epic Fight. It acts as a bridge between the
+ * controller mod’s input system (e.g., Controlify, Controllable, MidnightControls) and Epic Fight’s
+ * input handling logic.
+ * <p>
+ * Epic Fight relies on this interface to determine and manage the current
+ * {@link InputMode}. Since input mode management is not part of the vanilla
+ * Minecraft input system, controller mods must supply their own implementation.
+ * <p>
+ * <b>Note:</b> This interface exposes low-level controller integration. Most consumers should
+ * use a higher-level abstraction unless direct access is necessary for functionality
+ * that cannot be achieved otherwise.
+ * <p>
+ * <b>Warning:</b> This API is currently marked as experimental.
+ * This designation does not imply that the implementation is of an 'experimental' quality,
+ * but rather indicates that classes, methods, and fields may be subject to renaming, relocation, or removal.
+ * The Epic Fight team reserves the right to modify or completely remove any components of the API at any time,
+ * without prior notice.
+ * <p>
+ */
+@ApiStatus.Experimental
+public interface IEpicFightControllerMod {
+    /**
+     * Returns the controller mod’s display name (e.g., `Controlify`, `Controllable`).
+     * Intended for logging or debugging only; should not influence gameplay logic or be used as a workaround.
+     */
+    String getModName();
+
+    /**
+     * Returns the current input mode (keyboard/mouse or controller).
+     */
+    @NotNull
+    InputMode getInputMode();
+
+    /**
+     * Retrieves the universal controller binding for a given Epic Fight input action.
+     * <p>
+     * This method maps actions such as {@link EpicFightInputActions#JUMP},
+     * {@link EpicFightInputActions#ATTACK}, and
+     * {@link EpicFightInputActions#MOVE_FORWARD} to the corresponding controller
+     * buttons or axes.
+     * </p>
+     *
+     * @param action the Epic Fight input action to retrieve the binding for
+     * @return the {@link ControllerBinding} associated with the specified action,
+     * providing both state and metadata about the input
+     * @see ControllerBinding
+     */
+    @NotNull
+    ControllerBinding getBinding(EpicFightInputActions action);
+
+    /**
+     * Retrieves the current input state.
+     * This is used internally by Epic Fight to perform actions such as {@link EpicFightInputActions#DODGE}.
+     *
+     * @return a {@link PlayerInputState} representing the current input state.
+     */
+    @NotNull
+    PlayerInputState getInputState();
+
+    /**
+     * Checks whether the specified input actions are bound to the same controller button.
+     * <p>
+     * This comparison only applies to digital buttons (e.g., A, B, L3, R3) and does not
+     * account for analogue inputs such as triggers or stick movements.
+     * </p>
+     *
+     * @param action  the first input action
+     * @param action2 the second input action
+     * @return {@code true} if both actions are bound to the same controller button; {@code false} otherwise
+     */
+    boolean isBoundToSameButton(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2);
+}

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteActionHandler.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteActionHandler.java
@@ -1,0 +1,21 @@
+package yesman.epicfight.api.client.input.handlers;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Functional interface for discrete input action callbacks.
+ */
+@FunctionalInterface
+public interface DiscreteActionHandler {
+    /**
+     * Called when a discrete input action triggers.
+     *
+     * @param context The arguments of this handler
+     */
+    void onAction(@NotNull Context context);
+
+    /**
+     * @param triggeredByController true if the action was triggered by a controller, false if by keyboard/mouse
+     */
+    record Context(boolean triggeredByController) { }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteInputActionTrigger.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteInputActionTrigger.java
@@ -1,0 +1,85 @@
+package yesman.epicfight.api.client.input.handlers;
+
+import net.minecraft.client.KeyMapping;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
+import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
+
+/**
+ * Handles triggering of a discrete (one-time) {@link EpicFightInputActions}
+ * based on the current input state.
+ * <p>
+ * Consumers of this API provide only the "what to do" for each action;
+ * this class determines the "when" to trigger it.
+ * <p>
+ * Internally, it supports both vanilla keyboard/mouse input and third-party controllers.
+ * <p>
+ * <b>Note:</b> This is an internal API. Consumers should prefer using higher-level components
+ * such as {@link InputManager} unless direct access is truly required.
+ */
+@ApiStatus.Internal
+public final class DiscreteInputActionTrigger {
+    private DiscreteInputActionTrigger() {
+    }
+
+    @Nullable
+    private static IEpicFightControllerMod getControllerModApi() {
+        return EpicFightControllerModProvider.get();
+    }
+
+    /**
+     * Called on every client tick to potentially trigger the provided callback for a given input action.
+     * <p>
+     * Determines *when* to trigger the action; consumers define *how* it executes.
+     * For example, for {@link EpicFightInputActions#OPEN_SKILL_SCREEN}, this method decides when to call
+     * the callback that opens the screen, but not how the screen is opened.
+     * <p>
+     * Consumers do not need to know any keyboard/mouse or controller input internals.
+     *
+     * @param action  The input action to monitor.
+     * @param handler The callback to run when the action triggers.
+     */
+    public static void triggerOnPress(EpicFightInputActions action, DiscreteActionHandler handler) {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        final KeyMapping keyMapping = action.keyMapping();
+        if (controllerMod == null) {
+            handleKeyboardAndMouse(keyMapping, handler);
+            return;
+        }
+
+        switch (controllerMod.getInputMode()) {
+            case MIXED -> {
+                final boolean handled = handleController(controllerMod.getBinding(action), handler);
+                if (handled) {
+                    return;
+                }
+                handleKeyboardAndMouse(keyMapping, handler);
+            }
+            case CONTROLLER -> handleController(controllerMod.getBinding(action), handler);
+            case KEYBOARD_MOUSE -> handleKeyboardAndMouse(keyMapping, handler);
+        }
+    }
+
+    private static void handleKeyboardAndMouse(KeyMapping keyMapping, DiscreteActionHandler handler) {
+        while (keyMapping.consumeClick()) {
+            handler.onAction(createContext(false));
+        }
+    }
+
+    private static boolean handleController(ControllerBinding controllerBinding, DiscreteActionHandler handler) {
+        if (controllerBinding.isDigitalJustPressed()) {
+            handler.onAction(createContext(true));
+            return true;
+        }
+        return false;
+    }
+    
+    @NotNull
+    private static DiscreteActionHandler.Context createContext(boolean triggeredByController) {
+        return new DiscreteActionHandler.Context(triggeredByController);
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -1,0 +1,225 @@
+package yesman.epicfight.api.client.input.handlers;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.Input;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.event.InputEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.glfw.GLFW;
+import yesman.epicfight.api.client.input.InputMode;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
+import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
+import yesman.epicfight.client.events.engine.ControlEngine;
+import yesman.epicfight.api.client.input.controller.ControllerBinding.InputType;
+
+/**
+ * High-level input API that abstracts direct interactions with {@link KeyMapping}
+ * and supports controllers if an Epic Fight controller mod implementation is present
+ * (see {@link EpicFightControllerModProvider}).
+ * <p>
+ * Use this class whenever possible to ensure input works consistently across
+ * keyboard/mouse and supported controllers.
+ */
+@ApiStatus.Experimental
+public final class InputManager {
+    private InputManager() {
+    }
+
+    @Nullable
+    private static IEpicFightControllerMod getControllerModApi() {
+        return EpicFightControllerModProvider.get();
+    }
+
+    /**
+     * Checks if controller or gamepad input is currently supported.
+     *
+     * <p><b>Note:</b> The {@link InputMode#MIXED} mode supports both controller and keyboard/mouse input at the same time.
+     * Returning {@code true} here does not necessarily mean the input mode is exclusively {@link InputMode#CONTROLLER}.
+     *
+     * @return {@code true} if a controller mod is present and the current input mode allows controller input.
+     * @see InputMode
+     */
+    public static boolean supportsControllerInput() {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        if (controllerMod == null) {
+            return false;
+        }
+        return controllerMod.getInputMode().supportsController();
+    }
+
+    /**
+     * Returns whether the given input action is currently active this tick.
+     * <p>
+     * Checks the action state depending on the current input mode:
+     * <ul>
+     *     <li>{@link InputMode#KEYBOARD_MOUSE}: whether the key mapping is down.</li>
+     *     <li>{@link InputMode#CONTROLLER}: whether the controller binding digital state is active.</li>
+     *     <li>{@link InputMode#MIXED}: true if either the key mapping is down or the controller binding state is active.</li>
+     * </ul>
+     * If no controller mod is present, only the key mapping is checked.
+     * This is usually useful for continuous actions.
+     *
+     * @param action the input action to check
+     * @return true if the action is currently this tick active; false otherwise
+     * @see InputType
+     */
+    public static boolean isActionActive(@NotNull EpicFightInputActions action) {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        if (controllerMod == null) {
+            return isKeyDown(action.keyMapping());
+        }
+
+        return switch (controllerMod.getInputMode()) {
+            case KEYBOARD_MOUSE -> isKeyDown(action.keyMapping());
+            case CONTROLLER -> controllerMod.getBinding(action).isDigitalActiveNow();
+            case MIXED -> isKeyDown(action.keyMapping()) || controllerMod.getBinding(action).isDigitalActiveNow();
+        };
+    }
+
+    /**
+     * Called on every client tick to potentially trigger the provided callback for a given input action.
+     * <p>
+     * This calls the internal {@link DiscreteInputActionTrigger#triggerOnPress} API, and additionally fires
+     * the {@link InputEvent.InteractionKeyMappingTriggered} input event for keyboard/mouse if {@code interactionKeyEventCheck} is {@code true}.
+     *
+     * @param action     The input action to monitor and trigger.
+     * @param interactionKeyEventCheck If {@code true}, fires the {@link InputEvent.InteractionKeyMappingTriggered} event for non-controller actions.
+     *                   This event is cancellable.
+     * @param handler    The callback to invoke when the action triggers.
+     * @see DiscreteInputActionTrigger#triggerOnPress Internal implementation details.
+     */
+    public static void triggerOnPress(@NotNull EpicFightInputActions action, boolean interactionKeyEventCheck, @NotNull DiscreteActionHandler handler) {
+        DiscreteInputActionTrigger.triggerOnPress(action, (context) -> {
+            if (context.triggeredByController() || !interactionKeyEventCheck) {
+                handler.onAction(context);
+                return;
+            }
+
+            runKeyboardMouseEvent(action, handler);
+        });
+    }
+
+    /**
+     * Convenience overload of {@link #triggerOnPress(EpicFightInputActions, boolean, DiscreteActionHandler)}
+     * for callbacks that do not require the {@link DiscreteActionHandler.Context}.
+     *
+     * @see #triggerOnPress(EpicFightInputActions, boolean, DiscreteActionHandler)
+     */
+    public static void triggerOnPress(@NotNull EpicFightInputActions action, boolean interactionKeyEventCheck, @NotNull Runnable runnable) {
+        triggerOnPress(action, interactionKeyEventCheck, (context) -> runnable.run());
+    }
+
+    /**
+     * Checks whether the given input action is assigned to the same key / button as another action.
+     * <p>
+     * For keyboard/mouse, this compares the key codes; for controllers, it compares the digital button.
+     * <p><b>Note:</b> {@link InputMode#MIXED} is currently unsupported and its behavior is undefined.</p>
+     *
+     * @param action  the first input action
+     * @param action2 the second input action
+     * @return true if both actions are triggered by the same key or controller button; false otherwise
+     */
+    public static boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2) {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
+            return controllerMod.isBoundToSameButton(action, action2);
+        }
+
+        final KeyMapping keyMapping1 = action.keyMapping();
+        final KeyMapping keyMapping2 = action2.keyMapping();
+        return keyMapping1.getKey() == keyMapping2.getKey();
+    }
+
+    /**
+     * Retrieves the current input state for the current player (client-side).
+     * <p><b>Note:</b> {@link InputMode#MIXED} is currently unsupported and its behavior is undefined.</p>
+     * You should use this method instead of depending on the vanilla {@link Input} directly
+     * to support controllers.
+     * <p>
+     * The {@link PlayerInputState} is immutable, so properties cannot be updated directly, for that,
+     * use {@link InputManager#setInputState}.
+     *
+     * @param vanillaInput the Minecraft vanilla {@link Input} which will be mapped to a {@link PlayerInputState};
+     *                     ignored if using a controller.
+     * @return an immutable {@link PlayerInputState} representing the current input state.
+     * @see InputManager#setInputState
+     */
+    public static PlayerInputState getInputState(@NotNull Input vanillaInput) {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
+            return controllerMod.getInputState();
+        }
+
+        return PlayerInputState.fromVanillaInput(vanillaInput);
+    }
+
+    /**
+     * Updates the current input state for the current player (client-side).
+     * <p>
+     * You should use this instead of modifying fields in the vanilla {@link Input} directly
+     * to ensure controller input is properly supported.
+     * </p>
+     *
+     * @param inputState the updated input state.
+     * @see InputManager#getInputState
+     */
+    public static void setInputState(@NotNull PlayerInputState inputState) {
+        final LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null) {
+            Input input = player.input;
+            PlayerInputState.applyToVanillaInput(inputState, input);
+        }
+    }
+
+    /**
+     * Handles firing the {@link InputEvent.InteractionKeyMappingTriggered} input event for keyboard/mouse actions
+     * and runs the callback only if the event is not canceled.
+     * This method replaces the legacy internal {@link ControlEngine#isKeyPressed}.
+     */
+    @SuppressWarnings("JavadocReference")
+    private static void runKeyboardMouseEvent(@NotNull EpicFightInputActions action, @NotNull DiscreteActionHandler handler) {
+        final KeyMapping keyMapping = action.keyMapping();
+
+        final InputConstants.Key key = keyMapping.getKey();
+        final boolean isMouse = InputConstants.Type.MOUSE == key.getType();
+
+        final int mouseButton = isMouse ? key.getValue() : -1;
+
+        @SuppressWarnings("UnstableApiUsage")
+        InputEvent.InteractionKeyMappingTriggered inputEvent = ForgeHooksClient.onClickInput(
+                mouseButton, keyMapping, InteractionHand.MAIN_HAND
+        );
+
+        if (!inputEvent.isCanceled()) {
+            handler.onAction(new DiscreteActionHandler.Context(false));
+        }
+    }
+
+    /**
+     * Checks whether the vanilla {@link KeyMapping} is down.
+     * This internal method replaces the legacy {@link ControlEngine#isKeyDown}.
+     */
+    private static boolean isKeyDown(@NotNull KeyMapping keyMapping) {
+        if (keyMapping.isDown()) {
+            return true;
+        }
+        final InputConstants.Key key = keyMapping.getKey();
+        final int keyValue = key.getValue();
+        final long windowPointer = Minecraft.getInstance().getWindow().getWindow();
+
+        if (key.getType() == InputConstants.Type.KEYSYM) {
+            return GLFW.glfwGetKey(windowPointer, keyValue) > 0;
+        } else if (key.getType() == InputConstants.Type.MOUSE) {
+            return GLFW.glfwGetMouseButton(windowPointer, keyValue) > 0;
+        }
+        return false;
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -68,7 +68,7 @@ public final class InputManager {
      * This is usually useful for continuous actions.
      *
      * @param action the input action to check
-     * @return true if the action is currently this tick active; false otherwise
+     * @return true if the action is currently active in this tick; false otherwise
      * @see InputType
      */
     public static boolean isActionActive(@NotNull EpicFightInputActions action) {
@@ -152,6 +152,7 @@ public final class InputManager {
      * @return an immutable {@link PlayerInputState} representing the current input state.
      * @see InputManager#setInputState
      */
+    @NotNull
     public static PlayerInputState getInputState(@NotNull Input vanillaInput) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
@@ -159,6 +160,18 @@ public final class InputManager {
         }
 
         return PlayerInputState.fromVanillaInput(vanillaInput);
+    }
+
+    /**
+     * Convenience overload of {@link #getInputState(Input)} that requires the full {@link LocalPlayer},
+     * which is needed to read the vanilla {@link Input} used for non-controller inputs.
+     *
+     * @param localPlayer the player whose vanilla {@link Input} will be read; ignored when using a controller.
+     * @return an immutable {@link PlayerInputState} representing the current input state.
+     */
+    @NotNull
+    public static PlayerInputState getInputState(@NotNull LocalPlayer localPlayer) {
+        return getInputState(localPlayer.input);
     }
 
     /**

--- a/src/main/java/yesman/epicfight/api/client/input/utils/InputUtils.java
+++ b/src/main/java/yesman/epicfight/api/client/input/utils/InputUtils.java
@@ -1,0 +1,49 @@
+package yesman.epicfight.api.client.input.utils;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.Input;
+import net.minecraft.client.player.LocalPlayer;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.input.MovementDirection;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
+
+/**
+ * Internal utility for simplified input checks.
+ * Clients should use {@link InputManager} directly.
+ */
+@ApiStatus.Internal
+public final class InputUtils {
+    private InputUtils() {
+    }
+
+    public static boolean isJumpActionPressed() {
+        return InputManager.isActionActive(EpicFightInputActions.JUMP);
+    }
+
+    public static MovementDirection getMovementDirection(LocalPlayer localPlayer) {
+        return MovementDirection.fromInputState(getInputState(localPlayer));
+    }
+
+    public static PlayerInputState getInputState(LocalPlayer localPlayer) {
+        return InputManager.getInputState(localPlayer.input);
+    }
+
+    public static void sneakingTick(boolean isSneaking, float sneakingSpeedMultiplier) {
+        final LocalPlayer localPlayer = Minecraft.getInstance().player;
+        if (localPlayer != null) {
+            sneakingTick(localPlayer, isSneaking, sneakingSpeedMultiplier);
+        }
+    }
+
+    /**
+     * Currently, this calls {@link Input#tick} without performing any additional logic.
+     * This abstraction was introduced to allow calling it without depending on the vanilla Minecraft {@link Input},
+     * enabling Epic Fight to introduce changes in future updates if necessary to support controllers.
+     */
+    public static void sneakingTick(@NotNull LocalPlayer player, boolean isSneaking, float sneakingSpeedMultiplier) {
+        player.input.tick(isSneaking, sneakingSpeedMultiplier);
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/utils/InputUtils.java
+++ b/src/main/java/yesman/epicfight/api/client/input/utils/InputUtils.java
@@ -5,9 +5,6 @@ import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import yesman.epicfight.api.client.input.MovementDirection;
-import yesman.epicfight.api.client.input.PlayerInputState;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 
 /**
@@ -17,18 +14,6 @@ import yesman.epicfight.api.client.input.handlers.InputManager;
 @ApiStatus.Internal
 public final class InputUtils {
     private InputUtils() {
-    }
-
-    public static boolean isJumpActionPressed() {
-        return InputManager.isActionActive(EpicFightInputActions.JUMP);
-    }
-
-    public static MovementDirection getMovementDirection(LocalPlayer localPlayer) {
-        return MovementDirection.fromInputState(getInputState(localPlayer));
-    }
-
-    public static PlayerInputState getInputState(LocalPlayer localPlayer) {
-        return InputManager.getInputState(localPlayer.input);
     }
 
     public static void sneakingTick(boolean isSneaking, float sneakingSpeedMultiplier) {

--- a/src/main/java/yesman/epicfight/client/events/ClientEvents.java
+++ b/src/main/java/yesman/epicfight/client/events/ClientEvents.java
@@ -75,7 +75,9 @@ public class ClientEvents {
 	@SubscribeEvent
 	public static void presssKeyInGui(ScreenEvent.KeyPressed.Pre event) {
 		CapabilityItem itemCapability = CapabilityItem.EMPTY;
-		
+
+        // TODO: (INPUT_SYSTEM_REFACTOR) This only disables swaping off hand item for key inputs.
+        //  Explore a universal solution that also supports controllers and other input systems.
 		if (event.getKeyCode() == MINECRAFT.options.keySwapOffhand.getKey().getValue()) {
 			if (event.getScreen() instanceof AbstractContainerScreen) {
 				Slot slot = ((AbstractContainerScreen<?>)event.getScreen()).getSlotUnderMouse();

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -2,7 +2,12 @@ package yesman.epicfight.client.events.engine;
 
 import java.util.Set;
 
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.world.entity.player.Inventory;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 import com.google.common.collect.Sets;
@@ -33,10 +38,12 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import yesman.epicfight.api.animation.types.EntityState;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.gui.screen.config.IngameConfigurationScreen;
-import yesman.epicfight.client.input.EpicFightKeyMappings;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.main.EpicFightMod;
@@ -47,6 +54,7 @@ import yesman.epicfight.skill.SkillSlots;
 import yesman.epicfight.skill.modules.ChargeableSkill;
 import yesman.epicfight.skill.modules.HoldableSkill;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.skill.CapabilitySkill;
 import yesman.epicfight.world.entity.eventlistener.MovementInputEvent;
 import yesman.epicfight.world.entity.eventlistener.PlayerEventListener.EventType;
 import yesman.epicfight.world.entity.eventlistener.SkillCastEvent;
@@ -70,9 +78,32 @@ public class ControlEngine {
 	private boolean hotbarLocked;
 	private boolean holdingFinished;
 	private int reserveCounter;
+    /**
+     * <b>DEPRECATED:</b> This field is retained for backward compatibility and should not be used
+     * for comparisons or method calls on this instance. In future updates, {@link EpicFightInputActions}
+     * will be stored directly instead of a vanilla {@link KeyMapping}.
+     *
+     * <p>Do not rely on this field for new functionality. For mapping a {@link KeyMapping} to an
+     * action, use {@link ControlEngine#mapKeyMappingToAction} instead (temporary solution).</p>
+     *
+     * @see ControlEngine#mapKeyMappingToAction
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
 	private KeyMapping reservedKey;
 	private SkillSlot reservedOrHoldingSkillSlot;
-	private KeyMapping currentHoldingKey;
+    /**
+     * <b>DEPRECATED:</b> Consider using {@link ControlEngine#isCurrentHoldingAction} or 
+     * {@link ControlEngine#isCurrentHoldingActionActive} instead of directly 
+     * accessing or comparing this field. This field is retained for backward 
+     * compatibility; in future updates, {@link EpicFightInputActions} will be 
+     * stored directly instead of a vanilla {@link KeyMapping}.
+     *
+     * @see ControlEngine#mapKeyMappingToAction
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
+    private KeyMapping currentHoldingKey;
 	public Options options;
 	
 	public ControlEngine() {
@@ -108,156 +139,30 @@ public class ControlEngine {
 		if (this.playerPatch == null) {
 			return;
 		}
+
+        InputManager.triggerOnPress(EpicFightInputActions.OPEN_SKILL_SCREEN, false, this::openSkillEditor);
+
+        InputManager.triggerOnPress(EpicFightInputActions.OPEN_CONFIG_SCREEN, false, this::openConfig);
+
+        InputManager.triggerOnPress(EpicFightInputActions.SWITCH_VANILLA_MODEL_DEBUGGING, false, this::switchVanillaModelDebugging);
+
+        InputManager.triggerOnPress(EpicFightInputActions.ATTACK, true, this::maybeAttack);
+
+        InputManager.triggerOnPress(EpicFightInputActions.DODGE, true, this::maybeDodge);
+
+        if (InputManager.isActionActive(EpicFightInputActions.GUARD)) {
+            maybeGuard();
+        }
+
+        InputManager.triggerOnPress(EpicFightInputActions.WEAPON_INNATE_SKILL, true, this::handleSeparateWeaponInnateSkill);
+
+        InputManager.triggerOnPress(EpicFightInputActions.MOBILITY, true, this::maybePerformMoverSkill);
+
+        InputManager.triggerOnPress(EpicFightInputActions.SWITCH_MODE, false, this::switchMode);
 		
-		if (isKeyPressed(EpicFightKeyMappings.SKILL_EDIT, false)) {
-			if (this.playerPatch.getSkillCapability() != null) {
-				Minecraft.getInstance().setScreen(new SkillEditScreen(this.player, this.playerPatch.getSkillCapability()));
-			}
-		}
+        InputManager.triggerOnPress(EpicFightInputActions.LOCK_ON, false, () -> this.playerPatch.toggleLockOn());
 		
-		if (isKeyPressed(EpicFightKeyMappings.OPEN_CONFIG_SCREEN, false)) {
-			Minecraft.getInstance().setScreen(new IngameConfigurationScreen(null));
-		}
-		
-		if (isKeyPressed(EpicFightKeyMappings.SWITCH_VANILLA_MODEL_DEBUGGING, false)) {
-			boolean flag = ClientEngine.getInstance().switchVanillaModelDebuggingMode();
-			this.minecraft.keyboardHandler.debugFeedbackTranslated(flag ? "debug.vanilla_model_debugging.on" : "debug.vanilla_model_debugging.off");
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.ATTACK, true)) {
-			if (this.playerPatch.isEpicFightMode() && this.currentHoldingKey != EpicFightKeyMappings.ATTACK) {
-				boolean shouldPlayAttackAnimation = this.playerPatch.canPlayAttackAnimation();
-				
-				if (this.options.keyAttack.getKey() == EpicFightKeyMappings.ATTACK.getKey() && this.minecraft.hitResult != null) {
-					// Disable vanilla attack key
-					if (shouldPlayAttackAnimation) {
-						makeUnpressed(this.options.keyAttack);
-					}
-				}
-				
-				if (shouldPlayAttackAnimation) {
-					if (!EpicFightKeyMappings.ATTACK.getKey().equals(EpicFightKeyMappings.WEAPON_INNATE_SKILL.getKey())) {
-						SkillContainer airSlash = this.playerPatch.getSkill(SkillSlots.AIR_ATTACK);
-						SkillSlot slot = (this.tickSinceLastJump > 0 && airSlash.getSkill() != null && airSlash.getSkill().canExecute(airSlash)) ? SkillSlots.AIR_ATTACK : SkillSlots.BASIC_ATTACK;
-						SkillCastEvent skillCastEvent = this.playerPatch.getSkill(slot).sendCastRequest(this.playerPatch, this);
-						
-						if (skillCastEvent.isExecutable()) {
-							this.player.resetAttackStrengthTicker();
-							this.attackLightPressToggle = false;
-							this.releaseAllServedKeys();
-						} else {
-							if (!this.player.isSpectator() && slot == SkillSlots.BASIC_ATTACK) {
-								this.reserveKey(slot, EpicFightKeyMappings.ATTACK);
-							}
-						}
-						
-						this.lockHotkeys();
-						this.attackLightPressToggle = false;
-						this.weaponInnatePressToggle = false;
-						this.weaponInnatePressCounter = 0;
-					} else {
-						if (!this.weaponInnatePressToggle) {
-							this.weaponInnatePressToggle = true;
-						}
-					}
-				}
-			}
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.DODGE, true)) {
-			if (this.playerPatch.isEpicFightMode() && this.currentHoldingKey != EpicFightKeyMappings.DODGE) {
-				if (EpicFightKeyMappings.DODGE.getKey().getValue() == this.options.keyShift.getKey().getValue()) {
-					if (this.player.getVehicle() == null) {
-						if (!this.sneakPressToggle) {
-							this.sneakPressToggle = true;
-						}
-					}
-				} else {
-					SkillSlot skillCategory = (this.playerPatch.getEntityState().knockDown()) ? SkillSlots.KNOCKDOWN_WAKEUP : SkillSlots.DODGE;
-					SkillContainer skill = this.playerPatch.getSkill(skillCategory);
-					
-					if (!skill.isEmpty() && skill.sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
-						this.reserveKey(SkillSlots.DODGE, EpicFightKeyMappings.DODGE);
-					}
-				}
-			}
-		}
-		
-		if (isKeyDown(EpicFightKeyMappings.GUARD)) {
-			if (this.playerPatch.isEpicFightMode() && this.currentHoldingKey != EpicFightKeyMappings.GUARD) {
-				boolean shouldCancelGuard = false;
-				
-				if (this.playerPatch.isHoldingAny()) {
-					shouldCancelGuard = true;
-				} else if (this.player.getMainHandItem().getUseAnimation() == UseAnim.BLOCK || this.player.getOffhandItem().getUseAnimation() == UseAnim.BLOCK) {
-					shouldCancelGuard = true;
-				}
-				
-				if (!shouldCancelGuard) {
-					SkillCastEvent skillCastEvent = this.playerPatch.getSkill(SkillSlots.GUARD).sendCastRequest(this.playerPatch, this);
-					
-					if (skillCastEvent.shouldReserveKey()) {
-						if (!this.player.isSpectator()) {
-							this.reserveKey(SkillSlots.GUARD, EpicFightKeyMappings.GUARD);
-						}
-					} else {
-						this.lockHotkeys();
-					}
-				}
-			}
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.WEAPON_INNATE_SKILL, true)) {
-			if (this.playerPatch.isEpicFightMode() && this.currentHoldingKey != EpicFightKeyMappings.WEAPON_INNATE_SKILL) {
-				if (!EpicFightKeyMappings.ATTACK.getKey().equals(EpicFightKeyMappings.WEAPON_INNATE_SKILL.getKey())) {
-					if (this.playerPatch.getSkill(SkillSlots.WEAPON_INNATE).sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
-						if (!this.player.isSpectator()) {
-							this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightKeyMappings.WEAPON_INNATE_SKILL);
-						}
-					} else {
-						this.lockHotkeys();
-					}
-				}
-			}
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.MOVER_SKILL, true)) {
-			if (this.playerPatch.isEpicFightMode() && !this.playerPatch.isHoldingAny()) {
-				if (EpicFightKeyMappings.MOVER_SKILL.getKey().getValue() == this.options.keyJump.getKey().getValue()) {
-					SkillContainer skillContainer = this.playerPatch.getSkill(SkillSlots.MOVER);
-					
-					if (!skillContainer.isEmpty()) {
-						SkillCastEvent event = new SkillCastEvent(this.playerPatch, skillContainer, skillContainer.getSkill().gatherArguments(skillContainer, this));
-						
-						if (skillContainer.canUse(this.playerPatch, event) && this.player.getVehicle() == null) {
-							if (!this.moverPressToggle) {
-								this.moverPressToggle = true;
-							}
-						}
-					}
-				} else {
-					SkillContainer skill = this.playerPatch.getSkill(SkillSlots.MOVER);
-					skill.sendCastRequest(this.playerPatch, this);
-				}
-			}
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.SWITCH_MODE, false)) {
-			if (EpicFightGameRules.CAN_SWITCH_PLAYER_MODE.getRuleValue(this.playerPatch.getOriginal().level())) {
-				this.playerPatch.toggleMode();
-			} else {
-				this.minecraft.gui.getChat().addMessage(Component.translatable("epicfight.messages.mode_switching_disabled").withStyle(ChatFormatting.RED));
-			}
-		}
-		
-		while (isKeyPressed(EpicFightKeyMappings.LOCK_ON, false)) {
-			this.playerPatch.toggleLockOn();
-		}
-		
-		// Disable swap hand items
-		if (this.playerPatch.getEntityState().inaction() || (!this.playerPatch.getHoldingItemCapability(InteractionHand.MAIN_HAND).canBePlacedOffhand())) {
-			makeUnpressed(this.minecraft.options.keySwapOffhand);
-		}
+		consumeSwapOffhandClick();
 		
 		// Pause here if player is not in battle mode
 		if (!this.playerPatch.isEpicFightMode() || Minecraft.getInstance().isPaused()) {
@@ -269,16 +174,16 @@ public class ControlEngine {
 		}
 		
 		if (this.weaponInnatePressToggle) {
-			if (!isKeyDown(EpicFightKeyMappings.WEAPON_INNATE_SKILL)) {
+			if (!InputManager.isActionActive(EpicFightInputActions.WEAPON_INNATE_SKILL)) {
 				this.attackLightPressToggle = true;
 				this.weaponInnatePressToggle = false;
 				this.weaponInnatePressCounter = 0;
 			} else {
-				if (EpicFightKeyMappings.WEAPON_INNATE_SKILL.getKey().equals(EpicFightKeyMappings.ATTACK.getKey())) {
+				if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.WEAPON_INNATE_SKILL, EpicFightInputActions.ATTACK)) {
 					if (this.weaponInnatePressCounter > ClientConfig.longPressCounter) {
 						if (this.playerPatch.getSkill(SkillSlots.WEAPON_INNATE).sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
 							if (!this.player.isSpectator()) {
-								this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightKeyMappings.WEAPON_INNATE_SKILL);
+								this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputActions.WEAPON_INNATE_SKILL);
 							}
 						} else {
 							this.lockHotkeys();
@@ -303,7 +208,7 @@ public class ControlEngine {
 				this.releaseAllServedKeys();
 			} else {
 				if (!this.player.isSpectator() && slot == SkillSlots.BASIC_ATTACK) {
-					this.reserveKey(slot, EpicFightKeyMappings.ATTACK);
+					this.reserveKey(slot, EpicFightInputActions.ATTACK);
 				}
 			}
 			
@@ -315,12 +220,12 @@ public class ControlEngine {
 		}
 		
 		if (this.sneakPressToggle) {
-			if (!isKeyDown(this.options.keyShift)) {
+			if (!InputManager.isActionActive(EpicFightInputActions.SNEAK)) {
 				SkillSlot skillSlot = (this.playerPatch.getEntityState().knockDown()) ? SkillSlots.KNOCKDOWN_WAKEUP : SkillSlots.DODGE;
 				SkillContainer skill = this.playerPatch.getSkill(skillSlot);
 				
 				if (skill.sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
-					this.reserveKey(skillSlot, this.options.keyShift);
+					this.reserveKey(skillSlot, EpicFightInputActions.SNEAK);
 				}
 				
 				this.sneakPressToggle = false;
@@ -340,7 +245,7 @@ public class ControlEngine {
 			
 			if (!container.isEmpty()) {
 				if (container.getSkill() instanceof HoldableSkill) {
-					if (!isKeyDown(this.currentHoldingKey)) {
+					if (!isCurrentHoldingActionActive()) {
 						this.holdingFinished = true;
 					}
 					
@@ -385,23 +290,169 @@ public class ControlEngine {
 		}
 
 		if (!this.playerPatch.getEntityState().canSwitchHoldingItem() || this.hotbarLocked) {
-			for (int i = 0; i < 9; ++i) {
-				while (this.options.keyHotbarSlots[i].consumeClick());
-			}
+			consumeHotbarSlotClicks();
 
+            // TODO: (INPUT_SYSTEM_REFACTOR) This only works for key inputs (the usage of keyDrop).
+            //  Explore a universal solution that also supports controllers and other input systems.
 			while (this.options.keyDrop.consumeClick());
 		}
 	}
+
+    private void openSkillEditor() {
+        final CapabilitySkill capabilitySkill = this.playerPatch.getSkillCapability();
+        if (capabilitySkill == null) {
+            return;
+        }
+        minecraft.setScreen(new SkillEditScreen(this.player, capabilitySkill));
+    }
+
+    private void openConfig() {
+        minecraft.setScreen(new IngameConfigurationScreen(null));
+    }
+
+    private void switchVanillaModelDebugging() {
+        boolean flag = ClientEngine.getInstance().switchVanillaModelDebuggingMode();
+        this.minecraft.keyboardHandler.debugFeedbackTranslated(flag ? "debug.vanilla_model_debugging.on" : "debug.vanilla_model_debugging.off");
+    }
+
+    private void maybeAttack() {
+        if (!this.playerPatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.ATTACK)) {
+            return;
+        }
+        boolean shouldPlayAttackAnimation = this.playerPatch.canPlayAttackAnimation();
+        consumeAttackKeyClick(shouldPlayAttackAnimation);
+
+        if (shouldPlayAttackAnimation) {
+            if (!InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.ATTACK, EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+                SkillContainer airSlash = this.playerPatch.getSkill(SkillSlots.AIR_ATTACK);
+                SkillSlot slot = (this.tickSinceLastJump > 0 && airSlash.getSkill() != null && airSlash.getSkill().canExecute(airSlash)) ? SkillSlots.AIR_ATTACK : SkillSlots.BASIC_ATTACK;
+                SkillCastEvent skillCastEvent = this.playerPatch.getSkill(slot).sendCastRequest(this.playerPatch, this);
+
+                if (skillCastEvent.isExecutable()) {
+                    this.player.resetAttackStrengthTicker();
+                    this.attackLightPressToggle = false;
+                    this.releaseAllServedKeys();
+                } else {
+                    if (!this.player.isSpectator() && slot == SkillSlots.BASIC_ATTACK) {
+                        this.reserveKey(slot, EpicFightInputActions.ATTACK);
+                    }
+                }
+
+                this.lockHotkeys();
+                this.attackLightPressToggle = false;
+                this.weaponInnatePressToggle = false;
+                this.weaponInnatePressCounter = 0;
+            } else {
+                if (!this.weaponInnatePressToggle) {
+                    this.weaponInnatePressToggle = true;
+                }
+            }
+        }
+    }
+
+    private void maybeDodge() {
+        if (!this.playerPatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.DODGE)) {
+            return;
+        }
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.DODGE, EpicFightInputActions.SNEAK)) {
+            if (this.player.getVehicle() == null) {
+                if (!this.sneakPressToggle) {
+                    this.sneakPressToggle = true;
+                }
+            }
+        } else {
+            SkillSlot skillCategory = (this.playerPatch.getEntityState().knockDown()) ? SkillSlots.KNOCKDOWN_WAKEUP : SkillSlots.DODGE;
+            SkillContainer skill = this.playerPatch.getSkill(skillCategory);
+
+            if (!skill.isEmpty() && skill.sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
+                this.reserveKey(SkillSlots.DODGE, EpicFightInputActions.DODGE);
+            }
+        }
+    }
+
+    private void maybeGuard() {
+        if (!this.playerPatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.GUARD)) {
+            return;
+        }
+        boolean shouldCancelGuard = false;
+
+        if (this.playerPatch.isHoldingAny()) {
+            shouldCancelGuard = true;
+        } else if (this.player.getMainHandItem().getUseAnimation() == UseAnim.BLOCK || this.player.getOffhandItem().getUseAnimation() == UseAnim.BLOCK) {
+            shouldCancelGuard = true;
+        }
+
+        if (!shouldCancelGuard) {
+            SkillCastEvent skillCastEvent = this.playerPatch.getSkill(SkillSlots.GUARD).sendCastRequest(this.playerPatch, this);
+
+            if (skillCastEvent.shouldReserveKey()) {
+                if (!this.player.isSpectator()) {
+                    this.reserveKey(SkillSlots.GUARD, EpicFightInputActions.GUARD);
+                }
+            } else {
+                this.lockHotkeys();
+            }
+        }
+    }
+
+    private void handleSeparateWeaponInnateSkill() {
+        if (!this.playerPatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+            return;
+        }
+        if (!InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.ATTACK, EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+            if (this.playerPatch.getSkill(SkillSlots.WEAPON_INNATE).sendCastRequest(this.playerPatch, this).shouldReserveKey()) {
+                if (!this.player.isSpectator()) {
+                    this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputActions.WEAPON_INNATE_SKILL);
+                }
+            } else {
+                this.lockHotkeys();
+            }
+        }
+    }
+
+    private void maybePerformMoverSkill() {
+        if (!this.playerPatch.isEpicFightMode() || this.playerPatch.isHoldingAny()) {
+            return;
+        }
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.MOBILITY, EpicFightInputActions.JUMP)) {
+            SkillContainer skillContainer = this.playerPatch.getSkill(SkillSlots.MOVER);
+
+            if (!skillContainer.isEmpty()) {
+                SkillCastEvent event = new SkillCastEvent(this.playerPatch, skillContainer, skillContainer.getSkill().gatherArguments(skillContainer, this));
+
+                if (skillContainer.canUse(this.playerPatch, event) && this.player.getVehicle() == null) {
+                    if (!this.moverPressToggle) {
+                        this.moverPressToggle = true;
+                    }
+                }
+            }
+        } else {
+            // Immediately trigger the skill cast if Mover and Jump are bound to different keys/buttons.
+            SkillContainer skill = this.playerPatch.getSkill(SkillSlots.MOVER);
+            skill.sendCastRequest(this.playerPatch, this);
+        }
+    }
+
+    private void switchMode() {
+        final boolean canSwitch = EpicFightGameRules.CAN_SWITCH_PLAYER_MODE.getRuleValue(this.playerPatch.getOriginal().level());
+        if (!canSwitch) {
+            this.minecraft.gui.getChat().addMessage(Component.translatable("epicfight.messages.mode_switching_disabled").withStyle(ChatFormatting.RED));
+            return;
+        }
+        this.playerPatch.toggleMode();
+    }
 	
 	private void inputTick(Input input) {
+        PlayerInputState inputState = InputManager.getInputState(input);
 		if (this.moverPressToggle) {
-			if (!isKeyDown(this.options.keyJump)) {
+			if (!InputManager.isActionActive(EpicFightInputActions.JUMP)) {
 				this.moverPressToggle = false;
 				this.moverPressCounter = 0;
 				
 				if (this.player.onGround()) {
 					this.player.noJumpDelay = 0;
-					input.jumping = true;
+                    inputState = inputState.withJumping(true);
+                    InputManager.setInputState(inputState);
 				}
 			} else {
 				if (this.moverPressCounter > ClientConfig.longPressCounter) {
@@ -418,30 +469,37 @@ public class ControlEngine {
 		}
 		
 		if (!this.canPlayerMove(this.playerPatch.getEntityState())) {
-			input.forwardImpulse = 0F;
-			input.leftImpulse = 0F;
-			input.up = false;
-			input.down = false;
-			input.left = false;
-			input.right = false;
-			input.jumping = false;
-			input.shiftKeyDown = false;
+            inputState = inputState.copyWith(0F, 0F, false, false, false, false, false, false);
+            InputManager.setInputState(inputState);
 			this.player.sprintTriggerTime = -1;
 			this.player.setSprinting(false);
 		}
 		
 		if (this.player.isAlive()) {
-			this.playerPatch.getEventListener().triggerEvents(EventType.MOVEMENT_INPUT_EVENT, new MovementInputEvent(this.playerPatch, input));
+			this.playerPatch.getEventListener().triggerEvents(EventType.MOVEMENT_INPUT_EVENT, new MovementInputEvent(this.playerPatch, inputState));
 		}
 		
 		if (this.tickSinceLastJump > 0) this.tickSinceLastJump--;
 	}
-	
+
+    /**
+     * <b>DEPRECATED:</b> This method is retained for backward compatibility and will 
+     * be removed in a future release. Do not use it for new code.
+     * <p>Instead of using this method, use
+     * {@link #reserveKey(SkillSlot, EpicFightInputActions)}, which works directly
+     * with {@link EpicFightInputActions}.</p>
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated(forRemoval = true)
 	private void reserveKey(SkillSlot slot, KeyMapping keyMapping) {
 		this.reservedKey = keyMapping;
 		this.reservedOrHoldingSkillSlot = slot;
 		this.reserveCounter = 8;
 	}
+
+    private void reserveKey(SkillSlot slot, EpicFightInputActions action) {
+        reserveKey(slot, action.keyMapping());
+    }
 	
 	public void releaseAllServedKeys() {
 		this.holdingFinished = true;
@@ -464,6 +522,8 @@ public class ControlEngine {
 		this.lastHotbarLockedTime = this.player.tickCount;
 
 		for (int i = 0; i < 9; ++i) {
+            // TODO: (INPUT_SYSTEM_REFACTOR) This only works for key inputs (the usage of keyHotbarSlots).
+            //  Explore a universal solution that also supports controllers and other input systems.
 			while (this.options.keyHotbarSlots[i].consumeClick());
 		}
 	}
@@ -475,8 +535,18 @@ public class ControlEngine {
 	public void addPacketToSend(Object packet) {
 		this.packets.add(packet);
 	}
-	
-	public static boolean isKeyDown(KeyMapping key) {
+
+    /**
+     * <b>DEPRECATED:</b> Use {@link InputManager#isActionActive} instead for controller support,
+     * though it only handles Epic Fight supported actions. For checking a custom mod keybind,
+     * use the vanilla {@link KeyMapping#isDown}.
+     * <p>
+     * Even though this is a private method, it is retained in case an Epic Fight addon
+     * accesses it by bypassing Java private access modifier restriction.
+     */
+	@SuppressWarnings({"JavadocReference", "DeprecatedIsStillUsed"})
+    @Deprecated(forRemoval = true)
+    public static boolean isKeyDown(KeyMapping key) {
 		if (key.getKey().getType() == InputConstants.Type.KEYSYM) {
 			return key.isDown() || GLFW.glfwGetKey(Minecraft.getInstance().getWindow().getWindow(), key.getKey().getValue()) > 0;
 		} else if(key.getKey().getType() == InputConstants.Type.MOUSE) {
@@ -485,7 +555,16 @@ public class ControlEngine {
 			return false;
 		}
 	}
-	
+
+    /**
+     * <b>DEPRECATED:</b> Use {@link InputManager#triggerOnPress} instead for controller support,
+     * though it only handles Epic Fight supported actions. For checking a custom mod keybind,
+     * use the vanilla {@link KeyMapping#consumeClick} with a {@code while} statement.
+     * <p>
+     * Even though this is a private method, it is retained in case an Epic Fight addon
+     * accesses it by bypassing Java private access modifier restriction.
+     */
+    @Deprecated(forRemoval = true)
 	private static boolean isKeyPressed(KeyMapping key, boolean eventCheck) {
 		boolean consumes = key.consumeClick();
 		
@@ -500,17 +579,277 @@ public class ControlEngine {
         
     	return consumes;
 	}
-	
-	public static void makeUnpressed(KeyMapping keyMapping) {
-		while (keyMapping.consumeClick()) {}
-		setKeyBind(keyMapping, false);
-	}
-	
-	public static void setKeyBind(KeyMapping key, boolean setter) {
-		KeyMapping.set(key.getKey(), setter);
-	}
-	
-	public boolean moverToggling() {
+
+    /**
+     * <b>DISCOURAGED:</b> Does not support controller mods or other input systems.
+     * <p>
+     * This method was previously called before {@link Minecraft#handleKeybinds} to disable some vanilla
+     * input actions.
+     * <p>
+     * Rather than relying on this method, consider fixing the problem at the core.
+     * For example, to disable vanilla attack:
+     * <pre>
+     * {@code
+     * @Mixin(value = Minecraft.class)
+     * public class MixinMinecraft {
+     *     @Inject(method = "startAttack", at = @At("HEAD"), cancellable = true)
+     *     private void onVanillaAttack(CallbackInfoReturnable<Boolean> cir) {
+     *         cir.cancel();
+     *     }
+     * }
+     * }
+     * </pre>
+     * <b>NOTE:</b> You may still want to call this method to reset the internal {@link KeyMapping#clickCount} state,
+     * as a safety guard to prevent potential issues with other mods.
+     * Refer to {@link ControlEngine#consumeAttackKeyClick} and {@link ControlEngine#shouldDisableVanillaAttack} as an example.
+     *
+     * @see ControlEngine#shouldDisableVanillaAttack
+     * @see ControlEngine#shouldDisableSwapHandItems
+     */
+    @SuppressWarnings({"JavadocReference", "DeprecatedIsStillUsed", "StatementWithEmptyBody", "DefaultAnnotationParam"})
+    @Deprecated(forRemoval = false)
+    public static void makeUnpressed(KeyMapping keyMapping) {
+        while (keyMapping.consumeClick()) {
+        }
+        KeyMapping.set(keyMapping.getKey(), false);
+    }
+
+    /**
+     * <b>DISCOURAGED:</b> Does not allow Epic Fight to perform additional
+     * logic that is independent of the Minecraft vanilla {@link KeyMapping}.
+     * Previously used to set the {@link KeyMapping#isDown} state for sprint keybind,
+     * but that is now handled in {@link ControlEngine#setSprintingKeyStateNotDown}.
+     * Alternatively, you could use the vanilla @{@link KeyMapping#set} directly.
+     *
+     * @see ControlEngine#makeUnpressed
+     * @see ControlEngine#setSprintingKeyStateNotDown
+     */
+    @SuppressWarnings("JavadocReference")
+    @Deprecated(forRemoval = true)
+    public static void setKeyBind(KeyMapping key, boolean setter) {
+        KeyMapping.set(key.getKey(), setter);
+    }
+
+    /**
+     * Sets the state of the sprint keybind ({@link KeyMapping#isDown}) to `false`.
+     * <p>
+     * This only changes the internal {@link KeyMapping} state and does not actually disable sprinting.
+     * To actually stop sprinting, this should usually be called alongside
+     * {@link LocalPlayer#setSprinting}.
+     * <p>
+     * This is intended to support mods and other systems that rely on {@link KeyMapping#isDown()}
+     * to check whether the player is sprinting, rather than {@link LocalPlayer#isSprinting()}.
+     * This is not needed for controller mods.
+     */
+    @SuppressWarnings("JavadocReference")
+    public static void setSprintingKeyStateNotDown() {
+        KeyMapping.set(EpicFightInputActions.SPRINT.keyMapping().getKey(), false);
+    }
+
+    /**
+     * Disables the player's vanilla attacks while in Epic Fight mode.
+     * <p>
+     * Previously, we injected into the vanilla {@link Minecraft#handleKeybinds} method
+     * and used this workaround to reset the internal counter for the vanilla attack keybind:
+     * <pre>
+     * {@code
+     * // Called before Minecraft#handleKeybinds is called.
+     * KeyMapping attack = Minecraft.getInstance().options.keyAttack;
+     * while (attack.consumeClick()) {}
+     * KeyMapping.set(attack.getKey(), false);
+     * }
+     * </pre>
+     * <p>
+     * However, that approach relied on assumptions and did not support other mods, inputs, or systems.
+     * The problem is now solved by injecting into {@link Minecraft#startAttack} and
+     * canceling the call when the player is in Epic Fight mode.
+     * This also means, the player must be always in vanilla mode to perform vanilla attacks, which is as intended.
+     *
+     * @see ControlEngine#consumeAttackKeyClick
+     */
+    @SuppressWarnings("JavadocReference")
+    @ApiStatus.Internal
+    public static boolean shouldDisableVanillaAttack() {
+        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
+        if (playerPatch == null) {
+            return false;
+        }
+        return playerPatch.isEpicFightMode() && playerPatch.canPlayAttackAnimation();
+    }
+
+    /**
+     * Disables the swap offhand items while the player is in action.
+     * <p>
+     * Previously, we injected into the vanilla {@link Minecraft#handleKeybinds} method
+     * and used this workaround to reset the internal counter for the vanilla swap offhand keybind:
+     * <pre>
+     * {@code
+     * // Called before Minecraft#handleKeybinds is called.
+     * KeyMapping swapOffhand = Minecraft.getInstance().options.keySwapOffhand;
+     * while (swapOffhand.consumeClick()) {}
+     * KeyMapping.set(swapOffhand.getKey(), false);
+     * }
+     * </pre>
+     * <p>
+     * However, that approach relied on assumptions and did not support other mods, inputs, or systems.
+     * The problem is now solved by injecting into {@link ClientPacketListener#send} and
+     * canceling the call when the player is in action and trying to swap offhand items.
+     *
+     * @see ControlEngine#consumeSwapOffhandClick
+     */
+    @SuppressWarnings("JavadocReference")
+    @ApiStatus.Internal
+    public static boolean shouldDisableSwapHandItems() {
+        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
+        if (playerPatch == null) {
+            return false;
+        }
+        return playerPatch.getEntityState().inaction() || (!playerPatch.getHoldingItemCapability(InteractionHand.MAIN_HAND).canBePlacedOffhand());
+    }
+
+
+    /**
+     * Previously used to disable the vanilla attack key so the player
+     * can't attack entities or break grass when in Epic Fight mode, but that is now handled by
+     * {@link yesman.epicfight.mixin.client.MixinMinecraft#onStartVanillaAttack} and
+     * {@link yesman.epicfight.mixin.client.MixinMinecraft#onContinueVanillaAttack}.
+     * <p>
+     * This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
+     * to prevent potential conflicts with other mods. It acts as a safety measure;
+     * removing it should no longer cause issues.
+     * <p>
+     * This method does not rely on {@link InputManager#isBoundToSamePhysicalInput} because it operates solely on
+     * the vanilla {@link KeyMapping} behavior and mechanics, and is intentionally not compatible with controllers.
+     * @see ControlEngine#shouldDisableVanillaAttack
+     */
+    @SuppressWarnings("JavadocReference")
+    private static void consumeAttackKeyClick(boolean shouldPlayAttackAnimation) {
+        final KeyMapping vanillaAttack = EpicFightInputActions.VANILLA_ATTACK_DESTROY.keyMapping();
+        final KeyMapping epicFightAttack = EpicFightInputActions.ATTACK.keyMapping();
+        if (vanillaAttack.getKey() == epicFightAttack.getKey() && Minecraft.getInstance().hitResult != null) {
+            if (shouldPlayAttackAnimation) {
+                makeUnpressed(vanillaAttack);
+            }
+        }
+    }
+
+    /**
+     * Previously used to temporarily disable the vanilla swap-offhand key while the player
+     * was performing an action or attacking, but this is now handled by
+     * {@link yesman.epicfight.mixin.client.MixinClientPacketListener#onSendPacket}.
+     * <p>
+     * This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
+     * to prevent potential conflicts with other mods. It serves as a safety measure;
+     * removing it should no longer cause any issues.
+     * <p>
+     * This method does not rely on {@link InputManager#isBoundToSamePhysicalInput} because it operates solely on
+     * the vanilla {@link KeyMapping} behavior and mechanics, and is intentionally not compatible with controllers.
+     * @see ControlEngine#shouldDisableSwapHandItems
+     */
+    @SuppressWarnings("JavadocReference")
+    private static void consumeSwapOffhandClick() {
+        if (shouldDisableSwapHandItems()) {
+            makeUnpressed(EpicFightInputActions.SWAP_OFF_HAND.keyMapping());
+        }
+    }
+
+    /**
+     * Consumes hotbar slot key presses (keyboard only).
+     * <p>
+     * This feature is strictly for keyboards and will not support controllers,
+     * as controllers have limited buttons. Keyboard users can switch slots via
+     * number keys or the mouse wheel. Controller users can only switch using
+     * forward/backward buttons.
+     *
+     * @see ControlEngine#isHotbarCyclingDisabled
+     */
+    private static void consumeHotbarSlotClicks() {
+        final KeyMapping[] hotbarSlots = Minecraft.getInstance().options.keyHotbarSlots;
+        for (int i = 0; i < 9; ++i) {
+            final KeyMapping hotbarSlot = hotbarSlots[i];
+            makeUnpressed(hotbarSlot);
+        }
+    }
+
+    /**
+     * Maps a {@link KeyMapping} to its corresponding input action, if defined.
+     * <p>
+     * Each {@link EpicFightInputActions} enum constant has an associated {@link KeyMapping},
+     * but not every {@link KeyMapping} corresponds to an {@link EpicFightInputActions}, so this may return {@code null}.
+     * Using {@link KeyMapping} directly does not support controllers.
+     * <p>
+     * Ideally, this workaround should not exist. The code should depend on {@link EpicFightInputActions} directly
+     * instead of storing {@link KeyMapping} instances. However, since some classes and Epic Fight addons still rely on:
+     * <ul>
+     *   <li>{@link HoldableSkill#getKeyMapping}</li>
+     *   <li>{@link ControlEngine#currentHoldingKey}</li>
+     *   <li>{@link ControlEngine#reservedKey}</li>
+     * </ul>
+     * this method remains temporarily for backward compatibility. Future updates should refactor these dependencies
+     * to remove reliance on {@link KeyMapping}, allowing this method to be fully removed.
+     * <p>
+     * Sometimes, it makes sense to use this method, for example, if you're using an event such as {@link InputEvent.InteractionKeyMappingTriggered},
+     * which provides only a {@link KeyMapping}.
+     */
+    private static @Nullable EpicFightInputActions mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
+        return EpicFightInputActions.fromKeyMapping(keyMapping);
+    }
+
+    /**
+     * Checks if the specified input action is currently being held.
+     *
+     * @param other the input action to check
+     * @return {@code true} if the given action is currently held; otherwise {@code false}
+     * @see ControlEngine#mapKeyMappingToAction
+     */
+    private boolean isCurrentHoldingAction(@NotNull EpicFightInputActions other) {
+        if (currentHoldingKey == null) {
+            return false;
+        }
+        final EpicFightInputActions currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        if (currentHoldingAction == null) {
+            // Fallback for legacy or custom key mappings.
+            // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
+            // but controller inputs will not support those custom keybinds.
+            return currentHoldingKey == other.keyMapping();
+        }
+        return other == currentHoldingAction;
+    }
+    
+    private boolean isCurrentHoldingActionActive() {
+        if (currentHoldingKey == null) {
+            return false;
+        }
+        final EpicFightInputActions currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        if (currentHoldingAction == null) {
+            // Fallback for legacy or custom key mappings.
+            // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
+            // but controller inputs will not support those custom keybinds.
+            return isKeyDown(currentHoldingKey);
+        }
+        return InputManager.isActionActive(currentHoldingAction);
+    }
+
+    /**
+     * Determines whether hotbar cycling should be disabled.
+     * <p>
+     * Used internally in {@link InputEvent.MouseScrollingEvent} and
+     * {@link yesman.epicfight.mixin.client.MixinInventory}. Cancelling the mouse
+     * scroll event disables cycling for vanilla mouse input, but other input
+     * systems (e.g., controllers) still call {@link Inventory#swapPaint}, so we
+     * cancel those calls as well. This ensures universal behavior while
+     * maximizing compatibility.
+     *
+     * @return {@code true} if hotbar item cycling should be disabled; {@code false} otherwise.
+     * */
+    @ApiStatus.Internal
+    public static boolean isHotbarCyclingDisabled() {
+        final Minecraft minecraft = Minecraft.getInstance();
+        final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+        return minecraft.player != null && localPlayerPatch != null && !localPlayerPatch.getEntityState().canSwitchHoldingItem() && minecraft.screen == null;
+    }
+
+    public boolean moverToggling() {
 		return this.moverPressToggle;
 	}
 	
@@ -540,8 +879,8 @@ public class ControlEngine {
 		
 		@SubscribeEvent
 		public static void mouseScrollEvent(InputEvent.MouseScrollingEvent event) {
-			// Disable item switching
-			if (controlEngine.minecraft.player != null && controlEngine.playerPatch != null && !controlEngine.playerPatch.getEntityState().canSwitchHoldingItem() && controlEngine.minecraft.screen == null) {
+			// Disables item switching for the vanilla mouse input
+			if (isHotbarCyclingDisabled()) {
 				event.setCanceled(true);
 			}
 		}
@@ -575,10 +914,16 @@ public class ControlEngine {
 			if (controlEngine.minecraft.player == null) {
 				return;
 			}
-			
+
+            final EpicFightInputActions triggeredAction = mapKeyMappingToAction(event.getKeyMapping());
+            if (triggeredAction == null) {
+                // The key mapping corresponds to a fixed vanilla action (attack, pick block, or use item).
+                // These are predictable, so it's safe to map the key mapping to an input action.
+                return;
+            }
 			if (
-				event.getKeyMapping() == controlEngine.minecraft.options.keyAttack &&
-				EpicFightKeyMappings.ATTACK.getKey() == controlEngine.minecraft.options.keyAttack.getKey() &&
+                triggeredAction == EpicFightInputActions.VANILLA_ATTACK_DESTROY && 
+                InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.ATTACK, EpicFightInputActions.VANILLA_ATTACK_DESTROY) &&
 				controlEngine.minecraft.hitResult.getType() == HitResult.Type.BLOCK &&
 				ClientConfig.combatPreferredItems.contains(controlEngine.player.getMainHandItem().getItem())
 			) {
@@ -593,8 +938,8 @@ public class ControlEngine {
 			}
 			
 			if (
-				event.getKeyMapping() == controlEngine.minecraft.options.keyUse &&
-				event.getKeyMapping().getKey().equals(EpicFightKeyMappings.GUARD.getKey())
+                triggeredAction == EpicFightInputActions.USE &&
+                InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.USE, EpicFightInputActions.GUARD)
 			) {
 				MutableBoolean canGuard = new MutableBoolean();
 				

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -77,6 +77,8 @@ import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings.ViewLimit;
 import yesman.epicfight.api.client.forgeevent.PatchedRenderersEvent;
 import yesman.epicfight.api.client.forgeevent.RenderEnderDragonEvent;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
@@ -691,7 +693,7 @@ public class RenderEngine {
 					CapabilityItem cap = EpicFightCapabilities.getItemStackCapabilityOr(event.getItemStack(), null);
 					
 					if (cap != null) {
-						if (ControlEngine.isKeyDown(EpicFightKeyMappings.WEAPON_INNATE_SKILL_TOOLTIP)) {
+						if (InputManager.isActionActive(EpicFightInputActions.WEAPON_INNATE_SKILL_TOOLTIP)) {
 							Skill weaponInnateSkill = cap.getInnateSkill(playerpatch, event.getItemStack());
 
 							if (weaponInnateSkill != null) {

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
@@ -43,9 +43,10 @@ import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings;
 import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings.ViewLimit;
 import yesman.epicfight.api.client.animation.Layer;
 import yesman.epicfight.api.client.animation.property.ClientAnimationProperties;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.client.ClientEngine;
-import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.gameasset.Animations;
@@ -364,7 +365,7 @@ public class LocalPlayerPatch extends AbstractClientPlayerPatch<LocalPlayer> {
 	
 	@Override
 	public boolean shouldBlockMoving() {
-		return ControlEngine.isKeyDown(this.minecraft.options.keyDown) || ControlEngine.isKeyDown(this.minecraft.options.keyShift);
+		return InputManager.isActionActive(EpicFightInputActions.MOVE_BACKWARD) || InputManager.isActionActive(EpicFightInputActions.SNEAK);
 	}
 	
 	@Override

--- a/src/main/java/yesman/epicfight/compat/ShoulderSurfingCompat.java
+++ b/src/main/java/yesman/epicfight/compat/ShoulderSurfingCompat.java
@@ -6,9 +6,9 @@ import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistra
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.client.ClientEngine;
-import yesman.epicfight.client.events.engine.ControlEngine;
-import yesman.epicfight.client.input.EpicFightKeyMappings;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
 /**
@@ -52,7 +52,7 @@ public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
     private static class ForceCameraCouplingWhenAttackingCallback implements ICameraCouplingCallback {
         @Override
         public boolean isForcingCameraCoupling(Minecraft minecraft) {
-            return ControlEngine.isKeyDown(EpicFightKeyMappings.ATTACK) || minecraft.options.keyAttack.isDown();
+            return InputManager.isActionActive(EpicFightInputActions.ATTACK) || InputManager.isActionActive(EpicFightInputActions.VANILLA_ATTACK_DESTROY);
         }
     }
 

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -38,6 +38,8 @@ import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.SynchedAnimationVariableKeys;
 import yesman.epicfight.api.client.animation.property.JointMaskReloadListener;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.model.ItemSkinsReloadListener;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.data.reloader.ItemCapabilityReloadListener;
@@ -218,6 +220,7 @@ public class EpicFightMod {
     	WeaponCategory.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, WeaponCategories.class);
     	Faction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, Factions.class);
     	EntityPairingPacketType.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EntityPairingPacketTypes.class);
+    	InputAction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EpicFightInputActions.class);
     	
     	EpicFightMobEffects.EFFECTS.register(bus);
     	EpicFightPotions.POTIONS.register(bus);

--- a/src/main/java/yesman/epicfight/mixin/client/MixinClientPacketListener.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinClientPacketListener.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.client;
 
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -8,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.protocol.game.ClientboundRespawnPacket;
 import yesman.epicfight.client.events.ClientEvents;
+import yesman.epicfight.client.events.engine.ControlEngine;
 
 @Mixin(value = ClientPacketListener.class)
 public abstract class MixinClientPacketListener {
@@ -15,4 +18,18 @@ public abstract class MixinClientPacketListener {
 	private void epicfight_handleRespawn(ClientboundRespawnPacket clientboundRespawnPacket, CallbackInfo info) {
 		ClientEvents.packet = clientboundRespawnPacket;
 	}
+
+    @Inject(
+            method = "send(Lnet/minecraft/network/protocol/Packet;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onBeforeSendPacket(Packet<?> packet, CallbackInfo ci) {
+        final boolean isSwapItemWithOffhand = packet instanceof ServerboundPlayerActionPacket actionPacket &&
+                actionPacket.getAction() == ServerboundPlayerActionPacket.Action.SWAP_ITEM_WITH_OFFHAND; 
+        if (isSwapItemWithOffhand && ControlEngine.shouldDisableSwapHandItems()) {
+            // Disables the swap offhand items while in action (e.g., attacking in Epic Fight mode).
+            ci.cancel();
+        }
+    }
 }

--- a/src/main/java/yesman/epicfight/mixin/client/MixinInventory.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinInventory.java
@@ -1,0 +1,32 @@
+package yesman.epicfight.mixin.client;
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.client.events.engine.ControlEngine;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin(Inventory.class)
+public class MixinInventory {
+    @Inject(
+            // Note for maintainers: when porting to 1.21.2 or newer, target setSelectedHotbarSlot instead.
+            // Some adjustments may be required. Please see: https://github.com/isXander/Controlify/blob/e90c94a9dfe45bc071e4ad01c4db039a0dd2492d/src/main/java/dev/isxander/controlify/ingame/InGameInputHandler.java#L96-L102
+            // And test with Controlify to avoid regressions. Remove this comment as well.
+            method = "swapPaint",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onCycleHotbarSlot(double direction, CallbackInfo ci) {
+        // Called whenever the player changes their selected hotbar item via the mouse wheel or other input systems.
+        if (ControlEngine.isHotbarCyclingDisabled()) {
+            // InputEvent.MouseScrollingEvent is already cancelled in ControlEngine.Events#mouseScrollEvent to block hotbar cycling for mouse input.
+            // Controller inputs are unaffected, so we also cancel it here to enforce the restriction
+            // for all input methods.
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/yesman/epicfight/mixin/client/MixinMinecraft.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinMinecraft.java
@@ -11,6 +11,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.Entity;
 import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 
@@ -33,4 +34,20 @@ public class MixinMinecraft {
 			}
 		});
 	}
+
+    @Inject(at = @At("HEAD"), method = "startAttack", cancellable = true)
+    private void onStartVanillaAttack(CallbackInfoReturnable<Boolean> cir) {
+        if (ControlEngine.shouldDisableVanillaAttack()) {
+            // Prevents the player from performing vanilla attack actions while in Epic Fight mode.
+            cir.cancel();
+        }
+    }
+
+    @Inject(at = @At("HEAD"), method = "continueAttack", cancellable = true)
+    private void onContinueVanillaAttack(boolean leftClick, CallbackInfo ci) {
+        if (ControlEngine.shouldDisableVanillaAttack()) {
+            // Prevents the player from breaking blocks such as grass while in Epic Fight mode.
+            ci.cancel();
+        }
+    }
 }

--- a/src/main/java/yesman/epicfight/skill/dodge/DodgeSkill.java
+++ b/src/main/java/yesman/epicfight/skill/dodge/DodgeSkill.java
@@ -3,7 +3,7 @@ package yesman.epicfight.skill.dodge;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.Input;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
@@ -13,6 +13,9 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.types.EntityState;
 import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.client.input.MovementDirection;
+import yesman.epicfight.api.client.input.handlers.InputManager;
+import yesman.epicfight.api.client.input.utils.InputUtils;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.network.client.CPSkillRequest;
 import yesman.epicfight.skill.Skill;
@@ -49,16 +52,13 @@ public class DodgeSkill extends Skill {
 	@Override
 	public Object getExecutionPacket(SkillContainer skillContainer, FriendlyByteBuf args) {
 		LocalPlayerPatch executor = skillContainer.getClientExecutor();
-		Input input = executor.getOriginal().input;
+		LocalPlayer localPlayer = executor.getOriginal();
 		float pulse = Mth.clamp(0.3F + EnchantmentHelper.getSneakingSpeedBonus(executor.getOriginal()), 0.0F, 1.0F);
-		input.tick(false, pulse);
+        InputUtils.sneakingTick(localPlayer, false, pulse);
 		
-        int forward = input.up ? 1 : 0;
-        int backward = input.down ? -1 : 0;
-        int left = input.left ? 1 : 0;
-        int right = input.right ? -1 : 0;
-		int vertic = forward + backward;
-		int horizon = left + right;
+        final MovementDirection movementDirection = MovementDirection.fromInputState(InputManager.getInputState(localPlayer.input));
+		final int vertic = movementDirection.vertical();
+		final int horizon = movementDirection.horizontal();
 		float yRot = Minecraft.getInstance().gameRenderer.getMainCamera().getYRot();
 		float degree = Mth.wrapDegrees(-(90 * horizon * (1 - Math.abs(vertic)) + 45 * vertic * horizon) + yRot);
 		

--- a/src/main/java/yesman/epicfight/skill/dodge/KnockdownWakeupSkill.java
+++ b/src/main/java/yesman/epicfight/skill/dodge/KnockdownWakeupSkill.java
@@ -1,13 +1,16 @@
 package yesman.epicfight.skill.dodge;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.Input;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.types.EntityState;
+import yesman.epicfight.api.client.input.MovementDirection;
+import yesman.epicfight.api.client.input.handlers.InputManager;
+import yesman.epicfight.api.client.input.utils.InputUtils;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.network.client.CPSkillRequest;
 import yesman.epicfight.skill.SkillContainer;
@@ -22,14 +25,13 @@ public class KnockdownWakeupSkill extends DodgeSkill {
 	@Override
 	public Object getExecutionPacket(SkillContainer skillContainer, FriendlyByteBuf args) {
 		LocalPlayerPatch executor = skillContainer.getClientExecutor();
-		Input input = executor.getOriginal().input;
+        LocalPlayer localPlayer = executor.getOriginal();
 		float pulse = Mth.clamp(0.3F + EnchantmentHelper.getSneakingSpeedBonus(executor.getOriginal()), 0.0F, 1.0F);
-		input.tick(false, pulse);
-		
-        int left = input.left ? 1 : 0;
-        int right = input.right ? -1 : 0;
-		int horizon = left + right;
-		float yRot = Minecraft.getInstance().gameRenderer.getMainCamera().getYRot();
+		InputUtils.sneakingTick(localPlayer, false, pulse);
+
+        final MovementDirection movementDirection = MovementDirection.fromInputState(InputManager.getInputState(localPlayer.input));
+        final int horizon = movementDirection.horizontal();
+        final float yRot = Minecraft.getInstance().gameRenderer.getMainCamera().getYRot();
 		
 		CPSkillRequest packet = new CPSkillRequest(skillContainer.getSlot());
 		packet.getBuffer().writeInt(horizon >= 0 ? 0 : 1);

--- a/src/main/java/yesman/epicfight/skill/guard/GuardSkill.java
+++ b/src/main/java/yesman/epicfight/skill/guard/GuardSkill.java
@@ -11,7 +11,6 @@ import com.google.common.collect.Maps;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -30,6 +29,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.AttackResult;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.gui.BattleModeGui;
@@ -140,10 +141,13 @@ public class GuardSkill extends Skill implements HoldableSkill {
 			if (container.isActivated() && event.getPlayerPatch().getHoldingSkill() == this) {
 				event.getPlayerPatch().getOriginal().setSprinting(false);
 				event.getPlayerPatch().getOriginal().sprintTriggerTime = -1;
-				
-				ControlEngine.setKeyBind(Minecraft.getInstance().options.keySprint, false);
-				event.getMovementInput().forwardImpulse *= 0.5f;
-				event.getMovementInput().leftImpulse *= 0.5f;
+
+                ControlEngine.setSprintingKeyStateNotDown();
+                final PlayerInputState current = event.getInputState();
+                final PlayerInputState updated = current
+                        .withForwardImpulse(current.forwardImpulse() * 0.5f)
+                        .withLeftImpulse(current.leftImpulse() * 0.5f);
+                InputManager.setInputState(updated);
 			}
 		});
 		

--- a/src/main/java/yesman/epicfight/skill/modules/HoldableSkill.java
+++ b/src/main/java/yesman/epicfight/skill/modules/HoldableSkill.java
@@ -4,6 +4,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.network.server.SPSkillExecutionFeedback;
 import yesman.epicfight.skill.Skill;
@@ -46,8 +47,21 @@ public interface HoldableSkill {
     
     /**
      * Retrieves the keybind of this skill.
-     * @return Class: {@link KeyMapping} the key mapping that the skill is mapped to.
+     * <p>
+     * If the returned {@link KeyMapping} corresponds to an action defined in
+     * {@link yesman.epicfight.api.client.input.action.EpicFightInputActions#keyMapping()},
+     * controller input will be supported as well. Otherwise, the skill will only
+     * support keyboard and mouse input. This is related to the workaround implemented in the internal
+     * {@link ControlEngine#mapKeyMappingToAction}.
+     * <p>
+     * In future updates, this method may be deprecated in favor of returning
+     * {@link yesman.epicfight.api.client.input.action.EpicFightInputActions}
+     * (OR {@link yesman.epicfight.api.client.input.action.InputAction}) directly,
+     * eliminating the need for {@link ControlEngine#mapKeyMappingToAction} to support controllers.
+     * @see yesman.epicfight.api.client.input.action.EpicFightInputActions
+     * @see ControlEngine#mapKeyMappingToAction
      */
+    @SuppressWarnings({"JavadocReference", "deprecation"})
     @OnlyIn(Dist.CLIENT)
     KeyMapping getKeyMapping();
 }

--- a/src/main/java/yesman/epicfight/skill/mover/DemolitionLeapSkill.java
+++ b/src/main/java/yesman/epicfight/skill/mover/DemolitionLeapSkill.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.LevelUtil;
 import yesman.epicfight.api.utils.math.ValueModifier;
 import yesman.epicfight.api.utils.math.Vec3f;
@@ -49,7 +50,7 @@ public class DemolitionLeapSkill extends Skill implements ChargeableSkill {
 		
 		listener.addEventListener(EventType.MOVEMENT_INPUT_EVENT, EVENT_UUID, (event) -> {
 			if (event.getPlayerPatch().isHoldingSkill(this)) {
-				event.getMovementInput().jumping = false;
+                InputManager.setInputState(event.getInputState().withJumping(false));
 			}
 		});
 

--- a/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
+++ b/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.Input;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.util.Mth;
@@ -17,6 +15,9 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.client.input.MovementDirection;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.ValueModifier;
 import yesman.epicfight.api.utils.math.Vec3f;
@@ -63,8 +64,8 @@ public class PhantomAscentSkill extends Skill {
 				return;
 			}
 			
-			// Check directly from the keybind because event.getMovementInput().isJumping doesn't allow to be set as true while player's jumping
-			boolean jumpPressed = Minecraft.getInstance().options.keyJump.isDown();
+			// Check directly from the input bind because event.getMovementInput().isJumping doesn't allow to be set as true while player's jumping
+            boolean jumpPressed = isJumpActionPressed();
 			boolean jumpPressedPrev = container.getDataManager().getDataValue(SkillDataKeys.JUMP_KEY_PRESSED_LAST_TICK.get());
 			
 			if (jumpPressed && !jumpPressedPrev) {
@@ -93,16 +94,16 @@ public class PhantomAscentSkill extends Skill {
 						
 						container.getDataManager().setDataSync(SkillDataKeys.PROTECT_NEXT_FALL.get(), true);
 						
-						Input input = event.getMovementInput();
 						float f = Mth.clamp(0.3F + EnchantmentHelper.getSneakingSpeedBonus(container.getExecutor().getOriginal()), 0.0F, 1.0F);
-						input.tick(false, f);
-						
-				        int forward = event.getMovementInput().up ? 1 : 0;
-				        int backward = event.getMovementInput().down ? -1 : 0;
-				        int left = event.getMovementInput().left ? 1 : 0;
-				        int right = event.getMovementInput().right ? -1 : 0;
-						int vertic = forward + backward;
-						int horizon = left + right;
+                        event.sneakingTick(false, f);
+
+                        final MovementDirection movementDirection = MovementDirection.fromInputState(event.getInputState());
+                        final int forward = movementDirection.forward();
+                        final int backward = movementDirection.backward();
+                        final int left = movementDirection.left();
+                        final int right = movementDirection.right();
+                        final int vertic = movementDirection.vertical();
+                        final int horizon = movementDirection.horizontal();
 						int degree = -(90 * horizon * (1 - Math.abs(vertic)) + 45 * vertic * horizon);
 						int scale = forward == 0 && backward == 0 && left == 0 && right == 0 ? 0 : (vertic < 0 ? -1 : 1);
 						Vec3 forwardHorizontal = Vec3.directionFromRotation(new Vec2(0, container.getExecutor().getOriginal().getViewYRot(1.0F)));
@@ -163,4 +164,8 @@ public class PhantomAscentSkill extends Skill {
 		
 		return list;
 	}
+
+    private static boolean isJumpActionPressed() {
+        return InputManager.isActionActive(EpicFightInputActions.JUMP);
+    }
 }

--- a/src/main/java/yesman/epicfight/skill/weaponinnate/LiechtenauerSkill.java
+++ b/src/main/java/yesman/epicfight/skill/weaponinnate/LiechtenauerSkill.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import com.google.common.collect.Lists;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -109,7 +108,7 @@ public class LiechtenauerSkill extends WeaponInnateSkill {
 				LocalPlayer clientPlayer = event.getPlayerPatch().getOriginal();
 				clientPlayer.setSprinting(false);
 				clientPlayer.sprintTriggerTime = -1;
-				ControlEngine.setKeyBind(Minecraft.getInstance().options.keySprint, false);
+                ControlEngine.setSprintingKeyStateNotDown();
 			}
 		});
 	}

--- a/src/main/java/yesman/epicfight/skill/weaponinnate/SteelWhirlwindSkill.java
+++ b/src/main/java/yesman/epicfight/skill/weaponinnate/SteelWhirlwindSkill.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -14,6 +13,8 @@ import yesman.epicfight.api.animation.types.AttackAnimation;
 import yesman.epicfight.api.animation.types.AttackAnimation.Phase;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.asset.AssetAccessor;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
 import yesman.epicfight.gameasset.Animations;
@@ -48,10 +49,12 @@ public class SteelWhirlwindSkill extends WeaponInnateSkill implements Chargeable
 				LocalPlayer clientPlayer = event.getPlayerPatch().getOriginal();
 				clientPlayer.setSprinting(false);
 				clientPlayer.sprintTriggerTime = -1;
-				Minecraft mc = Minecraft.getInstance();
-				ControlEngine.setKeyBind(mc.options.keySprint, false);
-				
-				event.getMovementInput().forwardImpulse *= 1.0F - 0.8F * event.getPlayerPatch().getSkillChargingTicks() / 30.0F;
+                ControlEngine.setSprintingKeyStateNotDown();
+
+                final PlayerInputState current = event.getInputState();
+                final PlayerInputState updated = current
+                        .withForwardImpulse(current.forwardImpulse() * (1.0F - 0.8F * event.getPlayerPatch().getSkillChargingTicks() / 30.0F));
+                InputManager.setInputState(updated);
 			}
 		});
 	}

--- a/src/main/java/yesman/epicfight/world/entity/eventlistener/MovementInputEvent.java
+++ b/src/main/java/yesman/epicfight/world/entity/eventlistener/MovementInputEvent.java
@@ -1,17 +1,108 @@
 package yesman.epicfight.world.entity.eventlistener;
 
 import net.minecraft.client.player.Input;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.handlers.InputManager;
+import yesman.epicfight.api.client.input.utils.InputUtils;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
 public class MovementInputEvent extends AbstractPlayerEvent<LocalPlayerPatch> {
-	private final Input movementInput;
-	
-	public MovementInputEvent(LocalPlayerPatch playerpatch, Input movementInput) {
-		super(playerpatch, false);
-		this.movementInput = movementInput;
-	}
-	
-	public Input getMovementInput() {
-		return this.movementInput;
-	}
+    /**
+     * <b>DEPRECATED:</b>: This field is kept for backward compatibility with existing Epic Fight addons.
+     * <p>
+     * Consumers should migrate to using {@link #getInputState()} and
+     * {@link InputManager#setInputState} instead, which fully support controller input.
+     * </p>
+     *
+     * @see MovementInputEvent#getInputState
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @NotNull
+    @Deprecated
+    private final Input movementInput;
+
+    // This was set as @Nullable to introduce PlayerInputState in a backward compatible way.
+    // As soon as we introduce a breaking change by removing the existing constructor that sets movementInput, we
+    // should set this to @NotNull.
+    @Nullable
+    private final PlayerInputState inputState;
+
+    /**
+     * <b>DEPRECATED:</b>: Please use the new constructor that accepts {@link PlayerInputState} to support controllers.
+     * <p>
+     * This constructor is only kept for backward compatibility with addons that rely on vanilla {@link Input}.
+     * </p>
+     *
+     * @see InputManager
+     */
+    @Deprecated
+    @ApiStatus.Internal
+    public MovementInputEvent(LocalPlayerPatch playerPatch, @NotNull Input input) {
+        super(playerPatch, false);
+        this.movementInput = input;
+        this.inputState = null;
+    }
+
+    /**
+     * Creates a new {@link MovementInputEvent} with an immutable {@link PlayerInputState}.
+     * <p>
+     * Use this constructor to fully support controllers.
+     * </p>
+     *
+     * @param playerPatch the patched local player
+     * @param inputState  the current input state
+     */
+    @ApiStatus.Internal
+    public MovementInputEvent(LocalPlayerPatch playerPatch, @NotNull PlayerInputState inputState) {
+        super(playerPatch, false);
+        this.inputState = inputState;
+        // DEPRECATED: Still set the vanilla Input for backward compatibility to avoid Epic Fight addons breakage.
+        // Not setting this, may break any consumers that depend on the deprecated MovementInputEvent#getMovementInput() method.
+        this.movementInput = PlayerInputState.applyToVanillaInput(inputState, playerPatch.getOriginal().input);
+    }
+
+    /**
+     * <b>DEPRECATED:</b>: Use {@link #getInputState()} instead to support controllers.
+     * <p>
+     * Note that {@link PlayerInputState} is immutable. You cannot directly modify the fields
+     * like in vanilla {@link Input}. To apply changes, use {@link InputManager#setInputState}.
+     * </p>
+     *
+     * @return the vanilla input instance (deprecated)
+     * @see InputManager#setInputState 
+     */
+    @Deprecated
+    public @NotNull Input getMovementInput() {
+        return this.movementInput;
+    }
+
+    /**
+     * Returns the current input state for the player.
+     * <p>
+     * This method abstracts over vanilla {@link Input} and controller input, providing a unified,
+     * immutable {@link PlayerInputState}.
+     * </p>
+     *
+     * @return the current player input state
+     */
+    @NotNull
+    public PlayerInputState getInputState() {
+        if (inputState == null) {
+            return InputManager.getInputState(movementInput);
+        }
+        return inputState;
+    }
+
+    /**
+     * Currently, this calls {@link Input#tick} without performing any additional logic.
+     * This abstraction was introduced to allow calling it without depending on the vanilla Minecraft {@link Input},
+     * enabling Epic Fight to introduce changes in future updates if necessary to support controllers.
+     */
+    @ApiStatus.Experimental
+    public void sneakingTick(boolean isSneaking, float sneakingSpeedMultiplier) {
+        InputUtils.sneakingTick(isSneaking, sneakingSpeedMultiplier);
+    }
 }

--- a/src/main/resources/mixins.epicfight.json
+++ b/src/main/resources/mixins.epicfight.json
@@ -21,6 +21,7 @@
 		"client.MixinMouseHandler",
 		"client.MixinParticleEngine",
 		"client.MixinThrownTridentRenderer",
+        "client.MixinInventory",
 		"skinlayers.MixinCustomModelPart",
 		"skinlayers.MixinCustomizableCubeWrapper$SkinLayer3DMixinCustomModelCube",
 		"teamlapen.MixinVampirePlayerHeadLayer",


### PR DESCRIPTION
This PR fixes #2116 and aims to simplify and improve controller support; it does not target any specific controller mod at this stage. More PRs are in progress.

Feedback, suggestions, and questions are welcome at any stage.

### Common APIs of the Input Action system

#### Input Actions

```diff
- EpicFightKeyMappings.DODGE; // Raw access to KeyMapping, does not support controllers.
+ EpicFightInputActions.DODGE; // Use raw ".keyMapping()" if really necessary; prefer new supported APIs.
```

#### Discrete (one-time) actions

```diff
- while (isKeyPressed(EpicFightKeyMappings.ATTACK, true)) {
-    // ...
- }
+ InputManager.triggerOnPress(EpicFightInputActions.ATTACK, true, (context) -> {
+      boolean triggeredByController = context.triggeredByController() // Optional context
+     // ...
+ });
```

#### Continuous actions

```diff
- if (minecraft.options.keyAttack.isDown()) {}
+ if (InputManager.isActionActive(EpicFightInputActions.VANILLA_ATTACK_DESTROY)) {}
```

#### Player Movement Input

##### Direction

```diff
- int forward = input.up ? 1 : 0;
- int backward = input.down ? -1 : 0;
- int left = input.left ? 1 : 0;
- int right = input.right ? -1 : 0;
- int vertic = forward + backward;
- int horizon = left + right;
+ final MovementDirection movementDirection = MovementDirection.fromInputState(InputManager.getInputState(input));
+ final int vertic = movementDirection.vertical();
+ final int horizon = movementDirection.horizontal();
```

##### Updating state

```diff
- Minecraft.getInstance().player.input.jumping = true; // Bad: Mutable, unpredictable, and may not support controllers
+ final PlayerInputState updated = InputManager.getInputState(Minecraft.getInstance().player)
+        .withJumping(true);
+ InputManager.setInputState(updated);
```

#### Checking if bound to the same physical button/key

```diff
- if (EpicFightKeyMappings.WEAPON_INNATE_SKILL.getKey().equals(EpicFightKeyMappings.ATTACK.getKey())) {}
+ if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.WEAPON_INNATE_SKILL, EpicFightInputActions.ATTACK)) {}
```

#### Integrating a controller mod

```java
// Controlify mod is used as an example here.
final class ControlifyModIntegration implements IEpicFightControllerMod {
    // Implement the required methods...
}
```

Then register it:

```java
EpicFightControllerModProvider.set(EpicFightMod.MODID, new ControlifyModIntegration());
```

#### Low-level Controller access

```java
IEpicFightControllerMod controllerModApi = EpicFightControllerModProvider.get();

if (controllerModApi == null {
    // Null if no controller mod integration is available
   // (e.g., the controller mod is not installed, or Epic Fight does not support it).
    return;
}

// Checking the input mode

InputMode inputMode = controllerModApi.getInputMode();
boolean supportsController = inputMode.supportsController();

// Getting raw controller binding

ControllerBinding moveForward = controllerModApi.getBinding(EpicFightInputActions.MOVE_FORWARD);
float analogue = moveForward.getAnalogueNow();

// OR

ControllerBinding jump = controllerModApi.getBinding(EpicFightInputActions.JUMP);
boolean justPressed = jump.isDigitalJustPressed();

```

### Additional Cleanup Checklist

- [x] `ControlEngine.handleEpicFightKeyMappings` currently mixes **when** an action should be triggered with **how** it is executed. To simplify future improvements and integration with the new input system, the **when** logic—including the conditional checks and associated `while`/`if` statements—should be extracted into separate functions.  
- [x] `ControlEngine.handleEpicFightKeyMappings` is long and not modular. Consider breaking it into smaller, focused methods (e.g., `handleAttackKey()`, `handleDodgeKey()`, `handleGuardKey()`) to improve readability, and maintainability.

### Very Minor issues

These are existing issues when using a controller mod with Epic Fight. These should be tested and fixed with Controlify on NeoForge 1.21.1:

- [x] Player should not be able to switch or drop the current selected item when Epic Fight locks the hotbar.
- [ ] Should not be able to place Epic Fight greatswords or any incompatible weapon types in the offhand slot within the inventory GUI.

These issues don't affect the player experience significantly. Most players will not notice them.

### Changelog

We should add a note to the changelog of the new version if it includes these changes:

```md
**Important:** If you're a mod developer modifying Epic Fight’s `ControlEngine` using a mixin, please test your changes against the latest version to avoid breaking Epic Fight internals or your add-on’s behavior.
You may see some **deprecations** — please consider **migrating** to support controllers in future updates.
For more details, refer to [PR #2122](https://github.com/Epic-Fight/epicfight/pull/2122).
```

### Testing

Verified using manual testing against many Epic Fight addons:

https://github.com/user-attachments/assets/cb24f9a1-74d6-43ef-9286-33256cbaf2bd


