### PR TITLE
Remove an outdated TODO + Minor cleanup

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/ClientEvents.java
+++ b/src/main/java/yesman/epicfight/client/events/ClientEvents.java
@@ -76,7 +76,7 @@ public class ClientEvents {
 	public static void presssKeyInGui(ScreenEvent.KeyPressed.Pre event) {
 		CapabilityItem itemCapability = CapabilityItem.EMPTY;
 
-        // TODO: (INPUT_SYSTEM_REFACTOR) This only disables swaping off hand item for key inputs.
+        // TODO: (INPUT_SYSTEM_REFACTOR) This only disables putting the item to offhand inventory slot for key inputs (defaults to F).
         //  Explore a universal solution that also supports controllers and other input systems.
 		if (event.getKeyCode() == MINECRAFT.options.keySwapOffhand.getKey().getValue()) {
 			if (event.getScreen() instanceof AbstractContainerScreen) {

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -525,12 +525,7 @@ public class ControlEngine {
 	public void lockHotkeys() {
 		this.hotbarLocked = true;
 		this.lastHotbarLockedTime = this.player.tickCount;
-
-		for (int i = 0; i < 9; ++i) {
-            // TODO: (INPUT_SYSTEM_REFACTOR) This only works for key inputs (the usage of keyHotbarSlots).
-            //  Explore a universal solution that also supports controllers and other input systems.
-			while (this.options.keyHotbarSlots[i].consumeClick());
-		}
+        consumeHotbarSlotKeyClicks();
 	}
 	
 	public void unlockHotkeys() {

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -292,7 +292,7 @@ public class ControlEngine {
 		}
 
 		if (isSwitchOrDropBlocked()) {
-			consumeHotbarSlotKeyClicks();
+			disableHotbarSlotPresses();
 			consumeDropKeyClicks();
 		}
 	}
@@ -525,7 +525,7 @@ public class ControlEngine {
 	public void lockHotkeys() {
 		this.hotbarLocked = true;
 		this.lastHotbarLockedTime = this.player.tickCount;
-        consumeHotbarSlotKeyClicks();
+        disableHotbarSlotPresses();
 	}
 	
 	public void unlockHotkeys() {
@@ -746,7 +746,7 @@ public class ControlEngine {
     }
 
     /**
-     * Consumes hotbar slot key presses (keyboard only).
+     * Disables hotbar slot key presses (keyboard only).
      * <p>
      * This feature is strictly for keyboards and will not support controllers,
      * as controllers have limited buttons. Keyboard users can switch slots via
@@ -755,7 +755,7 @@ public class ControlEngine {
      *
      * @see ControlEngine#isHotbarCyclingDisabled
      */
-    private static void consumeHotbarSlotKeyClicks() {
+    private static void disableHotbarSlotPresses() {
         final KeyMapping[] hotbarSlots = Minecraft.getInstance().options.keyHotbarSlots;
         for (int i = 0; i < 9; ++i) {
             final KeyMapping hotbarSlot = hotbarSlots[i];


### PR DESCRIPTION
This does not fix any gameplay issues, just discovered that there is an outdated TODO that I already fixed, and also renamed the function `consumeHotbarSlotKeyClicks` to `disableHotbarSlotPresses`, to avoid confusion, since this one is special and does not follow the same pattern as the others, it actually do something that is keyboard-specific, unlike `consumeDropKeyClicks`, for example, which only resets the vanilla internal counter state.

This allows others and future me to read the code without any confusion. Optionally, it removes code duplication by calling an existing method.