### PR TITLE
[NeoForge 1.21.1] Controlify integration for controller support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ repositories {
             includeGroup "dev.latvian.mods"
         }
     }
+
+    // TODO: Use Controlify from Modrinth maven once this PR is published: https://github.com/isXander/Controlify/pull/689
+    //  and then remove this temporary Maven.
+    exclusiveContent {
+        forRepository { maven { url "https://echoellet.github.io/Controlify/" } }
+        filter { includeGroup "dev.echoellet" }
+    }
 }
 
 base {
@@ -156,6 +163,9 @@ dependencies {
 
     compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993797" // API only (https://www.curseforge.com/minecraft/mc-mods/shoulder-surfing-reloaded/files/6993792)
     //compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993795" // Actual mod file (for test)
+
+    // Change "compileOnly" to "implementation" for testing in-game.
+    compileOnly "dev.echoellet:controlify:2.4.2-1.21.1-neoforge"
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
@@ -8,9 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a default set of input actions used in the Epic Fight mod.
@@ -135,5 +133,20 @@ public enum EpicFightInputActions implements InputAction {
      */
     public static @Nullable EpicFightInputActions fromKeyMapping(@NotNull KeyMapping keyMapping) {
         return BY_KEY_MAPPING.get(keyMapping);
+    }
+
+    /**
+     * Returns a set of all Epic Fight actions that are not part of the vanilla
+     * Minecraft key mappings.
+     *
+     * @return a set containing all non-vanilla {@link EpicFightInputActions}
+     * @see EpicFightInputActions#isVanilla
+     */
+    public static @NotNull Set<EpicFightInputActions> nonVanillaActions() {
+        Set<EpicFightInputActions> result = EnumSet.noneOf(EpicFightInputActions.class);
+        for (EpicFightInputActions action : EpicFightInputActions.values()) {
+            if (!action.isVanilla()) result.add(action);
+        }
+        return result;
     }
 }

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -734,7 +734,7 @@ public class ControlEngine implements IEventBasedEngine {
     /**
      * Previously used to temporarily disable the vanilla swap-offhand key while the player
      * was performing an action or attacking, but this is now handled by
-     * {@link yesman.epicfight.mixin.client.MixinClientPacketListener#onBeforeSendPacket}.
+     * {@link yesman.epicfight.mixin.client.MixinClientCommonPacketListenerImpl#onBeforeSendPacket}.
      * <p>
      * This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
      * to prevent potential conflicts with other mods. It serves as a safety measure;

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.gui.components.*;
 import org.joml.Matrix4f;
 
 import com.google.common.collect.Lists;
@@ -18,13 +19,6 @@ import com.mojang.blaze3d.vertex.VertexSorting;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.ContainerObjectSelectionList;
-import net.minecraft.client.gui.components.ObjectSelectionList;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.components.Tooltip;
-import net.minecraft.client.gui.components.WidgetSprites;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
@@ -116,6 +110,7 @@ public class SkillBookScreen extends Screen {
 	protected final AttributeIconList providingAttributesList;
 	protected final InteractionHand hand;
 	private double customScale;
+    public AbstractButton learnButton;
 	
 	public SkillBookScreen(Player opener, ItemStack stack, @Nullable InteractionHand hand) {
 		this(opener, SkillBookItem.getContainSkill(stack).get().value(), hand, null);
@@ -217,7 +212,7 @@ public class SkillBookScreen extends Screen {
 			this.customScale = window.getGuiScale();
 		}
 		
-		Button learnButton =
+		learnButton =
 			Button.builder(
 				Component.translatable(EpicFightMod.format("gui.%s") + (isUsing ? ".applied" : meetsCondition ? ".learn" : ".unusable")),
 				button -> {

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -1,0 +1,510 @@
+package yesman.epicfight.compat.controlify;
+
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.ControlifyBindApi;
+import dev.isxander.controlify.api.bind.InputBinding;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
+import dev.isxander.controlify.api.entrypoint.InitContext;
+import dev.isxander.controlify.api.entrypoint.PreInitContext;
+import dev.isxander.controlify.api.event.ControlifyEvents;
+import dev.isxander.controlify.api.guide.*;
+import dev.isxander.controlify.bindings.BindContext;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.bindings.RadialIcons;
+import dev.isxander.controlify.bindings.input.Input;
+import dev.isxander.controlify.controller.ControllerEntity;
+import dev.isxander.controlify.screenop.ScreenProcessor;
+import dev.isxander.controlify.screenop.compat.vanilla.AbstractButtonComponentProcessor;
+import dev.isxander.controlify.utils.render.Blit;
+import dev.isxander.controlify.utils.render.CGuiPose;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.api.client.input.InputMode;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
+import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.gui.screen.SkillEditScreen;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+import yesman.epicfight.main.EpicFightMod;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+// Important for maintainers: Be careful when using Epic Fight classes here,
+// as the Epic Fight mod might not be loaded yet. For example, avoid referencing
+// EpicFightItems.UCHIGATANA.get() in onControlifyPreInit.
+@ApiStatus.Internal
+public class ControlifyCompat implements ControlifyEntrypoint {
+    @Override
+    public void onControllersDiscovered(ControlifyApi controlify) {
+    }
+
+    @Override
+    public void onControlifyInit(InitContext context) {
+        // It's best to call this method in onControlifyInit,
+        // ensuring that Epic Fight can use Controlify input bindings
+        // only after they have been registered.
+        registerModIntegration();
+    }
+
+    @Override
+    public void onControlifyPreInit(PreInitContext context) {
+        final ControlifyBindApi registrar = ControlifyBindApi.get();
+        registerCustomRadialIcons();
+        registrar.registerBindContext(COMBAT_MODE_CONTEXT);
+        registerInputBindings(registrar);
+        registerTargetLockOnSupport();
+        registerInGameGuides(context.guideRegistries().inGame());
+        registerScreenProcessors();
+    }
+
+    private static InputBindingSupplier attack;
+    private static InputBindingSupplier mobility;
+    private static InputBindingSupplier guard;
+    private static InputBindingSupplier dodge;
+    private static InputBindingSupplier lockOn;
+    private static InputBindingSupplier switchMode;
+    private static InputBindingSupplier weaponInnateSkill;
+    private static InputBindingSupplier weaponInnateSkillTooltip;
+    private static InputBindingSupplier openSkillEditorScreen;
+    private static InputBindingSupplier openConfigScreen;
+    private static InputBindingSupplier switchVanillaModeDebugging;
+
+    private static final BindContext COMBAT_MODE_CONTEXT = new BindContext(
+            EpicFightMod.rl("epicfight_combat"),
+            mc -> {
+                final boolean isInGame = mc.screen == null && mc.level != null && mc.player != null;
+                return isInGame && ClientEngine.getInstance().isEpicFightMode();
+            }
+    );
+    private static final BindContext IN_GAME_CONTEXT = BindContext.IN_GAME;
+    private static final BindContext ANY_SCREEN_CONTEXT = BindContext.ANY_SCREEN;
+
+    private static class ComponentConstants {
+        private static final Component KEY_COMBAT = Component.translatable("key.epicfight.combat");
+        private static final Component KEY_GUI = Component.translatable("key.epicfight.gui");
+        private static final Component KEY_SYSTEM = Component.translatable("key.epicfight.system");
+
+        // Titles
+
+        private static final Component WEAPON_INNATE_SKILL_TOOLTIP = Component.translatable("key.epicfight.show_tooltip");
+        private static final Component KEY_SWITCH_MODE = Component.translatable("key.epicfight.switch_mode");
+        private static final Component KEY_ATTACK = Component.translatable("key.epicfight.attack");
+        private static final Component KEY_WEAPON_INNATE_SKILL = Component.translatable("key.epicfight.weapon_innate_skill");
+        private static final Component KEY_SKILL_GUI = Component.translatable("key.epicfight.skill_gui");
+        private static final Component KEY_DODGE = Component.translatable("key.epicfight.dodge");
+        private static final Component KEY_GUARD = Component.translatable("key.epicfight.guard");
+        private static final Component KEY_LOCK_ON = Component.translatable("key.epicfight.lock_on");
+        private static final Component KEY_MOVER_SKILL = Component.translatable("key.epicfight.mover_skill");
+        private static final Component KEY_CONFIG = Component.translatable("key.epicfight.config");
+        private static final Component KEY_SWITCH_VANILLA_MODEL_DEBUG = Component.translatable("key.epicfight.switch_vanilla_model_debug");
+
+        // Descriptions
+
+        private static final Component WEAPON_INNATE_SKILL_TOOLTIP_DESCRIPTION = Component.translatable("key.epicfight.show_tooltip.description");
+        private static final Component KEY_SWITCH_MODE_DESCRIPTION = Component.translatable("key.epicfight.switch_mode.description");
+        private static final Component KEY_ATTACK_DESCRIPTION = Component.translatable("key.epicfight.attack.description");
+        private static final Component KEY_WEAPON_INNATE_SKILL_DESCRIPTION = Component.translatable("key.epicfight.weapon_innate_skill.description");
+        private static final Component KEY_SKILL_GUI_DESCRIPTION = Component.translatable("key.epicfight.skill_gui.description");
+        private static final Component KEY_DODGE_DESCRIPTION = Component.translatable("key.epicfight.dodge.description");
+        private static final Component KEY_GUARD_DESCRIPTION = Component.translatable("key.epicfight.guard.description");
+        private static final Component KEY_LOCK_ON_DESCRIPTION = Component.translatable("key.epicfight.lock_on.description");
+        private static final Component KEY_MOVER_SKILL_DESCRIPTION = Component.translatable("key.epicfight.mover_skill.description");
+        private static final Component KEY_CONFIG_DESCRIPTION = Component.translatable("key.epicfight.config.description");
+        private static final Component KEY_SWITCH_VANILLA_MODEL_DEBUG_DESCRIPTION = Component.translatable("key.epicfight.switch_vanilla_model_debug.description");
+    }
+
+    private enum EpicFightRadialIcons {
+        UCHIGATANA(EpicFightMod.rl("textures/item/uchigatana_gui.png")),
+        SKILL_BOOK(EpicFightMod.rl("textures/item/skillbook.png"));
+
+        private final @NotNull ResourceLocation id;
+
+        EpicFightRadialIcons(@NotNull ResourceLocation id) {
+            this.id = id;
+        }
+
+        public @NotNull ResourceLocation getId() {
+            return id;
+        }
+    }
+
+    private static void registerCustomRadialIcons() {
+        for (EpicFightRadialIcons icon : EpicFightRadialIcons.values()) {
+            final ResourceLocation location = icon.getId();
+            RadialIcons.registerIcon(location, (graphics, x, y, tickDelta) -> {
+                var pose = CGuiPose.ofPush(graphics);
+                pose.translate(x, y);
+                pose.scale(0.5f, 0.5f);
+                Blit.tex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
+                pose.pop();
+            });
+        }
+    }
+
+    private static void registerInputBindings(ControlifyBindApi registrar) {
+        for (EpicFightInputActions action : nonVanillaActions()) {
+            registerInputBinding(registrar, action);
+        }
+    }
+
+    public static Set<EpicFightInputActions> nonVanillaActions() {
+        Set<EpicFightInputActions> result = EnumSet.noneOf(EpicFightInputActions.class);
+        for (EpicFightInputActions action : EpicFightInputActions.values()) {
+            if (!action.isVanilla()) result.add(action);
+        }
+        return result;
+    }
+
+    /**
+     * Registers a non-vanilla input binding with Controlify.
+     * <p>
+     * Must <strong>only</strong> be called for non-vanilla
+     * {@link EpicFightInputActions}. Vanilla actions are already registered
+     * and calling this with one will throw {@link IllegalArgumentException}.
+     * <p>
+     * <strong>Type-safety and exhaustive checking:</strong><br>
+     * Returns an {@link InputBindingSupplier} via a <em>switch expression</em>
+     * over all enum constants. The returned value is a dummy, used only
+     * to satisfy the Java compiler and enforce exhaustive handling. It is
+     * <strong>never used</strong> and has no effect on behavior.
+     *
+     * @param registrar the Controlify API used to register the binding
+     * @param action    the non-vanilla input action to register
+     * @return a dummy {@link InputBindingSupplier} for type-safety only
+     * @throws IllegalArgumentException if called with a vanilla input action
+     */
+    @SuppressWarnings("UnusedReturnValue") // Read Javadocs of this method before removing.
+    private static @NotNull InputBindingSupplier registerInputBinding(
+            @NotNull ControlifyBindApi registrar,
+            @NotNull EpicFightInputActions action
+    ) {
+        final Component combatCategory = ComponentConstants.KEY_COMBAT;
+        final Component guiCategory = ComponentConstants.KEY_GUI;
+        final Component systemCategory = ComponentConstants.KEY_SYSTEM;
+
+
+        // Prevents Controlify from auto-registering this vanilla key mapping,
+        // since Epic Fight already provides native support for it.
+        final KeyMapping keyMappingToDisable = action.keyMapping();
+
+        // Using a switch expression to enforce compile-time exhaustive checking.
+        // The returned value is a dummy and does nothing; its only purpose is to
+        // satisfy the compiler and ensure all enum constants are handled.
+        return switch (action) {
+            case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
+                 MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
+                    "ControlifyCompat#registerInputBinding() must only be called for non-vanilla actions. " +
+                            "This action is vanilla and already registered by Controlify: " + action.name()
+            );
+            case ATTACK -> attack = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("attack"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_ATTACK)
+                            .description(ComponentConstants.KEY_ATTACK_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case MOBILITY -> mobility = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("mobility"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_MOVER_SKILL)
+                            .description(ComponentConstants.KEY_MOVER_SKILL_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case GUARD -> guard = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("guard"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_GUARD)
+                            .description(ComponentConstants.KEY_GUARD_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case DODGE -> dodge = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("dodge"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_DODGE)
+                            .description(ComponentConstants.KEY_DODGE_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case LOCK_ON -> lockOn = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("lock_on"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_LOCK_ON)
+                            .description(ComponentConstants.KEY_LOCK_ON_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case SWITCH_MODE -> switchMode = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("switch_mode"))
+                            .category(systemCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .name(ComponentConstants.KEY_SWITCH_MODE)
+                            .description(ComponentConstants.KEY_SWITCH_MODE_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+                            .radialCandidate(EpicFightRadialIcons.UCHIGATANA.getId())
+            );
+            case WEAPON_INNATE_SKILL -> weaponInnateSkill = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("weapon_innate_skill"))
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+                            .name(ComponentConstants.KEY_WEAPON_INNATE_SKILL)
+                            .description(ComponentConstants.KEY_WEAPON_INNATE_SKILL_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case WEAPON_INNATE_SKILL_TOOLTIP -> weaponInnateSkillTooltip = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("weapon_innate_skill_tooltip"))
+                            .category(guiCategory)
+                            .allowedContexts(ANY_SCREEN_CONTEXT)
+                            .name(ComponentConstants.WEAPON_INNATE_SKILL_TOOLTIP)
+                            .description(ComponentConstants.WEAPON_INNATE_SKILL_TOOLTIP_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+            case OPEN_SKILL_SCREEN -> openSkillEditorScreen = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("open_skill_editor_screen"))
+                            .category(guiCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .name(ComponentConstants.KEY_SKILL_GUI)
+                            .description(ComponentConstants.KEY_SKILL_GUI_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+                            .radialCandidate(EpicFightRadialIcons.SKILL_BOOK.getId())
+            );
+            case OPEN_CONFIG_SCREEN -> openConfigScreen = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("open_config_screen"))
+                            .category(guiCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .name(ComponentConstants.KEY_CONFIG)
+                            .description(ComponentConstants.KEY_CONFIG_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+                            .radialCandidate(RadialIcons.getItem(Items.REDSTONE))
+            );
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging = registrar.registerBinding(
+                    builder -> builder.id(EpicFightMod.rl("switch_vanilla_mode_debugging"))
+                            .category(systemCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .name(ComponentConstants.KEY_SWITCH_VANILLA_MODEL_DEBUG)
+                            .description(ComponentConstants.KEY_SWITCH_VANILLA_MODEL_DEBUG_DESCRIPTION)
+                            .addKeyCorrelation(keyMappingToDisable)
+            );
+        };
+    }
+
+    private static void registerModIntegration() {
+        EpicFightControllerModProvider.set(EpicFightMod.MODID, new ControlifyIntegration());
+    }
+
+    private static void registerTargetLockOnSupport() {
+        ControlifyEvents.LOOK_INPUT_MODIFIER.register(event -> {
+            LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+
+            if (localPlayerPatch != null && localPlayerPatch.isTargetLockedOn()) {
+                // Fixes a minor issue when locking on an enemy.
+                event.lookInput().zero();
+            }
+        });
+    }
+
+    private static void registerInGameGuides(GuideDomainRegistry<InGameCtx> registry) {
+        registry.registerDynamicRule(
+                Rule.builder().binding(dodge)
+                        .where(ActionLocation.RIGHT)
+                        .then(ComponentConstants.KEY_GUARD)
+                        .build()
+        );
+        registry.registerDynamicRule(
+                Rule.builder().binding(lockOn)
+                        .where(ActionLocation.LEFT)
+                        .when(InGameFacts.LOOKING_AT_ENTITY)
+                        .then(ComponentConstants.KEY_LOCK_ON)
+                        .build()
+        );
+    }
+
+    private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputActions action) {
+        final InputBindingSupplier bindingSupplier = switch (action) {
+            case VANILLA_ATTACK_DESTROY -> ControlifyBindings.ATTACK;
+            case USE -> ControlifyBindings.USE;
+            case SWAP_OFF_HAND -> ControlifyBindings.SWAP_HANDS;
+            case DROP -> ControlifyBindings.DROP_INGAME;
+            case TOGGLE_PERSPECTIVE -> ControlifyBindings.CHANGE_PERSPECTIVE;
+            case ATTACK -> attack;
+            case JUMP -> ControlifyBindings.JUMP;
+            case MOBILITY -> mobility;
+            case GUARD -> guard;
+            case DODGE -> dodge;
+            case LOCK_ON -> lockOn;
+            case SWITCH_MODE -> switchMode;
+            case WEAPON_INNATE_SKILL -> weaponInnateSkill;
+            case WEAPON_INNATE_SKILL_TOOLTIP -> weaponInnateSkillTooltip;
+            case MOVE_FORWARD -> ControlifyBindings.WALK_FORWARD;
+            case MOVE_BACKWARD -> ControlifyBindings.WALK_BACKWARD;
+            case MOVE_LEFT -> ControlifyBindings.WALK_LEFT;
+            case MOVE_RIGHT -> ControlifyBindings.WALK_RIGHT;
+            case SPRINT -> ControlifyBindings.SPRINT;
+            case SNEAK -> ControlifyBindings.SNEAK;
+            case OPEN_SKILL_SCREEN -> openSkillEditorScreen;
+            case OPEN_CONFIG_SCREEN -> openConfigScreen;
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging;
+        };
+        final @Nullable InputBinding binding = bindingSupplier.onOrNull(requireControllerEntity());
+        return Objects.requireNonNull(binding, "The binding for the action " + action.name() + " is not yet registered.");
+    }
+
+    private static @NotNull ControlifyApi getApi() {
+        return ControlifyApi.get();
+    }
+
+    private static @NotNull ControllerEntity requireControllerEntity() {
+        Optional<ControllerEntity> optionalControllerEntity = getApi().getCurrentController();
+
+        if (optionalControllerEntity.isEmpty()) {
+            final String message = String.format(
+                    "The method IEpicFightControllerMod#getInputState must not be called when the input mode is not %s",
+                    InputMode.CONTROLLER.name()
+            );
+            EpicFightMod.LOGGER.error(message);
+            throw new IllegalStateException(message);
+        }
+
+        return optionalControllerEntity.get();
+    }
+
+    /**
+     * Allows Epic Fight to communicate with Controlify APIs without depending on their classes directly.
+     *
+     */
+    private static class ControlifyIntegration implements IEpicFightControllerMod {
+        @Override
+        public String getModName() {
+            return "Controlify";
+        }
+
+        @Override
+        public @NotNull InputMode getInputMode() {
+            return switch (getApi().currentInputMode()) {
+                case KEYBOARD_MOUSE -> InputMode.KEYBOARD_MOUSE;
+                case CONTROLLER -> InputMode.CONTROLLER;
+                case MIXED -> InputMode.MIXED;
+            };
+        }
+
+        @Override
+        public @NotNull ControllerBinding getBinding(EpicFightInputActions action) {
+            return new ControllerBindingImpl(getControlifyBinding(action));
+        }
+
+        @Override
+        public @NotNull PlayerInputState getInputState() {
+            ControllerEntity controller = requireControllerEntity();
+
+            InputBinding forwardBind = ControlifyBindings.WALK_FORWARD.on(controller);
+            InputBinding backwardBind = ControlifyBindings.WALK_BACKWARD.on(controller);
+            InputBinding leftBind = ControlifyBindings.WALK_LEFT.on(controller);
+            InputBinding rightBind = ControlifyBindings.WALK_RIGHT.on(controller);
+            InputBinding jumpBind = ControlifyBindings.JUMP.on(controller);
+            InputBinding sneakBind = ControlifyBindings.SNEAK.on(controller);
+
+            float forwardImpulse = forwardBind.analogueNow() - backwardBind.analogueNow();
+            float leftImpulse = leftBind.analogueNow() - rightBind.analogueNow();
+
+            return new PlayerInputState(
+                    leftImpulse, forwardImpulse,
+                    forwardBind.digitalNow(), backwardBind.digitalNow(),
+                    leftBind.digitalNow(), rightBind.digitalNow(),
+                    jumpBind.digitalNow(), sneakBind.digitalNow()
+            );
+        }
+
+        @Override
+        public boolean isBoundToSameButton(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2) {
+            final Input input1 = getControlifyBinding(action).boundInput();
+            final Input input2 = getControlifyBinding(action2).boundInput();
+            return input1.getRelevantInputs().equals(input2.getRelevantInputs());
+        }
+    }
+
+    private record ControllerBindingImpl(@NotNull InputBinding inputBinding) implements ControllerBinding {
+
+        @Override
+        public ResourceLocation id() {
+            return inputBinding.id();
+        }
+
+        @Override
+        public @NotNull InputType getInputType() {
+            if (inputBinding.boundInput().type() == dev.isxander.controlify.bindings.input.InputType.AXIS) {
+                return InputType.ANALOGUE;
+            }
+            EpicFightMod.LOGGER.error("The method ControllerBinding#getInputType is misleading and should not be called as it will be removed in future updates.");
+            return InputType.DIGITAL;
+        }
+
+        @Override
+        public boolean isDigitalActiveNow() {
+            return inputBinding.digitalNow();
+        }
+
+        @Override
+        public boolean wasDigitalActivePreviously() {
+            return inputBinding.digitalPrev();
+        }
+
+        @Override
+        public boolean isDigitalJustPressed() {
+            return inputBinding.justPressed();
+        }
+
+        @Override
+        public boolean isDigitalJustReleased() {
+            return inputBinding.justReleased();
+        }
+
+        @Override
+        public float getAnalogueNow() {
+            return inputBinding.analogueNow();
+        }
+
+        @Override
+        public void emulatePress() {
+            inputBinding.fakePress();
+        }
+    }
+
+    private static void registerScreenProcessors() {
+        // TODO: (Controlify) Add support for skill editor screen
+//        ScreenProcessorProvider.registerProvider(
+//                SkillEditScreen.class,
+//                SkillEditScreenProcessor::new
+//        );
+//        ComponentProcessorProvider.REGISTRY.register(
+//                SkillEditScreen.SlotButton.class,
+//                SkillEditScreenProcessor.SlotButtonProcessor::new
+//        );
+    }
+
+    private static class SkillEditScreenProcessor extends ScreenProcessor<SkillEditScreen> {
+        public SkillEditScreenProcessor(SkillEditScreen screen) {
+            super(screen);
+        }
+
+        private static class SlotButtonProcessor extends AbstractButtonComponentProcessor {
+            public SlotButtonProcessor(AbstractButton button) {
+                super(button);
+            }
+        }
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -158,17 +158,9 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private static void registerInputBindings(ControlifyBindApi registrar) {
-        for (EpicFightInputActions action : nonVanillaActions()) {
+        for (EpicFightInputActions action : EpicFightInputActions.nonVanillaActions()) {
             registerInputBinding(registrar, action);
         }
-    }
-
-    public static Set<EpicFightInputActions> nonVanillaActions() {
-        Set<EpicFightInputActions> result = EnumSet.noneOf(EpicFightInputActions.class);
-        for (EpicFightInputActions action : EpicFightInputActions.values()) {
-            if (!action.isVanilla()) result.add(action);
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -4,6 +4,8 @@ import dev.isxander.controlify.api.ControlifyApi;
 import dev.isxander.controlify.api.bind.ControlifyBindApi;
 import dev.isxander.controlify.api.bind.InputBinding;
 import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.buttonguide.ButtonGuideApi;
+import dev.isxander.controlify.api.buttonguide.ButtonGuidePredicate;
 import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
 import dev.isxander.controlify.api.entrypoint.InitContext;
 import dev.isxander.controlify.api.entrypoint.PreInitContext;
@@ -15,11 +17,11 @@ import dev.isxander.controlify.bindings.RadialIcons;
 import dev.isxander.controlify.bindings.input.Input;
 import dev.isxander.controlify.controller.ControllerEntity;
 import dev.isxander.controlify.screenop.ScreenProcessor;
-import dev.isxander.controlify.screenop.compat.vanilla.AbstractButtonComponentProcessor;
+import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
+import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.gui.components.AbstractButton;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
@@ -33,6 +35,7 @@ import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.main.EpicFightMod;
@@ -485,15 +488,14 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private static void registerScreenProcessors() {
-        // TODO: (Controlify) Add support for skill editor screen
-//        ScreenProcessorProvider.registerProvider(
-//                SkillEditScreen.class,
-//                SkillEditScreenProcessor::new
-//        );
-//        ComponentProcessorProvider.REGISTRY.register(
-//                SkillEditScreen.SlotButton.class,
-//                SkillEditScreenProcessor.SlotButtonProcessor::new
-//        );
+        ScreenProcessorProvider.registerProvider(
+                SkillEditScreen.class,
+                SkillEditScreenProcessor::new
+        );
+        ScreenProcessorProvider.registerProvider(
+                SkillBookScreen.class,
+                SkillBookScreenProcessor::new
+        );
     }
 
     private static class SkillEditScreenProcessor extends ScreenProcessor<SkillEditScreen> {
@@ -501,10 +503,48 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             super(screen);
         }
 
-        private static class SlotButtonProcessor extends AbstractButtonComponentProcessor {
-            public SlotButtonProcessor(AbstractButton button) {
-                super(button);
+        @Override
+        public VirtualMouseBehaviour virtualMouseBehaviour() {
+            // The skill edit screen does not natively support controllers.
+            // To save development time, we work around this issue by enforcing the virtual mouse.
+            return VirtualMouseBehaviour.ENABLED;
+        }
+    }
+
+    private static class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {
+        public SkillBookScreenProcessor(SkillBookScreen screen) {
+            super(screen);
+        }
+
+        private static final InputBindingSupplier LEARN_SKILL = ControlifyBindings.GUI_PRESS;
+
+        @Override
+        protected void handleButtons(ControllerEntity controller) {
+            if (LEARN_SKILL.on(controller).guiPressed().get()) {
+                screen.learnButton.onPress();
             }
+            super.handleButtons(controller);
+        }
+
+        @Override
+        protected void setInitialFocus() {
+            // No-op
+        }
+
+        @Override
+        protected void handleComponentNavigation(ControllerEntity controller) {
+            // No-op
+        }
+
+        @Override
+        public void onWidgetRebuild() {
+            super.onWidgetRebuild();
+
+            ButtonGuideApi.addGuideToButton(
+                    this.screen.learnButton,
+                    LEARN_SKILL,
+                    ButtonGuidePredicate.always()
+            );
         }
     }
 }

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -317,7 +317,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         registry.registerDynamicRule(
                 Rule.builder().binding(dodge)
                         .where(ActionLocation.RIGHT)
-                        .then(ComponentConstants.KEY_GUARD)
+                        .then(ComponentConstants.KEY_DODGE)
                         .build()
         );
         registry.registerDynamicRule(

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -278,6 +278,7 @@ public class EpicFightMod {
     	event.enqueueWork(WeaponCategory.ENUM_MANAGER::loadEnum);
     	event.enqueueWork(Faction.ENUM_MANAGER::loadEnum);
     	event.enqueueWork(EntityPairingPacketType.ENUM_MANAGER::loadEnum);
+    	event.enqueueWork(InputAction.ENUM_MANAGER::loadEnum);
     	event.enqueueWork(() -> {
     		AnimationManager.addNoWarningModId(EPICSKINS_MODID);
 			AnimationRegistryEvent animationregistryevent = new AnimationRegistryEvent();

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -6,6 +6,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,6 +38,7 @@ import net.neoforged.neoforge.event.AddPackFindersEvent;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -409,4 +411,8 @@ public class EpicFightMod {
 				event.accept(stack);
 			});
 	}
+
+    public static @NotNull ResourceLocation rl(@NotNull String path) {
+        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
 }

--- a/src/main/java/yesman/epicfight/mixin/client/MixinClientCommonPacketListenerImpl.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinClientCommonPacketListenerImpl.java
@@ -1,0 +1,27 @@
+package yesman.epicfight.mixin.client;
+
+import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.client.events.engine.ControlEngine;
+
+@Mixin(ClientCommonPacketListenerImpl.class)
+public class MixinClientCommonPacketListenerImpl {
+    @Inject(
+            method = "send(Lnet/minecraft/network/protocol/Packet;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onBeforeSendPacket(Packet<?> packet, CallbackInfo ci) {
+        final boolean isSwapItemWithOffhand = packet instanceof ServerboundPlayerActionPacket actionPacket &&
+                actionPacket.getAction() == ServerboundPlayerActionPacket.Action.SWAP_ITEM_WITH_OFFHAND;
+        if (isSwapItemWithOffhand && ControlEngine.shouldDisableSwapHandItems()) {
+            // Disables the swap offhand items while in action (e.g., attacking in Epic Fight mode).
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/yesman/epicfight/mixin/client/MixinClientPacketListener.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinClientPacketListener.java
@@ -1,7 +1,5 @@
 package yesman.epicfight.mixin.client;
 
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -10,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.protocol.game.ClientboundRespawnPacket;
 import yesman.epicfight.client.events.ClientEvents;
-import yesman.epicfight.client.events.engine.ControlEngine;
 
 @Mixin(value = ClientPacketListener.class)
 public abstract class MixinClientPacketListener {
@@ -18,18 +15,4 @@ public abstract class MixinClientPacketListener {
 	private void epicfight_handleRespawn(ClientboundRespawnPacket clientboundRespawnPacket, CallbackInfo info) {
 		ClientEvents.packet = clientboundRespawnPacket;
 	}
-
-    @Inject(
-            method = "send(Lnet/minecraft/network/protocol/Packet;)V",
-            at = @At("HEAD"),
-            cancellable = true
-    )
-    private void onBeforeSendPacket(Packet<?> packet, CallbackInfo ci) {
-        final boolean isSwapItemWithOffhand = packet instanceof ServerboundPlayerActionPacket actionPacket &&
-                actionPacket.getAction() == ServerboundPlayerActionPacket.Action.SWAP_ITEM_WITH_OFFHAND; 
-        if (isSwapItemWithOffhand && ControlEngine.shouldDisableSwapHandItems()) {
-            // Disables the swap offhand items while in action (e.g., attacking in Epic Fight mode).
-            ci.cancel();
-        }
-    }
 }

--- a/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
+++ b/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
@@ -1,0 +1,1 @@
+yesman.epicfight.compat.controlify.ControlifyCompat

--- a/src/main/resources/assets/controlify/controllers/default_bind/default.json
+++ b/src/main/resources/assets/controlify/controllers/default_bind/default.json
@@ -1,0 +1,22 @@
+{
+  "defaults": {
+    "epicfight:attack": {
+      "axis": "controlify:axis/right_trigger"
+    },
+    "epicfight:weapon_innate_skill": {
+      "axis": "controlify:axis/right_trigger"
+    },
+    "epicfight:mobility": {
+      "button": "controlify:button/south"
+    },
+    "epicfight:guard": {
+      "axis": "controlify:axis/left_trigger"
+    },
+    "epicfight:dodge": {
+      "button": "controlify:button/east"
+    },
+    "epicfight:lock_on": {
+      "button": "controlify:button/left_stick"
+    }
+  }
+}

--- a/src/main/resources/assets/controlify/controllers/default_bind/default.json
+++ b/src/main/resources/assets/controlify/controllers/default_bind/default.json
@@ -6,6 +6,9 @@
     "epicfight:weapon_innate_skill": {
       "axis": "controlify:axis/right_trigger"
     },
+    "epicfight:weapon_innate_skill_tooltip": {
+      "axis": "controlify:axis/left_trigger"
+    },
     "epicfight:mobility": {
       "button": "controlify:button/south"
     },

--- a/src/main/resources/assets/epicfight/lang/en_us.json
+++ b/src/main/resources/assets/epicfight/lang/en_us.json
@@ -364,6 +364,18 @@
 	"key.epicfight.mover_skill": "Mobility Skill",
 	"key.epicfight.config": "Open Configuration Screen",
 	"key.epicfight.switch_vanilla_model_debug": "Switch Vanilla Model Debugging",
+
+    "key.epicfight.show_tooltip.description": "Displays the tooltip of your weapon's innate skill when the inventory screen is open",
+    "key.epicfight.switch_mode.description": "Switches between combat and mining modes",
+    "key.epicfight.attack.description": "Performs a basic attack with your equipped weapon",
+    "key.epicfight.weapon_innate_skill.description": "Activates the innate skill of your equipped weapon",
+    "key.epicfight.skill_gui.description": "Opens the skill editor GUI to customize your skills",
+    "key.epicfight.dodge.description": "Performs a dodge maneuver to avoid attacks",
+    "key.epicfight.guard.description": "Blocks incoming attacks with your weapon",
+    "key.epicfight.lock_on.description": "Locks onto the nearest target for easier combat",
+    "key.epicfight.mover_skill.description": "Uses a skill that enhances movement or mobility",
+    "key.epicfight.config.description": "Opens the mod configuration screen",
+    "key.epicfight.switch_vanilla_model_debug.description": "Toggles debugging for vanilla player models",
 	
 	"skill.epicfight.dancing_edge": "Dancing Edge",
 	"skill.epicfight.dancing_edge.tooltip": "Cut down enemies with a lethal flourish! It strikes 3 times",

--- a/src/main/resources/epicfight.mixins.json
+++ b/src/main/resources/epicfight.mixins.json
@@ -7,6 +7,7 @@
 		"client.MixinAbstractContainerEventHandler",
 		"client.MixinAgeableListModel",
 		"client.MixinClientPacketListener",
+		"client.MixinClientCommonPacketListenerImpl",
 		"client.MixinCompositeRenderType",
 		"client.MixinEnderDragonRenderer",
 		"client.MixinEntityRenderer",


### PR DESCRIPTION
Fixes #2116 and adds fully functional controller support.
This PR relies heavily on the refactored input system #2122, which was developed for `1.20.1` and subsequently ported to `1.21.1`.

Also sent a PR to Epic Skills: https://github.com/Epic-Fight/epicskills/pull/5

### Quick Demo

[Watch the video on YouTube](https://youtu.be/8DnOr9_bAso)

### Quick Test

If you're a:

* **player:** download this [zip file](https://drive.google.com/file/d/1Lzh_3qmn4keZ-uxv-l3abkbr6Ec_Svn0/view?usp=sharing), drag and drop the JAR files in `.minecraft/mods` (NeoForge 1.21.1 only).
* **developer:** checkout this branch, [change the controlify `compileOnly` line to `implementation`](https://github.com/EchoEllet/epicfight/blob/d4ed6b7f8be77d65eb0f46fa6b401aa6abfb7a10/build.gradle#L167-L168) temporarily, then run `./gradlew runClient`.

### Screen support

- [x] **Skill Editor:** Forced the virtual mouse behavior for the skill editor screen to save development overhead.
- [x] **Skill Book:** Added full controller support for the skill book screen, since it has only one button, and it's pretty trivial to support.

This should be enough to make Epic Fight fully playable with a controller.

### Screenshots

<details><summary>Screenshots</summary>
<p>

<img width="1280" height="662" alt="image" src="https://github.com/user-attachments/assets/446684a1-3042-4ef2-84b5-d9a0d80db811" />

<img width="2560" height="1350" alt="image" src="https://github.com/user-attachments/assets/cd793518-6a33-43ca-9146-e21611cf0d38" />

<img width="1633" height="1074" alt="image" src="https://github.com/user-attachments/assets/8cf0ab25-980e-434e-931a-658eab225d9f" />


</p>
</details> 

### Release note entry

It might be worth adding this for addons:

```md
**Important:** If you're a mod developer modifying Epic Fight’s `ControlEngine` using a mixin, please test your changes against the latest version to avoid breaking Epic Fight internals or your add-on’s behavior.
You may see some **deprecations** — please consider **migrating** to support controllers in future updates.
For more details, refer to [PR #2122](https://github.com/Epic-Fight/epicfight/pull/2122).
```