### PR TITLE
[NeoForge 1.21.1] Data driven guides & Improve existing guides

### DIFF
--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -25,6 +25,7 @@ import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -41,6 +42,8 @@ import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.skill.SkillCategories;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -69,7 +72,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         registrar.registerBindContext(COMBAT_MODE_CONTEXT);
         registerInputBindings(registrar);
         registerTargetLockOnSupport();
-        registerInGameGuides(context.guideRegistries().inGame());
+        registerGuides(context.guideRegistries().inGame(), context.guideRegistries().container());
         registerScreenProcessors();
     }
 
@@ -344,14 +347,22 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         });
     }
 
-    private static void registerInGameGuides(GuideDomainRegistry<InGameCtx> registry) {
+    private static void registerGuides(GuideDomainRegistry<InGameCtx> inGameRegistry, GuideDomainRegistry<ContainerCtx> containerRegistry) {
         // Facts are registered here; rules in "assets/controlify/guides/in_game.json" reference these facts.
-        registry.registerFact(new Fact<>(EpicFightMod.rl("can_perform_dodge"), ctx -> {
+        inGameRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_perform_dodge"), ctx -> {
             final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
             if (localPlayerPatch == null || !localPlayerPatch.isEpicFightMode()) {
                 return false;
             }
             return localPlayerPatch.getPlayerSkills().hasCategory(SkillCategories.DODGE);
+        }));
+        containerRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_show_weapon_innate_skill_tooltip"), ctx -> {
+            final Slot hoveredSlot = ctx.hoveredSlot();
+            if (hoveredSlot == null || !ctx.hoveredSlot().hasItem()) {
+                return false;
+            }
+            final Optional<CapabilityItem> maybeCapabilityItem = EpicFightCapabilities.getItemCapability(hoveredSlot.getItem());
+            return maybeCapabilityItem.isPresent();
         }));
     }
 

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -40,6 +40,7 @@ import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.main.EpicFightMod;
+import yesman.epicfight.skill.SkillCategories;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -307,6 +308,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
     private static @NotNull ResourceLocation getBindingId(@NotNull EpicFightInputActions action) {
         final String path = switch (action) {
+            // Project maintainers: if you change any ID (e.g., "attack"), update assets/controlify too.
             case ATTACK -> "attack";
             case MOBILITY -> "mobility";
             case GUARD -> "guard";
@@ -343,19 +345,14 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private static void registerInGameGuides(GuideDomainRegistry<InGameCtx> registry) {
-        registry.registerDynamicRule(
-                Rule.builder().binding(dodge)
-                        .where(ActionLocation.RIGHT)
-                        .then(TranslationKeys.getNameOf(EpicFightInputActions.DODGE))
-                        .build()
-        );
-        registry.registerDynamicRule(
-                Rule.builder().binding(lockOn)
-                        .where(ActionLocation.LEFT)
-                        .when(InGameFacts.LOOKING_AT_ENTITY)
-                        .then(TranslationKeys.getNameOf(EpicFightInputActions.LOCK_ON))
-                        .build()
-        );
+        // Facts are registered here; rules in "assets/controlify/guides/in_game.json" reference these facts.
+        registry.registerFact(new Fact<>(EpicFightMod.rl("can_perform_dodge"), ctx -> {
+            final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+            if (localPlayerPatch == null || !localPlayerPatch.isEpicFightMode()) {
+                return false;
+            }
+            return localPlayerPatch.getPlayerSkills().hasCategory(SkillCategories.DODGE);
+        }));
     }
 
     private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputActions action) {

--- a/src/main/resources/assets/controlify/guides/container.json
+++ b/src/main/resources/assets/controlify/guides/container.json
@@ -1,0 +1,11 @@
+{
+  "override": false,
+  "rules": [
+    {
+      "for": "epicfight:weapon_innate_skill_tooltip",
+      "where": "left",
+      "when": ["epicfight:can_show_weapon_innate_skill_tooltip"],
+      "then": { "translate": "inventory.epicfight.guide.show_innate_skill" }
+    }
+  ]
+}

--- a/src/main/resources/assets/controlify/guides/in_game.json
+++ b/src/main/resources/assets/controlify/guides/in_game.json
@@ -1,0 +1,17 @@
+{
+  "override": false,
+  "rules": [
+    {
+      "for": "epicfight:dodge",
+      "where": "right",
+      "when": ["epicfight:can_perform_dodge"],
+      "then": { "translate": "key.epicfight.dodge" }
+    },
+    {
+      "for": "epicfight:lock_on",
+      "where": "left",
+      "when": ["controlify:looking_at_entity"],
+      "then": { "translate": "key.epicfight.lock_on" }
+    }
+  ]
+}

--- a/src/main/resources/assets/epicfight/lang/en_us.json
+++ b/src/main/resources/assets/epicfight/lang/en_us.json
@@ -348,6 +348,7 @@
 	"itemGroup.epicfight.items": "EpicFight Items",
 	
 	"inventory.epicfight.guide_innate_tooltip": "[%s] to see Innate skill",
+    "inventory.epicfight.guide.show_innate_skill": "Show Innate Skill",
 	
 	"key.epicfight.combat": "Epic Fight Combat",
 	"key.epicfight.gui": "Epic Fight GUI",


### PR DESCRIPTION
* Follows [data-driven guide](https://moddedmc.wiki/en/project/controlify/latest/docs/resource-packs/guides) rules—modpack authors and users can fully override or disable them.  
* Adds a new fact for Dodge. Previously, I used a built-in Controlify fact, which always showed the dodge guide even outside Epic Fight mode or without a dodge skill.
* Adds a new rule for showing a guide for the weapon innate skill tooltip when hovering over an item in the inventory GUI.

<img width="1708" height="960" alt="WeaponInnateSkillTooltipGuide" src="https://github.com/user-attachments/assets/e94fbb8b-1ff0-4904-9665-9da652fbed1a" />
