### PR TITLE
[NeoForge 1.21.1] Prevent Epic Fight from breaking Controlify sneaking movement speed

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/neoevent/MappedMovementInputUpdateEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/MappedMovementInputUpdateEvent.java
@@ -22,7 +22,7 @@ public class MappedMovementInputUpdateEvent extends PlayerPatchEvent<LocalPlayer
      * {@link InputManager#setInputState} instead, which fully support controller input.
      * </p>
      *
-     * @see MovementInputEvent#getInputState
+     * @see #getMovementInput()
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     @NotNull
@@ -52,7 +52,7 @@ public class MappedMovementInputUpdateEvent extends PlayerPatchEvent<LocalPlayer
     }
     
     /**
-     * Creates a new {@link MovementInputEvent} with an immutable {@link PlayerInputState}.
+     * Creates a new {@link MappedMovementInputUpdateEvent} with an immutable {@link PlayerInputState}.
      * <p>
      * Use this constructor to fully support controllers.
      * </p>
@@ -66,7 +66,7 @@ public class MappedMovementInputUpdateEvent extends PlayerPatchEvent<LocalPlayer
         this.inputState = inputState;
         // DEPRECATED: Still set the vanilla Input for backward compatibility to avoid Epic Fight addons breakage.
         // Not setting this, may break any consumers that depend on the deprecated MovementInputEvent#getMovementInput() method.
-        this.movementInput = PlayerInputState.applyToVanillaInput(inputState, playerPatch.getOriginal().input);
+        this.movementInput = playerPatch.getOriginal().input;
     }
     
     /**


### PR DESCRIPTION
Fixes #2143.

This issue is from my PR #2122, though it's only problematic for controller mods, such as Controlify. The usage of `PlayerInputState.applyToVanillaInput` in the previous code is incorrect; `applyToVanillaInput` has a side effect, not just pure mapping.

This whole statement exists for backward compatibility.

> [!TIP]
> I do encourage merging this, as there is a low chance that without this fix, it might cause issues with other mods or addons too.

This fix is backportable to 1.20.1, so I will, just in case.