### PR TITLE
[Forge 1.20.1] Backport PR #2144 from NeoForge 1.21.1

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputActions.java
@@ -8,9 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a default set of input actions used in the Epic Fight mod.
@@ -135,5 +133,20 @@ public enum EpicFightInputActions implements InputAction {
      */
     public static @Nullable EpicFightInputActions fromKeyMapping(@NotNull KeyMapping keyMapping) {
         return BY_KEY_MAPPING.get(keyMapping);
+    }
+
+    /**
+     * Returns a set of all Epic Fight actions that are not part of the vanilla
+     * Minecraft key mappings.
+     *
+     * @return a set containing all non-vanilla {@link EpicFightInputActions}
+     * @see EpicFightInputActions#isVanilla
+     */
+    public static @NotNull Set<EpicFightInputActions> nonVanillaActions() {
+        Set<EpicFightInputActions> result = EnumSet.noneOf(EpicFightInputActions.class);
+        for (EpicFightInputActions action : EpicFightInputActions.values()) {
+            if (!action.isVanilla()) result.add(action);
+        }
+        return result;
     }
 }

--- a/src/main/java/yesman/epicfight/world/entity/eventlistener/MovementInputEvent.java
+++ b/src/main/java/yesman/epicfight/world/entity/eventlistener/MovementInputEvent.java
@@ -61,7 +61,7 @@ public class MovementInputEvent extends AbstractPlayerEvent<LocalPlayerPatch> {
         this.inputState = inputState;
         // DEPRECATED: Still set the vanilla Input for backward compatibility to avoid Epic Fight addons breakage.
         // Not setting this, may break any consumers that depend on the deprecated MovementInputEvent#getMovementInput() method.
-        this.movementInput = PlayerInputState.applyToVanillaInput(inputState, playerPatch.getOriginal().input);
+        this.movementInput = playerPatch.getOriginal().input;
     }
 
     /**


### PR DESCRIPTION
This backports the #2144 fix; it does not fix any issues for vanilla keyboard/mouse users, only controller users.

Since there is no supported controller mod implementation on Forge 1.20.1, this PR seems redundant, but it's useful to prevent Epic fight from potentially breaking any other mods that depend on the vanilla `Input` (an assumption).