### PR TITLE
[NeoForge 1.21.1] Replace the temporary Controlify maven and remove the TODO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,9 @@ repositories {
         }
     }
 
-    // TODO: Use Controlify from Modrinth maven once this PR is published: https://github.com/isXander/Controlify/pull/689
-    //  and then remove this temporary Maven.
     exclusiveContent {
-        forRepository { maven { url "https://echoellet.github.io/Controlify/" } }
-        filter { includeGroup "dev.echoellet" }
+        forRepository { maven { url "https://maven.isxander.dev/releases" } }
+        filter { includeGroup "dev.isxander" }
     }
 }
 
@@ -165,7 +163,10 @@ dependencies {
     //compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993795" // Actual mod file (for test)
 
     // Change "compileOnly" to "implementation" for testing in-game.
-    compileOnly "dev.echoellet:controlify:2.4.2-1.21.1-neoforge"
+    compileOnly("dev.isxander:controlify:${project.controlify_version}") {
+        // Only need Controlify API, ignore the transitive dependencies (e.g, QuiltMC parsers)
+        transitive = false
+    }
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,4 @@ jei_version=19.21.2.313
 kubejs_version=2101.7.1-build.181
 rhino_version=2006.2.4-build.17
 architectury_version=13.0.8
+controlify_version=2.4.3+1.21.1-neoforge


### PR DESCRIPTION
Controlify released the crash fix for NeoForge 1.21.1; this temporary maven is no longer needed.
This replaces it with the supported Maven rather than Modrinth/CurseForge for the sources JAR file, and it also includes more useful metadata to avoid any compile issues, etc....