### PR TITLE
Expose SkillBookScreen.learnButton

### DIFF
--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
@@ -112,6 +112,12 @@ public class SkillBookScreen extends Screen {
 	protected final InteractionHand hand;
 	
 	private double customScale;
+
+    private Button learnButton;
+
+    public Button getLearnButton() {
+        return learnButton;
+    }
 	
 	public SkillBookScreen(Player opener, ItemStack stack, @Nullable InteractionHand hand) {
 		this(opener, SkillBookItem.getContainSkill(stack), hand, null);
@@ -213,7 +219,7 @@ public class SkillBookScreen extends Screen {
 			this.customScale = window.getGuiScale();
 		}
 		
-		Button learnButton =
+		learnButton =
 			Button.builder(
 				Component.translatable(EpicFightMod.format("gui.%s") + (isUsing ? ".applied" : meetsCondition ? ".learn" : ".unusable")),
 				button -> {


### PR DESCRIPTION
Allows other mods to access the `SkillBookScreen.learnButton`, which is already the case in the NeoForge 1.21.1 branch.

I'm experimenting with a custom Controlify 1.20.1 integration (backported Controlify), and this change is required to allow learning the skill when using a controller.