### PR TITLE
[NeoForge 1.21.1] Play click sound when learn/equip a skill via controller

### DIFF
--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
@@ -110,8 +110,12 @@ public class SkillBookScreen extends Screen {
 	protected final AttributeIconList providingAttributesList;
 	protected final InteractionHand hand;
 	private double customScale;
-    public AbstractButton learnButton;
-	
+    private Button learnButton;
+
+    public Button getLearnButton() {
+        return learnButton;
+    }
+
 	public SkillBookScreen(Player opener, ItemStack stack, @Nullable InteractionHand hand) {
 		this(opener, SkillBookItem.getContainSkill(stack).get().value(), hand, null);
 	}

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -551,7 +551,8 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         @Override
         protected void handleButtons(ControllerEntity controller) {
             if (LEARN_SKILL.on(controller).guiPressed().get()) {
-                screen.learnButton.onPress();
+                screen.getLearnButton().onPress();
+                playClackSound();
             }
             super.handleButtons(controller);
         }
@@ -575,7 +576,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             super.onWidgetRebuild();
 
             ButtonGuideApi.addGuideToButton(
-                    this.screen.learnButton,
+                    this.screen.getLearnButton(),
                     LEARN_SKILL,
                     ButtonGuidePredicate.always()
             );


### PR DESCRIPTION
* When the player presses the physical controller's south button (e.g., X on a DualSense), the click sound does not play. However, when clicking the GUI button, the sound plays. This fixes the behavior consistently.
* Make `learnButton` private and expose it via a getter method for consistency with #2152, preventing consumers/mods from setting it to `null`, which could cause a crash. This is better for maintainability and long-term stability.
