### PR TITLE
Extract mixins for third-party classes outside of epicfight.mixins.json

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/model/transformer/GeoModelTransformer.java
+++ b/src/main/java/yesman/epicfight/api/client/model/transformer/GeoModelTransformer.java
@@ -42,8 +42,9 @@ import yesman.epicfight.api.client.neoevent.AnimatedArmorTextureEvent;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
-import yesman.epicfight.mixin.geckolib.MixinGeoArmorRenderer;
+import yesman.epicfight.compat.geckolib.mixin.MixinGeoArmorRenderer;
 
+// TODO: Move this file to yesman.epicfight.compat.geckolib
 @OnlyIn(Dist.CLIENT)
 public class GeoModelTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> HEAD = new SimpleTransformer(9);

--- a/src/main/java/yesman/epicfight/api/client/model/transformer/SkinLayer3DTransformer.java
+++ b/src/main/java/yesman/epicfight/api/client/model/transformer/SkinLayer3DTransformer.java
@@ -36,9 +36,10 @@ import yesman.epicfight.api.client.model.transformer.VanillaModelTransformer.Van
 import yesman.epicfight.api.utils.math.QuaternionUtils;
 import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
-import yesman.epicfight.mixin.skinlayers.MixinCustomModelPart;
-import yesman.epicfight.mixin.skinlayers.MixinCustomizableCubeWrapper.SkinLayer3DMixinCustomModelCube;
+import yesman.epicfight.compat.skinlayer3d.mixin.MixinCustomModelPart;
+import yesman.epicfight.compat.skinlayer3d.mixin.MixinCustomizableCubeWrapper.SkinLayer3DMixinCustomModelCube;
 
+// TODO: Move this file to yesman.epicfight.compat.skinlayer3d
 @OnlyIn(Dist.CLIENT)
 public class SkinLayer3DTransformer extends CustomizableCube {
 	private SkinLayer3DTransformer() {
@@ -214,7 +215,7 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 						.setEffectiveJointNumber(1)
 					);
 				}
-				
+
 				triangluatePolygon(indices, partName, indexCounter);
 			}
 		}

--- a/src/main/java/yesman/epicfight/compat/geckolib/mixin/MixinGeoArmorRenderer.java
+++ b/src/main/java/yesman/epicfight/compat/geckolib/mixin/MixinGeoArmorRenderer.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.geckolib;
+package yesman.epicfight.compat.geckolib.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/java/yesman/epicfight/compat/skinlayer3d/mixin/MixinCustomModelPart.java
+++ b/src/main/java/yesman/epicfight/compat/skinlayer3d/mixin/MixinCustomModelPart.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.skinlayers;
+package yesman.epicfight.compat.skinlayer3d.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/java/yesman/epicfight/compat/skinlayer3d/mixin/MixinCustomizableCubeWrapper.java
+++ b/src/main/java/yesman/epicfight/compat/skinlayer3d/mixin/MixinCustomizableCubeWrapper.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.skinlayers;
+package yesman.epicfight.compat.skinlayer3d.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/java/yesman/epicfight/compat/vampirism/VampirismCompat.java
+++ b/src/main/java/yesman/epicfight/compat/vampirism/VampirismCompat.java
@@ -23,7 +23,7 @@ import yesman.epicfight.client.renderer.patched.entity.PPlayerRenderer;
 import yesman.epicfight.client.renderer.patched.layer.ModelRenderLayer;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClientPlayerPatch;
 import yesman.epicfight.compat.ICompatModule;
-import yesman.epicfight.mixin.teamlapen.MixinVampirePlayerHeadLayer;
+import yesman.epicfight.compat.vampirism.mixin.MixinVampirePlayerHeadLayer;
 
 public class VampirismCompat implements ICompatModule {
 	@Override

--- a/src/main/java/yesman/epicfight/compat/vampirism/mixin/MixinVampirePlayerHeadLayer.java
+++ b/src/main/java/yesman/epicfight/compat/vampirism/mixin/MixinVampirePlayerHeadLayer.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.teamlapen;
+package yesman.epicfight.compat.vampirism.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesCompat.java
+++ b/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesCompat.java
@@ -29,7 +29,7 @@ import yesman.epicfight.client.renderer.patched.entity.PPlayerRenderer;
 import yesman.epicfight.client.renderer.patched.layer.PatchedLayer;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClientPlayerPatch;
 import yesman.epicfight.compat.ICompatModule;
-import yesman.epicfight.mixin.teamlapen.MixinHumanWerewolfLayer;
+import yesman.epicfight.compat.werewolves.mixin.MixinHumanWerewolfLayer;
 
 public class WerewolvesCompat implements ICompatModule {
 	@Override

--- a/src/main/java/yesman/epicfight/compat/werewolves/mixin/MixinHumanWerewolfLayer.java
+++ b/src/main/java/yesman/epicfight/compat/werewolves/mixin/MixinHumanWerewolfLayer.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.teamlapen;
+package yesman.epicfight.compat.werewolves.mixin;
 
 import java.util.List;
 

--- a/src/main/java/yesman/epicfight/mixin/client/MixinInventory.java
+++ b/src/main/java/yesman/epicfight/mixin/client/MixinInventory.java
@@ -6,11 +6,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.world.entity.player.Inventory;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.events.engine.ControlEngine;
 
-@OnlyIn(Dist.CLIENT)
 @Mixin(Inventory.class)
 public class MixinInventory {
     @Inject(

--- a/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
+++ b/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.mixin.client;
+package yesman.epicfight.platform.neoforge.mixin;
 
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.neoforged.bus.api.Event;
@@ -13,6 +13,8 @@ public abstract class MixinClientLevel {
     @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/bus/api/IEventBus;post(Lnet/neoforged/bus/api/Event;)Lnet/neoforged/bus/api/Event;"))
     private Event epicfight$init(IEventBus instance, Event e) {
         if (((ClientLevel)(Object)this) instanceof FakeLevel) {
+            // Prevents crashes that can occur when joining the world with certain mods.
+            // See: https://github.com/Epic-Fight/epicfight/issues/2164
             return null;
         }
 

--- a/src/main/resources/epicfight-compat.geckolib.mixins.json
+++ b/src/main/resources/epicfight-compat.geckolib.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_21",
+  "package": "yesman.epicfight.compat.geckolib.mixin",
+  "client": [
+    "MixinGeoArmorRenderer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/epicfight-compat.skinlayers3d.mixins.json
+++ b/src/main/resources/epicfight-compat.skinlayers3d.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_21",
+  "package": "yesman.epicfight.compat.skinlayer3d.mixin",
+  "client": [
+    "MixinCustomModelPart",
+    "MixinCustomizableCubeWrapper$SkinLayer3DMixinCustomModelCube"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/epicfight-compat.vampirism.mixins.json
+++ b/src/main/resources/epicfight-compat.vampirism.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_21",
+  "package": "yesman.epicfight.compat.vampirism.mixin",
+  "client": [
+    "MixinVampirePlayerHeadLayer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/epicfight-compat.werewolves.mixins.json
+++ b/src/main/resources/epicfight-compat.werewolves.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_21",
+  "package": "yesman.epicfight.compat.werewolves.mixin",
+  "client": [
+    "MixinHumanWerewolfLayer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/epicfight-platform.neoforge.mixins.json
+++ b/src/main/resources/epicfight-platform.neoforge.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_21",
+  "package": "yesman.epicfight.platform.neoforge.mixin",
+  "client": [
+    "MixinClientLevel"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/epicfight.mixins.json
+++ b/src/main/resources/epicfight.mixins.json
@@ -23,7 +23,6 @@
 		"client.MixinMouseHandler",
 		"client.MixinParticleEngine",
 		"client.MixinThrownTridentRenderer",
-		"geckolib.MixinGeoArmorRenderer",
 		"teamlapen.MixinVampirePlayerHeadLayer",
 		"teamlapen.MixinHumanWerewolfLayer"
 	],

--- a/src/main/resources/epicfight.mixins.json
+++ b/src/main/resources/epicfight.mixins.json
@@ -22,9 +22,7 @@
 		"client.MixinMinecraft",
 		"client.MixinMouseHandler",
 		"client.MixinParticleEngine",
-		"client.MixinThrownTridentRenderer",
-		"teamlapen.MixinVampirePlayerHeadLayer",
-		"teamlapen.MixinHumanWerewolfLayer"
+		"client.MixinThrownTridentRenderer"
 	],
 	"mixins": [
 		"common.MixinCrossbowAttack",

--- a/src/main/resources/epicfight.mixins.json
+++ b/src/main/resources/epicfight.mixins.json
@@ -8,7 +8,6 @@
 		"client.MixinAgeableListModel",
 		"client.MixinClientPacketListener",
 		"client.MixinClientCommonPacketListenerImpl",
-        "client.MixinClientLevel",
 		"client.MixinCompositeRenderType",
 		"client.MixinEnderDragonRenderer",
 		"client.MixinEntityRenderer",

--- a/src/main/resources/epicfight.mixins.json
+++ b/src/main/resources/epicfight.mixins.json
@@ -24,8 +24,6 @@
 		"client.MixinParticleEngine",
 		"client.MixinThrownTridentRenderer",
 		"geckolib.MixinGeoArmorRenderer",
-		"skinlayers.MixinCustomModelPart",
-		"skinlayers.MixinCustomizableCubeWrapper$SkinLayer3DMixinCustomModelCube",
 		"teamlapen.MixinVampirePlayerHeadLayer",
 		"teamlapen.MixinHumanWerewolfLayer"
 	],

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -22,6 +22,9 @@ config="${mod_id}-platform.neoforge.mixins.json"
 [[mixins]]
 config="${mod_id}-compat.skinlayers3d.mixins.json"
 
+[[mixins]]
+config="${mod_id}-compat.geckolib.mixins.json"
+
 [[accessTransformers]]
 file="META-INF/accesstransformer.cfg"
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -16,6 +16,9 @@ enumExtensions="META-INF/enum_extensions.json"
 [[mixins]]
 config="${mod_id}.mixins.json"
 
+[[mixins]]
+config="${mod_id}-platform.neoforge.mixins.json"
+
 [[accessTransformers]]
 file="META-INF/accesstransformer.cfg"
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -25,6 +25,12 @@ config="${mod_id}-compat.skinlayers3d.mixins.json"
 [[mixins]]
 config="${mod_id}-compat.geckolib.mixins.json"
 
+[[mixins]]
+config="${mod_id}-compat.vampirism.mixins.json"
+
+[[mixins]]
+config="${mod_id}-compat.werewolves.mixins.json"
+
 [[accessTransformers]]
 file="META-INF/accesstransformer.cfg"
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -19,6 +19,9 @@ config="${mod_id}.mixins.json"
 [[mixins]]
 config="${mod_id}-platform.neoforge.mixins.json"
 
+[[mixins]]
+config="${mod_id}-compat.skinlayers3d.mixins.json"
+
 [[accessTransformers]]
 file="META-INF/accesstransformer.cfg"
 


### PR DESCRIPTION
This PR is a follow-up to PR #2168 and a partial fix of issue #2147. Need another PR to fully fix ##2147, which just sets the `plugin` field with some other changes, but to keep the changes minimal, I decided to keep that in a separate PR.

This PR fixes the mixin tight-coupling issue, so the Epic Fight mixins are now more independent of any third-party mods or mod loaders.

### Changes

* Extract mixins for third-party classes outside of epicfight.mixins.json.
* Move files inside `mixin.${mod_name}.*` to `compat.${mod_name}.mixin.*`

### Motivation

This PR aims to:

* keep everything related to a mod, whether it's an `ICompatModule`, a mixin, an event, inside `compat.${mod_name}`. Often, we group by feature/domain rather than type.
* more independent of NeoForge and other mods, so now we have the full flexibility to decide which mixins should be registered on which versions or mod loader platforms
* register the mixins only if the mod is installed ([issue](https://github.com/Epic-Fight/epicfight/issues/2147)). Right now, Epic Fight attempts to access the classes of these mods, which may not be present in the runtime, which spams the log with errors and could cause potential issues. I have not fixed this registration issue yet, but this separation is necessary to fix the issue. I will keep the fix in a follow-up PR to keep the review easier.

### Testing

I have tested the game with these mods installed, and without them (in the production and development environment), I could not reproduce any crashes, and they seem to work.

> [!NOTE]
> Review the changes by commit, since they are structured.