### PR TITLE
[1.21.1] Add Javadocs for CombatKeyMapping

### DIFF
--- a/src/main/java/yesman/epicfight/client/input/CombatKeyMapping.java
+++ b/src/main/java/yesman/epicfight/client/input/CombatKeyMapping.java
@@ -9,6 +9,35 @@ import net.neoforged.neoforge.client.settings.KeyConflictContext;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.client.ClientEngine;
 
+/**
+ * A specialized {@link KeyMapping} used by Epic Fight to represent combat-related key bindings.
+ * <p>
+ * This enforces that all {@link #isDown()} or related checks to return {@code false}
+ * whenever the player is <strong>not</strong> in Epic Fight mode.
+ * <p>
+ * <strong>Important:</strong> Other mods or consumers should <em>not</em> rely on this behavior.
+ * They should explicitly check whether the player is in Epic Fight mode through
+ * {@link yesman.epicfight.client.ClientEngine#isEpicFightMode()} instead of depending on
+ * this key mapping’s conditional logic.
+ * <p>
+ * This also force setting {@link KeyConflictContext#IN_GAME},
+ * since a {@link CombatKeyMapping} is usually used for player moves
+ * (e.g, dodge, guard, mover skill, epic fight attack).
+ * <p>
+ * Note: The author of this code is not entirely certain about the exact purpose of
+ * {@link KeyConflictContext#IN_GAME}.
+ * It appears mainly relevant to key modifiers
+ * (e.g., distinguishing Shift + E from E) and does not affect the red conflict highlighting
+ * in the key bindings menu, since vanilla key mappings do not assign any {@link KeyConflictContext}.
+ * <p>
+ * This class is primarily used as a fallback or metadata reference for compatibility with
+ * other mods (hopefully!).
+ * Otherwise, it has no meaningful function beyond normal {@link KeyMapping} behavior.
+ * <p>
+ * Future maintainers should consider refactoring or removing this class
+ * if it becomes problematic or a maintenance burden.
+ * <p>
+ */
 @OnlyIn(Dist.CLIENT)
 public class CombatKeyMapping extends KeyMapping {
     public CombatKeyMapping(String description, int code, String category) {


### PR DESCRIPTION
To be honest, I prefer to remove any code that is confusing and does nothing meaningful, as future maintainers would assume this is useful in some way, so they think it's there for a reason, but there is just an inconsistency that makes it hard to maintain.

### Issue

For now, the best thing we could do is to document the existing confusing code while noting that we're not 100% about its usefulness, and we just hope that some other mods make use of this metadata, or it would be useful with other modded keybinds.

### Justification

We have already spent quite some time on Discord trying to figure out an answer, and this is a minor issue, so we need to focus on more important priorities.

[Unfortunately](https://www.oxfordlearnersdictionaries.com/definition/english/unfortunately), this [NeoForge doc section](https://docs.neoforged.net/docs/misc/keymappings/#registering-a-keymapping) appears to be [copied and pasted from MinecraftForge](https://docs.minecraftforge.net/en/latest/misc/keymappings/#ikeyconflictcontext).
