### PR TITLE
[CI] Add Shoulder Surfing to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,13 @@
 # All requests must be reviewed and approved by:
 * @Yesssssman
 
-# Controlify integration-related changes
+# Controlify compatibility
 /src/main/java/yesman/epicfight/compat/controlify/ @EchoEllet
 /src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint @EchoEllet
 /src/main/resources/assets/controlify/ @EchoEllet
 
 # Client Input API
 /src/main/java/yesman/epicfight/api/client/input/ @EchoEllet
+
+# Shoulder Surfing Compatibility
+/src/main/java/yesman/epicfight/compat/shouldersurfing/ @EchoEllet


### PR DESCRIPTION
I forgot to force push the addition of the Shoulder Surfing line (since it's an `--amend` commit). This PR is also a useful test for the newly added code owners.