### PR TITLE
[1.21.1] Avoid registering mixins for non-existing third-party mods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@
 
 ## [21.13.5] - Unreleased
 
+### Changed
+- Avoid registering mixins for non-existing third-party mods to avoid spamming the console log and prevent unnecessary operations.
+
 ### For Devs
 - Adopted KeyConflictContext for each keybind as documented by [Neoforge](https://docs.neoforged.net/docs/misc/keymappings/#ikeyconflictcontext) to avoid potential problem from inconsistency
 - Made GUARD and DODGE CombatKeyMapping, to activate only in Epic Fight mode

--- a/src/main/java/yesman/epicfight/compat/ModMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/ModMixinPlugin.java
@@ -1,0 +1,68 @@
+package yesman.epicfight.compat;
+
+import net.neoforged.fml.loading.LoadingModList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Enables registering mixins for other mods only when those mods are installed.
+ * <p>
+ * Maintainers: Do not reference any game or Epic Fight classes here.
+ * This runs during early game loading. {@link LoadingModList} is used because
+ * the mod loader is already initialized and is loading all mods, including Epic Fight.
+ *
+ * @see IMixinConfigPlugin
+ */
+@ApiStatus.Internal
+public abstract class ModMixinPlugin implements IMixinConfigPlugin {
+    /**
+     * Whether the is installed and is currently loading.
+     */
+    private final boolean isModInstalled;
+
+    protected ModMixinPlugin() {
+        isModInstalled = LoadingModList.get().getModFileById(this.getModId()) != null;
+    }
+
+    public abstract @NotNull String getModId();
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return isModInstalled;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/geckolib/GeckolibMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/geckolib/GeckolibMixinPlugin.java
@@ -1,0 +1,11 @@
+package yesman.epicfight.compat.geckolib;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.compat.ModMixinPlugin;
+
+public final class GeckolibMixinPlugin extends ModMixinPlugin {
+    @Override
+    public @NotNull String getModId() {
+        return "geckolib";
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/skinlayer3d/SkinLayer3DPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/skinlayer3d/SkinLayer3DPlugin.java
@@ -3,7 +3,7 @@ package yesman.epicfight.compat.skinlayer3d;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.compat.ModMixinPlugin;
 
-public class SkinLayer3DPlugin extends ModMixinPlugin {
+public final class SkinLayer3DPlugin extends ModMixinPlugin {
     @Override
     public @NotNull String getModId() {
         return "skinlayers3d";

--- a/src/main/java/yesman/epicfight/compat/skinlayer3d/SkinLayer3DPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/skinlayer3d/SkinLayer3DPlugin.java
@@ -1,0 +1,11 @@
+package yesman.epicfight.compat.skinlayer3d;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.compat.ModMixinPlugin;
+
+public class SkinLayer3DPlugin extends ModMixinPlugin {
+    @Override
+    public @NotNull String getModId() {
+        return "skinlayers3d";
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/vampirism/VampirismMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/vampirism/VampirismMixinPlugin.java
@@ -3,7 +3,7 @@ package yesman.epicfight.compat.vampirism;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.compat.ModMixinPlugin;
 
-public class VampirismMixinPlugin extends ModMixinPlugin {
+public final class VampirismMixinPlugin extends ModMixinPlugin {
     @Override
     public @NotNull String getModId() {
         return "vampirism";

--- a/src/main/java/yesman/epicfight/compat/vampirism/VampirismMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/vampirism/VampirismMixinPlugin.java
@@ -1,0 +1,11 @@
+package yesman.epicfight.compat.vampirism;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.compat.ModMixinPlugin;
+
+public class VampirismMixinPlugin extends ModMixinPlugin {
+    @Override
+    public @NotNull String getModId() {
+        return "vampirism";
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesMixinPlugin.java
@@ -1,0 +1,11 @@
+package yesman.epicfight.compat.werewolves;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.compat.ModMixinPlugin;
+
+public class WerewolvesMixinPlugin extends ModMixinPlugin {
+    @Override
+    public @NotNull String getModId() {
+        return "werewolves";
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesMixinPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/werewolves/WerewolvesMixinPlugin.java
@@ -3,7 +3,7 @@ package yesman.epicfight.compat.werewolves;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.compat.ModMixinPlugin;
 
-public class WerewolvesMixinPlugin extends ModMixinPlugin {
+public final class WerewolvesMixinPlugin extends ModMixinPlugin {
     @Override
     public @NotNull String getModId() {
         return "werewolves";

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -177,6 +177,10 @@ public class EpicFightMod {
         }
     	
     	EpicFightRegistries.DEFERRED_REGISTRIES.forEach(deferredRegistry -> deferredRegistry.register(modEventBus));
+
+        // TODO: Improve "ICompatModule"s registration by avoiding duplicating "ModList.get().isLoaded()".
+        //  Make sure we're not duplicating the mod ID anywhere else, like in "GeckolibMixinPlugin".
+        //  ALso, extract this in a separate function and avoid duplicating "ICompatModule.loadCompatModule" too.
 		
 		if (ModList.get().isLoaded("vampirism")) {
 			ICompatModule.loadCompatModule(modEventBus, VampirismCompat.class);

--- a/src/main/resources/epicfight-compat.geckolib.mixins.json
+++ b/src/main/resources/epicfight-compat.geckolib.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_21",
   "package": "yesman.epicfight.compat.geckolib.mixin",
+  "plugin": "yesman.epicfight.compat.geckolib.GeckolibMixinPlugin",
   "client": [
     "MixinGeoArmorRenderer"
   ],

--- a/src/main/resources/epicfight-compat.skinlayers3d.mixins.json
+++ b/src/main/resources/epicfight-compat.skinlayers3d.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_21",
   "package": "yesman.epicfight.compat.skinlayer3d.mixin",
+  "plugin": "yesman.epicfight.compat.skinlayer3d.SkinLayer3DPlugin",
   "client": [
     "MixinCustomModelPart",
     "MixinCustomizableCubeWrapper$SkinLayer3DMixinCustomModelCube"

--- a/src/main/resources/epicfight-compat.vampirism.mixins.json
+++ b/src/main/resources/epicfight-compat.vampirism.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_21",
   "package": "yesman.epicfight.compat.vampirism.mixin",
+  "plugin": "yesman.epicfight.compat.vampirism.VampirismMixinPlugin",
   "client": [
     "MixinVampirePlayerHeadLayer"
   ],

--- a/src/main/resources/epicfight-compat.werewolves.mixins.json
+++ b/src/main/resources/epicfight-compat.werewolves.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_21",
   "package": "yesman.epicfight.compat.werewolves.mixin",
+  "plugin": "yesman.epicfight.compat.werewolves.WerewolvesMixinPlugin",
   "client": [
     "MixinHumanWerewolfLayer"
   ],


### PR DESCRIPTION
Fixes #2147. This PR is a follow-up to #2169.

Avoids unnecessary mixins registration if these mods are not installed to avoid spamming the log when a mod is not installed (e.g., Werewolves):

```console
[20:25:10] [main/WARN] [mixin/]: Error loading class: de/teamlapen/werewolves/client/render/layer/HumanWerewolfLayer (java.lang.ClassNotFoundException: de.teamlapen.werewolves.client.render.layer.HumanWerewolfLayer)
[20:25:10] [main/WARN] [mixin/]: @Mixin target de.teamlapen.werewolves.client.render.layer.HumanWerewolfLayer was not found epicfight-compat.werewolves.mixins.json:MixinHumanWerewolfLayer from mod epicfight
[20:25:10] [main/DEBUG] [mixin/]: Preparing neoforge.mixins.json (2)
```

And to avoid non-trivial calls if they are not needed.

### New behavior

If the mod is installed (e.g., Werewolves):

```debug
[21:44:50] [Render thread/DEBUG] [mixin/]: Mixing MixinHumanWerewolfLayer from epicfight-compat.werewolves.mixins.json into de.teamlapen.werewolves.client.render.layer.HumanWerewolfLayer
```

If the mod is not installed, then the mixin JSON file will be silently ignored.

> [!NOTE]
> Review each commit separately for an easier review.