### PR TITLE
[1.20.1] Controlify Forgified Integration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,14 @@
   optimizing whether key down checks are performed per tick, by adapting
   Minecraft vanilla `KeyMapping`, which may also potentially fix other compatibility issues with other mods.
 
+### Added
+
+- Built-in Controlify integration for controller support.
+  No need to install
+  [Epic Fight: Controlify](https://www.curseforge.com/minecraft/mc-mods/epic-fight-controlify) anymore.
+  Install only
+  [Controlify: Forgified](https://www.curseforge.com/minecraft/mc-mods/controlify-forgified-unofficial) on 1.20.1
+
 ## [20.13.4] - 2025-11-04
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,12 @@ repositories {
             includeGroup "dev.latvian.mods"
         }
     }
+
+    exclusiveContent {
+        forRepository { maven { url "https://echoellet.github.io/Controlify/" } }
+        forRepositories(fg.repository)
+        filter { includeGroup "dev.echoellet" }
+    }
 }
 
 mixin {
@@ -170,6 +176,9 @@ dependencies {
     //compileOnly fg.deobf("curse.maven:shoulder-surfing-reloaded-243190:6993788") // Actual mod file (for test)
     
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+
+    implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
+    runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required dependency to run Controlify
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
-    implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
+    compileOnly fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
     runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required dependency to run Controlify
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,4 @@ jei_version=15.2.0.27
 kubejs_version=2001.6.5-build.16
 rhino_version=2001.2.3-build.10
 architectury_version=9.2.14
+controlify_version=2.1.7-mc1.20.1-forge

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -20,12 +20,10 @@ import dev.isxander.controlify.controller.ControllerEntity;
 import dev.isxander.controlify.screenop.ScreenProcessor;
 import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
-import dev.isxander.controlify.utils.render.CGuiPose;
 import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -41,9 +39,6 @@ import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.main.EpicFightMod;
-import yesman.epicfight.skill.SkillCategories;
-import yesman.epicfight.world.capabilities.EpicFightCapabilities;
-import yesman.epicfight.world.capabilities.item.CapabilityItem;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -72,7 +67,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         registrar.registerBindContext(COMBAT_MODE_CONTEXT);
         registerInputBindings(registrar);
         registerTargetLockOnSupport();
-        registerGuides(context.guideRegistries().inGame(), context.guideRegistries().container());
+        registerGuides();
         registerScreenProcessors();
     }
 
@@ -92,7 +87,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             EpicFightMod.rl("epicfight_combat"),
             mc -> {
                 final boolean isInGame = mc.screen == null && mc.level != null && mc.player != null;
-                return isInGame && ClientEngine.getInstance().isEpicFightMode();
+                return isInGame && ClientEngine.getInstance().isBattleMode();
             }
     );
     private static final BindContext IN_GAME_CONTEXT = BindContext.IN_GAME;
@@ -181,11 +176,11 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             // this code is equivalent to:
             // https://github.com/isXander/Controlify/blob/f5c94c57d5e0d4954e413624a0d7ead937b6e8ab/src/main/java/dev/isxander/controlify/bindings/RadialIcons.java#L106-L112
             RadialIcons.registerIcon(location, (graphics, x, y, tickDelta) -> {
-                var pose = CGuiPose.ofPush(graphics);
-                pose.translate(x, y);
-                pose.scale(0.5f, 0.5f);
-                Blit.tex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
-                pose.pop();
+                graphics.pose().pushPose();
+                graphics.pose().translate((float) x, (float) y, 0.0F);
+                graphics.pose().scale(0.5F, 0.5F, 1.0F);
+                Blit.blitTex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
+                graphics.pose().popPose();
             });
         }
     }
@@ -347,23 +342,10 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         });
     }
 
-    private static void registerGuides(GuideDomainRegistry<InGameCtx> inGameRegistry, GuideDomainRegistry<ContainerCtx> containerRegistry) {
-        // Facts are registered here; rules in "assets/controlify/guides/in_game.json" reference these facts.
-        inGameRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_perform_dodge"), ctx -> {
-            final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
-            if (localPlayerPatch == null || !localPlayerPatch.isEpicFightMode()) {
-                return false;
-            }
-            return localPlayerPatch.getPlayerSkills().hasCategory(SkillCategories.DODGE);
-        }));
-        containerRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_show_weapon_innate_skill_tooltip"), ctx -> {
-            final Slot hoveredSlot = ctx.hoveredSlot();
-            if (hoveredSlot == null || !ctx.hoveredSlot().hasItem()) {
-                return false;
-            }
-            final Optional<CapabilityItem> maybeCapabilityItem = EpicFightCapabilities.getItemCapability(hoveredSlot.getItem());
-            return maybeCapabilityItem.isPresent();
-        }));
+    private static void registerGuides() {
+        // Button guides are unsupported in "Controlify: Forgified"
+        // Since this is an official backport of an older version of Controlify.
+        // However, when using Epic Fight NeoForge 1.21.1, it's fully supported
     }
 
     private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputActions action) {

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -1,0 +1,585 @@
+package yesman.epicfight.compat.controlify;
+
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.ControlifyBindApi;
+import dev.isxander.controlify.api.bind.InputBinding;
+import dev.isxander.controlify.api.bind.InputBindingBuilder;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.buttonguide.ButtonGuideApi;
+import dev.isxander.controlify.api.buttonguide.ButtonGuidePredicate;
+import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
+import dev.isxander.controlify.api.entrypoint.InitContext;
+import dev.isxander.controlify.api.entrypoint.PreInitContext;
+import dev.isxander.controlify.api.event.ControlifyEvents;
+import dev.isxander.controlify.api.guide.*;
+import dev.isxander.controlify.bindings.BindContext;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.bindings.RadialIcons;
+import dev.isxander.controlify.bindings.input.Input;
+import dev.isxander.controlify.controller.ControllerEntity;
+import dev.isxander.controlify.screenop.ScreenProcessor;
+import dev.isxander.controlify.screenop.ScreenProcessorProvider;
+import dev.isxander.controlify.utils.render.Blit;
+import dev.isxander.controlify.utils.render.CGuiPose;
+import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.api.client.input.InputMode;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
+import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.gui.screen.SkillBookScreen;
+import yesman.epicfight.client.gui.screen.SkillEditScreen;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+import yesman.epicfight.main.EpicFightMod;
+import yesman.epicfight.skill.SkillCategories;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
+
+import java.util.Objects;
+import java.util.Optional;
+
+// Important for maintainers: Be careful when using Epic Fight classes here,
+// as the Epic Fight mod might not be loaded yet. For example, avoid referencing
+// EpicFightItems.UCHIGATANA.get() in onControlifyPreInit.
+@ApiStatus.Internal
+public class ControlifyCompat implements ControlifyEntrypoint {
+    @Override
+    public void onControllersDiscovered(ControlifyApi controlify) {
+    }
+
+    @Override
+    public void onControlifyInit(InitContext context) {
+        // It's best to call this method in onControlifyInit,
+        // ensuring that Epic Fight can use Controlify input bindings
+        // only after they have been registered.
+        registerModIntegration();
+    }
+
+    @Override
+    public void onControlifyPreInit(PreInitContext context) {
+        final ControlifyBindApi registrar = ControlifyBindApi.get();
+        registerCustomRadialIcons();
+        registrar.registerBindContext(COMBAT_MODE_CONTEXT);
+        registerInputBindings(registrar);
+        registerTargetLockOnSupport();
+        registerGuides(context.guideRegistries().inGame(), context.guideRegistries().container());
+        registerScreenProcessors();
+    }
+
+    private static InputBindingSupplier attack;
+    private static InputBindingSupplier mobility;
+    private static InputBindingSupplier guard;
+    private static InputBindingSupplier dodge;
+    private static InputBindingSupplier lockOn;
+    private static InputBindingSupplier switchMode;
+    private static InputBindingSupplier weaponInnateSkill;
+    private static InputBindingSupplier weaponInnateSkillTooltip;
+    private static InputBindingSupplier openSkillEditorScreen;
+    private static InputBindingSupplier openConfigScreen;
+    private static InputBindingSupplier switchVanillaModeDebugging;
+
+    private static final BindContext COMBAT_MODE_CONTEXT = new BindContext(
+            EpicFightMod.rl("epicfight_combat"),
+            mc -> {
+                final boolean isInGame = mc.screen == null && mc.level != null && mc.player != null;
+                return isInGame && ClientEngine.getInstance().isEpicFightMode();
+            }
+    );
+    private static final BindContext IN_GAME_CONTEXT = BindContext.IN_GAME;
+    private static final BindContext ANY_SCREEN_CONTEXT = BindContext.ANY_SCREEN;
+
+    private record TranslationKeys(@NotNull String name, @NotNull String description) {
+        private @NotNull Component getNameComponent() {
+            return Component.translatable(name());
+        }
+
+        private @NotNull Component getDescriptionComponent() {
+            return Component.translatable(description());
+        }
+
+        /**
+         * Maps a non-vanilla {@link EpicFightInputActions} to its corresponding translation keys.
+         *
+         * @param action the non-vanilla action to get the translation key for
+         * @return a {@link TranslationKeys} instance containing the translation keys for the name and description
+         * @throws IllegalArgumentException if the action is a vanilla action, since getting the translation keys in this class
+         *                                  is only relevant for Epic Fight custom input binds.
+         *                                  Vanilla input binds are handled internally by Controlify.
+         */
+        private static @NotNull TranslationKeys fromAction(@NotNull EpicFightInputActions action) {
+            return switch (action) {
+                case ATTACK -> new TranslationKeys("key.epicfight.attack", "key.epicfight.attack.description");
+                case DODGE -> new TranslationKeys("key.epicfight.dodge", "key.epicfight.dodge.description");
+                case GUARD -> new TranslationKeys("key.epicfight.guard", "key.epicfight.guard.description");
+                case LOCK_ON -> new TranslationKeys("key.epicfight.lock_on", "key.epicfight.lock_on.description");
+                case SWITCH_MODE ->
+                        new TranslationKeys("key.epicfight.switch_mode", "key.epicfight.switch_mode.description");
+                case WEAPON_INNATE_SKILL ->
+                        new TranslationKeys("key.epicfight.weapon_innate_skill", "key.epicfight.weapon_innate_skill.description");
+                case WEAPON_INNATE_SKILL_TOOLTIP ->
+                        new TranslationKeys("key.epicfight.show_tooltip", "key.epicfight.show_tooltip.description");
+                case OPEN_SKILL_SCREEN ->
+                        new TranslationKeys("key.epicfight.skill_gui", "key.epicfight.skill_gui.description");
+                case OPEN_CONFIG_SCREEN ->
+                        new TranslationKeys("key.epicfight.config", "key.epicfight.config.description");
+                case SWITCH_VANILLA_MODEL_DEBUGGING ->
+                        new TranslationKeys("key.epicfight.switch_vanilla_model_debug", "key.epicfight.switch_vanilla_model_debug.description");
+                case MOBILITY ->
+                        new TranslationKeys("key.epicfight.mover_skill", "key.epicfight.mover_skill.description");
+
+                // Vanilla actions translations already handled by Controlify.
+                case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, DROP, TOGGLE_PERSPECTIVE, JUMP,
+                     MOVE_FORWARD, MOVE_BACKWARD, MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK ->
+                        throw new IllegalArgumentException(
+                                "TranslationKeys#fromAction() must only be called for non-vanilla actions. " +
+                                        "This action is vanilla and already registered by Controlify: " + action.name()
+                        );
+            };
+        }
+
+        private static @NotNull Component getNameOf(@NotNull EpicFightInputActions action) {
+            return fromAction(action).getNameComponent();
+        }
+    }
+
+    private static class EpicFightInputCategories {
+        private static final Component COMBAT = Component.translatable("key.epicfight.combat");
+        private static final Component GUI = Component.translatable("key.epicfight.gui");
+        private static final Component SYSTEM = Component.translatable("key.epicfight.system");
+    }
+
+    private enum EpicFightRadialIcons {
+        UCHIGATANA(EpicFightMod.rl("textures/item/uchigatana_gui.png")),
+        SKILL_BOOK(EpicFightMod.rl("textures/item/skillbook.png"));
+
+        private final @NotNull ResourceLocation id;
+
+        EpicFightRadialIcons(@NotNull ResourceLocation id) {
+            this.id = id;
+        }
+
+        public @NotNull ResourceLocation getId() {
+            return id;
+        }
+    }
+
+    private static void registerCustomRadialIcons() {
+        for (EpicFightRadialIcons icon : EpicFightRadialIcons.values()) {
+            final ResourceLocation location = icon.getId();
+
+            // For consistency with the current Controlify radial icons,
+            // this code is equivalent to:
+            // https://github.com/isXander/Controlify/blob/f5c94c57d5e0d4954e413624a0d7ead937b6e8ab/src/main/java/dev/isxander/controlify/bindings/RadialIcons.java#L106-L112
+            RadialIcons.registerIcon(location, (graphics, x, y, tickDelta) -> {
+                var pose = CGuiPose.ofPush(graphics);
+                pose.translate(x, y);
+                pose.scale(0.5f, 0.5f);
+                Blit.tex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
+                pose.pop();
+            });
+        }
+    }
+
+    private static void registerInputBindings(ControlifyBindApi registrar) {
+        for (EpicFightInputActions action : EpicFightInputActions.nonVanillaActions()) {
+            registerInputBinding(registrar, action);
+        }
+    }
+
+    /**
+     * Registers a non-vanilla input binding with Controlify.
+     * <p>
+     * Must <strong>only</strong> be called for non-vanilla
+     * {@link EpicFightInputActions}. Vanilla actions are already registered
+     * and calling this with one will throw {@link IllegalArgumentException}.
+     * <p>
+     * <strong>Type-safety and exhaustive checking:</strong><br>
+     * Returns an {@link InputBindingSupplier} via a <em>switch expression</em>
+     * over all enum constants. The returned value is a dummy, used only
+     * to satisfy the Java compiler and enforce exhaustive handling. It is
+     * <strong>never used</strong> and has no effect on behavior.
+     *
+     * @param registrar the Controlify API used to register the binding
+     * @param action    the non-vanilla input action to register
+     * @return a dummy {@link InputBindingSupplier} for type-safety only
+     * @throws IllegalArgumentException if called with a vanilla input action
+     */
+    @SuppressWarnings("UnusedReturnValue") // Read Javadocs of this method before removing.
+    private static @NotNull InputBindingSupplier registerInputBinding(
+            @NotNull ControlifyBindApi registrar,
+            @NotNull EpicFightInputActions action
+    ) {
+        final Component combatCategory = EpicFightInputCategories.COMBAT;
+        final Component guiCategory = EpicFightInputCategories.GUI;
+        final Component systemCategory = EpicFightInputCategories.SYSTEM;
+
+        // Using a switch expression to enforce compile-time exhaustive checking.
+        // The returned value is a dummy and does nothing; its only purpose is to
+        // satisfy the compiler and ensure all enum constants are handled.
+        return switch (action) {
+            case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
+                 MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
+                    "ControlifyCompat#registerInputBinding() must only be called for non-vanilla actions. " +
+                            "This action is vanilla and already registered by Controlify: " + action.name()
+            );
+            case ATTACK -> attack = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case MOBILITY -> mobility = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case GUARD -> guard = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case DODGE -> dodge = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case LOCK_ON -> lockOn = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case SWITCH_MODE -> switchMode = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(systemCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .radialCandidate(EpicFightRadialIcons.UCHIGATANA.getId())
+            );
+            case WEAPON_INNATE_SKILL -> weaponInnateSkill = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(combatCategory)
+                            .allowedContexts(COMBAT_MODE_CONTEXT)
+            );
+            case WEAPON_INNATE_SKILL_TOOLTIP -> weaponInnateSkillTooltip = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(guiCategory)
+                            .allowedContexts(ANY_SCREEN_CONTEXT)
+            );
+            case OPEN_SKILL_SCREEN -> openSkillEditorScreen = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(guiCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .radialCandidate(EpicFightRadialIcons.SKILL_BOOK.getId())
+            );
+            case OPEN_CONFIG_SCREEN -> openConfigScreen = registrar.registerBinding(
+                    builder -> applyCommonBindingProperties(action, builder)
+                            .category(guiCategory)
+                            .allowedContexts(IN_GAME_CONTEXT)
+                            .radialCandidate(RadialIcons.getItem(Items.REDSTONE))
+            );
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging = registrar.registerBinding(
+                    builder ->
+                            applyCommonBindingProperties(action, builder)
+                                    .category(systemCategory)
+                                    .allowedContexts(IN_GAME_CONTEXT)
+            );
+        };
+    }
+
+    private static @NotNull InputBindingBuilder applyCommonBindingProperties(
+            @NotNull EpicFightInputActions action,
+            @NotNull InputBindingBuilder builder
+    ) {
+        final TranslationKeys translationKeys = TranslationKeys.fromAction(action);
+        final KeyMapping keyMappingToIgnore = action.keyMapping();
+        return builder
+                .id(getBindingId(action))
+                .name(translationKeys.getNameComponent())
+                .description(translationKeys.getDescriptionComponent())
+                // Prevents Controlify from auto-registering controller bindings for Epic Fight's
+                // vanilla key mappings, since Epic Fight already provides explicit native support.
+                .addKeyCorrelation(keyMappingToIgnore);
+    }
+
+    private static @NotNull ResourceLocation getBindingId(@NotNull EpicFightInputActions action) {
+        final String path = switch (action) {
+            // Project maintainers: if you change any ID (e.g., "attack"), update assets/controlify too.
+            case ATTACK -> "attack";
+            case MOBILITY -> "mobility";
+            case GUARD -> "guard";
+            case DODGE -> "dodge";
+            case LOCK_ON -> "lock_on";
+            case SWITCH_MODE -> "switch_mode";
+            case WEAPON_INNATE_SKILL -> "weapon_innate_skill";
+            case WEAPON_INNATE_SKILL_TOOLTIP -> "weapon_innate_skill_tooltip";
+            case OPEN_SKILL_SCREEN -> "open_skill_editor_screen";
+            case OPEN_CONFIG_SCREEN -> "open_config_screen";
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> "switch_vanilla_mode_debugging";
+            case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
+                 MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
+                    "ControlifyCompat#getInputBindingId() must only be called for non-vanilla actions. " +
+                            "This action is vanilla and already registered by Controlify: " + action.name()
+            );
+        };
+        return EpicFightMod.rl(path);
+    }
+
+    private static void registerModIntegration() {
+        EpicFightControllerModProvider.set(EpicFightMod.MODID, new ControlifyIntegration());
+    }
+
+    private static void registerTargetLockOnSupport() {
+        ControlifyEvents.LOOK_INPUT_MODIFIER.register(event -> {
+            LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+
+            if (localPlayerPatch != null && localPlayerPatch.isTargetLockedOn()) {
+                // Fixes a minor issue when locking on an enemy.
+                event.lookInput().zero();
+            }
+        });
+    }
+
+    private static void registerGuides(GuideDomainRegistry<InGameCtx> inGameRegistry, GuideDomainRegistry<ContainerCtx> containerRegistry) {
+        // Facts are registered here; rules in "assets/controlify/guides/in_game.json" reference these facts.
+        inGameRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_perform_dodge"), ctx -> {
+            final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+            if (localPlayerPatch == null || !localPlayerPatch.isEpicFightMode()) {
+                return false;
+            }
+            return localPlayerPatch.getPlayerSkills().hasCategory(SkillCategories.DODGE);
+        }));
+        containerRegistry.registerFact(new Fact<>(EpicFightMod.rl("can_show_weapon_innate_skill_tooltip"), ctx -> {
+            final Slot hoveredSlot = ctx.hoveredSlot();
+            if (hoveredSlot == null || !ctx.hoveredSlot().hasItem()) {
+                return false;
+            }
+            final Optional<CapabilityItem> maybeCapabilityItem = EpicFightCapabilities.getItemCapability(hoveredSlot.getItem());
+            return maybeCapabilityItem.isPresent();
+        }));
+    }
+
+    private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputActions action) {
+        final InputBindingSupplier bindingSupplier = switch (action) {
+            // Minecraft Vanilla actions
+            case VANILLA_ATTACK_DESTROY -> ControlifyBindings.ATTACK;
+            case MOVE_FORWARD -> ControlifyBindings.WALK_FORWARD;
+            case MOVE_BACKWARD -> ControlifyBindings.WALK_BACKWARD;
+            case MOVE_LEFT -> ControlifyBindings.WALK_LEFT;
+            case MOVE_RIGHT -> ControlifyBindings.WALK_RIGHT;
+            case SPRINT -> ControlifyBindings.SPRINT;
+            case SNEAK -> ControlifyBindings.SNEAK;
+            case USE -> ControlifyBindings.USE;
+            case SWAP_OFF_HAND -> ControlifyBindings.SWAP_HANDS;
+            case DROP -> ControlifyBindings.DROP_INGAME;
+            case TOGGLE_PERSPECTIVE -> ControlifyBindings.CHANGE_PERSPECTIVE;
+            case JUMP -> ControlifyBindings.JUMP;
+            // Epic Fight custom actions
+            case ATTACK -> attack;
+            case MOBILITY -> mobility;
+            case GUARD -> guard;
+            case DODGE -> dodge;
+            case LOCK_ON -> lockOn;
+            case SWITCH_MODE -> switchMode;
+            case WEAPON_INNATE_SKILL -> weaponInnateSkill;
+            case WEAPON_INNATE_SKILL_TOOLTIP -> weaponInnateSkillTooltip;
+            case OPEN_SKILL_SCREEN -> openSkillEditorScreen;
+            case OPEN_CONFIG_SCREEN -> openConfigScreen;
+            case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging;
+        };
+        final @Nullable InputBinding binding = bindingSupplier.onOrNull(requireControllerEntity());
+        return Objects.requireNonNull(binding, "The binding for the action " + action.name() + " is not yet registered.");
+    }
+
+    private static @NotNull ControlifyApi getApi() {
+        return ControlifyApi.get();
+    }
+
+    private static @NotNull ControllerEntity requireControllerEntity() {
+        Optional<ControllerEntity> optionalControllerEntity = getApi().getCurrentController();
+
+        if (optionalControllerEntity.isEmpty()) {
+            final String message = String.format(
+                    "The method IEpicFightControllerMod#getInputState must not be called when the input mode is not %s",
+                    InputMode.CONTROLLER.name()
+            );
+            EpicFightMod.LOGGER.error(message);
+            throw new IllegalStateException(message);
+        }
+
+        return optionalControllerEntity.get();
+    }
+
+    /**
+     * Allows Epic Fight to communicate with Controlify APIs without depending on their classes directly.
+     */
+    private static class ControlifyIntegration implements IEpicFightControllerMod {
+        @Override
+        public String getModName() {
+            return "Controlify";
+        }
+
+        @Override
+        public @NotNull InputMode getInputMode() {
+            return switch (getApi().currentInputMode()) {
+                case KEYBOARD_MOUSE -> InputMode.KEYBOARD_MOUSE;
+                case CONTROLLER -> InputMode.CONTROLLER;
+                case MIXED -> InputMode.MIXED;
+            };
+        }
+
+        @Override
+        public @NotNull ControllerBinding getBinding(EpicFightInputActions action) {
+            return new ControllerBindingImpl(getControlifyBinding(action));
+        }
+
+        @Override
+        public @NotNull PlayerInputState getInputState() {
+            ControllerEntity controller = requireControllerEntity();
+
+            InputBinding forwardBind = ControlifyBindings.WALK_FORWARD.on(controller);
+            InputBinding backwardBind = ControlifyBindings.WALK_BACKWARD.on(controller);
+            InputBinding leftBind = ControlifyBindings.WALK_LEFT.on(controller);
+            InputBinding rightBind = ControlifyBindings.WALK_RIGHT.on(controller);
+            InputBinding jumpBind = ControlifyBindings.JUMP.on(controller);
+            InputBinding sneakBind = ControlifyBindings.SNEAK.on(controller);
+
+            float forwardImpulse = forwardBind.analogueNow() - backwardBind.analogueNow();
+            float leftImpulse = leftBind.analogueNow() - rightBind.analogueNow();
+
+            return new PlayerInputState(
+                    leftImpulse, forwardImpulse,
+                    forwardBind.digitalNow(), backwardBind.digitalNow(),
+                    leftBind.digitalNow(), rightBind.digitalNow(),
+                    jumpBind.digitalNow(), sneakBind.digitalNow()
+            );
+        }
+
+        @Override
+        public boolean isBoundToSameButton(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2) {
+            final Input input1 = getControlifyBinding(action).boundInput();
+            final Input input2 = getControlifyBinding(action2).boundInput();
+            return input1.getRelevantInputs().equals(input2.getRelevantInputs());
+        }
+    }
+
+    private record ControllerBindingImpl(@NotNull InputBinding inputBinding) implements ControllerBinding {
+
+        @Override
+        public ResourceLocation id() {
+            return inputBinding.id();
+        }
+
+        @Override
+        public @NotNull InputType getInputType() {
+            if (inputBinding.boundInput().type() == dev.isxander.controlify.bindings.input.InputType.AXIS) {
+                return InputType.ANALOGUE;
+            }
+            EpicFightMod.LOGGER.error("The method ControllerBinding#getInputType is misleading and should not be called as it will be removed in future updates.");
+            return InputType.DIGITAL;
+        }
+
+        @Override
+        public boolean isDigitalActiveNow() {
+            return inputBinding.digitalNow();
+        }
+
+        @Override
+        public boolean wasDigitalActivePreviously() {
+            return inputBinding.digitalPrev();
+        }
+
+        @Override
+        public boolean isDigitalJustPressed() {
+            return inputBinding.justPressed();
+        }
+
+        @Override
+        public boolean isDigitalJustReleased() {
+            return inputBinding.justReleased();
+        }
+
+        @Override
+        public float getAnalogueNow() {
+            return inputBinding.analogueNow();
+        }
+
+        @Override
+        public void emulatePress() {
+            inputBinding.fakePress();
+        }
+    }
+
+    private static void registerScreenProcessors() {
+        ScreenProcessorProvider.registerProvider(
+                SkillEditScreen.class,
+                SkillEditScreenProcessor::new
+        );
+        ScreenProcessorProvider.registerProvider(
+                SkillBookScreen.class,
+                SkillBookScreenProcessor::new
+        );
+    }
+
+    private static class SkillEditScreenProcessor extends ScreenProcessor<SkillEditScreen> {
+        public SkillEditScreenProcessor(SkillEditScreen screen) {
+            super(screen);
+        }
+
+        @Override
+        public VirtualMouseBehaviour virtualMouseBehaviour() {
+            // The skill edit screen does not natively support controllers.
+            // To save development time, we work around this issue by enforcing the virtual mouse.
+            return VirtualMouseBehaviour.ENABLED;
+        }
+    }
+
+    private static class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {
+        public SkillBookScreenProcessor(SkillBookScreen screen) {
+            super(screen);
+        }
+
+        private static final InputBindingSupplier LEARN_SKILL = ControlifyBindings.GUI_PRESS;
+
+        @Override
+        protected void handleButtons(ControllerEntity controller) {
+            if (LEARN_SKILL.on(controller).guiPressed().get()) {
+                screen.getLearnButton().onPress();
+                playClackSound();
+            }
+            super.handleButtons(controller);
+        }
+
+        // The Skill Book screen has a single actionable button (the "learn skill" button).
+        // Controller navigation and focus are disabled, and only the primary controller
+        // button (e.g., X on DualSense) is used to trigger the action.
+
+        @Override
+        protected void setInitialFocus() {
+            // Intentionally empty. Do NOT call super.setInitialFocus().
+        }
+
+        @Override
+        protected void handleComponentNavigation(ControllerEntity controller) {
+            // Intentionally empty. Do NOT call super.handleComponentNavigation().
+        }
+
+        @Override
+        public void onWidgetRebuild() {
+            super.onWidgetRebuild();
+
+            ButtonGuideApi.addGuideToButton(
+                    this.screen.getLearnButton(),
+                    LEARN_SKILL,
+                    ButtonGuidePredicate.always()
+            );
+        }
+    }
+}

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -32,6 +33,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -385,4 +387,8 @@ public class EpicFightMod {
 			event.accept(stack);
 		});
 	}
+
+    public static @NotNull ResourceLocation rl(@NotNull String path) {
+        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
 }

--- a/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
+++ b/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
@@ -1,0 +1,1 @@
+yesman.epicfight.compat.controlify.ControlifyCompat

--- a/src/main/resources/assets/controlify/controllers/default_bind/default.json
+++ b/src/main/resources/assets/controlify/controllers/default_bind/default.json
@@ -1,0 +1,25 @@
+{
+  "defaults": {
+    "epicfight:attack": {
+      "axis": "controlify:axis/right_trigger"
+    },
+    "epicfight:weapon_innate_skill": {
+      "axis": "controlify:axis/right_trigger"
+    },
+    "epicfight:weapon_innate_skill_tooltip": {
+      "axis": "controlify:axis/left_trigger"
+    },
+    "epicfight:mobility": {
+      "button": "controlify:button/south"
+    },
+    "epicfight:guard": {
+      "axis": "controlify:axis/left_trigger"
+    },
+    "epicfight:dodge": {
+      "button": "controlify:button/east"
+    },
+    "epicfight:lock_on": {
+      "button": "controlify:button/left_stick"
+    }
+  }
+}

--- a/src/main/resources/assets/epicfight/lang/en_us.json
+++ b/src/main/resources/assets/epicfight/lang/en_us.json
@@ -11,17 +11,17 @@
 	"attribute.name.epicfight.offhand_impact": "Offhand Impact",
 	"attribute.name.epicfight.offhand_armor_negation": "Offhand Armor Negation",
 	"attribute.name.epicfight.offhand_max_strikes": "Offhand Max Strikes",
-	
+
 	"attribute.name.epicfight.impact.value": "%s Impact",
 	"attribute.name.epicfight.armor_negation.value": "%s%% Armor Negation",
 	"attribute.name.epicfight.max_strikes.value": "Hit %s Enemies per Swing",
-	
+
 	"attribute.name.generic.max_health.skillbook_tooltip": "Increases player's max health",
 	"attribute.name.generic.attack_damage.skillbook_tooltip": "Increases player's attack damage",
 	"attribute.name.generic.attack_speed.skillbook_tooltip": "Increases player's attack speed",
 	"attribute.name.epicfight.staminar.skillbook_tooltip": "Increases player's max stamina",
 	"attribute.name.epicfight.stamina_regen.skillbook_tooltip": "Reduces the amount of time taken for stamina to regen",
-	
+
 	"attribute.name.epicfight.stamina.consume": "%s Stamina",
 	"attribute.name.epicfight.stamina_current_ratio.consume": "%s%% of current stamina",
 	"attribute.name.epicfight.stamina_per_second.consume": "%s per second",
@@ -30,7 +30,7 @@
 	"attribute.name.epicfight.cooldown.consume.tooltip": "A cooldown time to activate a skill again",
 	"attribute.name.epicfight.health.consume": "%s Health",
 	"attribute.name.epicfight.health.consume.tooltip": "Requires an indicated amount of health to execute",
-	
+
 	"commands.epicfight.skill.add.success.single": "Added skill %s to %s",
 	"commands.epicfight.skill.add.success.multiple": "Added skill %s to %s targets",
 	"commands.epicfight.skill.add.failed": "Unable to add this skill (skill already applied)",
@@ -40,21 +40,21 @@
 	"commands.epicfight.skill.clear.success.single": "Removed all skills from %s",
 	"commands.epicfight.skill.clear.success.multiple": "Removed all skills from %s targets",
 	"commands.epicfight.skill.clear.failed": "Target has no skills to remove",
-	
+
 	"commands.epicfight.stamina.success.self": "Successfully Modified %s's stamina to %s",
 	"commands.epicfight.stamina.success.other": "Successfully Modified stamina from %s targets",
 	"commands.epicfight.stamina.success.failed": "Failed at modifying stamina",
-	
+
 	"commands.epicfight.stamina.value.get.success": "Value of stamina for player %s is %s",
 	"commands.epicfight.stamina.failed.no_stamina": "Player %s has no stamina",
-	
+
 	"death.attack.wither_beam": "%1$s was vaporized by wither beam",
 	"death.attack.shockwave": "%1$s was teared up by Shockwave",
 	"debug.vanilla_model_debugging.on": "Vanilla model debugging: On",
 	"debug.vanilla_model_debugging.off": "Vanilla model debugging: Off",
 	"debug.show_epicfight_tooltip.on": "Show Epic Fight Tooltip: On",
 	"debug.show_epicfight_tooltip.off": "Show Epic Fight Tooltip: Off",
-	
+
 	"damage_source.epicfight.damage": "%s damage",
 	"damage_source.epicfight.target_lost_health": " + %s of the target lost health",
 	"damage_source.epicfight.sweeping_edge_enchant_level": " + %s (sweeping Edge %s lv)",
@@ -64,15 +64,15 @@
 	"damage_source.epicfight.stun_hold": "§cHOLD §8targets",
 	"damage_source.epicfight.stun_knockdown": "§cKNOCKDOWN §8targets",
 	"damage_source.epicfight.stun_neutralize": "",
-	
+
 	"effect.epicfight.stun_immunity": "Stun Immunity",
 	"effect.epicfight.blooming": "Blooming",
 	"effect.epicfight.instability": "Instability",
-	
+
 	"entity.epicfight.wither_skeleton_minion": "Wither's Minion",
 	"entity.epicfight.wither_ghost": "Wither Ghost",
 	"entity.epicfight.area_effect_breath": "Dragon Breath",
-	
+
 	"epicfight.gui.configuration.item_preferences": "Item Preferences",
 	"epicfight.gui.combat_perferred": "Combat Preferred",
 	"epicfight.gui.combat_perferred.tooltip": "Items categorized here will play attack animations if you target any entity",
@@ -83,10 +83,10 @@
 	"epicfight.gui.tooltip_battle": "All items with epic fight attributes will automatically be registered.",
 	"epicfight.gui.tooltip_mining": "All items excluded from battle mode will automatically be registered.",
 	"epicfight.gui.attribute": "Epic Fight Attributes:",
-	
+
 	"epicfight.skillNotFound": "Unknown skill: %s",
 	"epicfight.animationNotFound": "Unknown animation name: %s",
-	
+
 	"epicfight.weapon_category.not_weapon": "Not Weapon",
 	"epicfight.weapon_category.axe": "Axe",
 	"epicfight.weapon_category.fist": "Fist",
@@ -103,11 +103,11 @@
 	"epicfight.weapon_category.dagger": "Dagger",
 	"epicfight.weapon_category.shield": "Shield",
 	"epicfight.weapon_category.ranged": "Ranged",
-	
+
 	"epicfight.skill_category.dodge": "Dodge",
 	"epicfight.skill_category.passive": "Passive",
 	"epicfight.skill_category.guard": "Guard",
-	
+
 	"epicfight.skill_slot.dodge": "Dodge",
 	"epicfight.skill_slot.passive1": "Passive 1",
 	"epicfight.skill_slot.passive2": "Passive 2",
@@ -115,21 +115,21 @@
 	"epicfight.skill_slot.guard": "Guard",
 	"epicfight.skill_slot.identity": "Identity",
 	"epicfight.skill_slot.mover": "Mobility",
-	
+
 	"epicfight.style.one_hand": "One Handed",
 	"epicfight.style.two_hand": "Two Handed",
 	"epicfight.style.mount": "Mount",
 	"epicfight.style.ranged": "Ranged",
 	"epicfight.style.sheath": "Sheathed",
 	"epicfight.style.ochs": "Guard Stance",
-	
+
 	"epicfight.skill_slot.passive1": "Passive 1",
 	"epicfight.skill_slot.passive2": "Passive 2",
 	"epicfight.skill_slot.passive3": "Passive 3",
 	"epicfight.skill_slot.guard": "Guard",
 	"epicfight.skill_slot.identity": "Identity",
 	"epicfight.skill_slot.mover": "Mobility",
-	
+
 	"entity.weapon.whoosh": "Whoosh",
 	"entity.weapon.whoosh_small": "Small whoosh",
 	"entity.weapon.whoosh_hard": "Big whoosh",
@@ -159,10 +159,10 @@
 	"skill.roll": "Rolling",
 	"skill.tumble": "Tumbling",
 	"skill.forbidden_strength": "Forbidden magic casting",
-	
+
 	"gameMode.epicfight.vanilla": "Vanilla",
 	"gameMode.epicfight.epicfight": "EpicFight",
-	
+
 	"gamerule.doVanillaAttack": "Enable vanilla attack",
 	"gamerule.hasFallAnimation": "Enable landing animation",
 	"gamerule.keepSkills": "Keep skills after death",
@@ -177,20 +177,20 @@
 	"gamerule.epicDrop": "Enable the fancy drop effect of the boss loots",
 	"gamerule.skillReplaceCooldown": "Skill replace cooldown",
 	"gamerule.skillReplaceCooldown.description": "Cooldown ticks to replace skills again",
-	
+
 	"gui.epicfight.configurations": "Epic Fight Configurations",
 	"gui.epicfight.graphic_options": "Epic Fight Graphics",
 	"gui.epicfight.control_options": "Epic Fight Controls",
-	
+
 	"gui.epicfight.skill_tree": "Skill Tree",
-	
+
 	"gui.epicfight.health_bar_show_option.none": "Health Bar Show Option: None",
 	"gui.epicfight.health_bar_show_option.hurt": "Health Bar Show Option: Hurt",
 	"gui.epicfight.health_bar_show_option.target": "Health Bar Show Option: Target",
 	"gui.epicfight.health_bar_show_option.target_and_hurt": "Health Bar Show Option: Target and Hurt",
 	"gui.epicfight.target_indicator.on": "Show Target Indicator: ON",
 	"gui.epicfight.target_indicator.off": "Show Target Indicator: OFF",
-	
+
 	"gui.epicfight.ui_setup": "Ingame UI Setup",
 	"gui.epicfight.ui_setup.tooltip": "Open UI setup screen",
 	"gui.epicfight.aim_helper.on": "Show Aim Helper: ON",
@@ -265,41 +265,41 @@
 	"gui.epicfight.changing_cost": "Cost: %d",
 	"gui.epicfight.no_skills": "You have not learned any skills yet! You can learn skills by acquiring skill books from looting mobs and chests.",
 	"gui.epicfight.select_slot_tooltip": "Choose a slot to replace the skill",
-	
+
 	"gui.epicfight.save": "Save",
 	"gui.epicfight.export": "Export",
 	"gui.epicfight.find_weapon": "Find Weapons",
-	
+
 	"gui.epicfight.button.graphics": "Graphics",
 	"gui.epicfight.button.controls": "Controls",
 	"gui.epicfight.button.datapack_edit": "Datapack Editor",
-	
+
 	"gui.epicfight.tab.datapack.weapon_type": "Weapon Type",
 	"gui.epicfight.tab.datapack.item_capability": "Item Capability",
 	"gui.epicfight.tab.datapack.mob_patch": "Mob Capability",
-	
+
 	"gui.epicfight.select": "%s List",
 	"gui.epicfight.available_weapon_types": "Available Weapon Types",
-	
+
 	"gui.epicfight.warn.no_target": "No targeted entity",
 	"gui.epicfight.warn.animation_unsync": "Below animations are missing or don't exist in the server\n\n%s\nPlease check the resource packs that you're missing or unload the packs that the server doesn't have",
 	"gui.epicfight.warn.animation_unsync.etc": "... and %d other animations",
-	
+
 	"gui.epicskins.skin_config": "Skin Configuration",
 	"gui.epicskins.button.skin_configuration": "Skin Configuration",
 	"gui.epicskins.button.save": "Save",
 	"gui.epicskins.button.quit": "Quit",
 	"gui.epicskins.button.delete_account": "Delete Account",
 	"gui.epicskins.button.back": "Back",
-	
+
 	"gui.epicskins.avatar.cape_type": "Cape Type",
 	"gui.epicskins.avatar.cape_color": "Cape Color",
 	"gui.epicskins.avatar.vanilla_texture": "Vanilla Texture",
-	
+
 	"gui.epicskins.avatar.cape_type.tooltip": "Select a cape type",
 	"gui.epicskins.avatar.cape_color.tooltip": "Set a color of cape",
 	"gui.epicskins.avatar.vanilla_texture.tooltip": "Check if you want to use vanilla cape texture",
-	
+
 	"item.epicfight.bokken": "Bokken",
 	"item.epicfight.uchigatana": "Uchigatana",
 	"item.epicfight.stray_hat": "Stray Hat",
@@ -337,21 +337,21 @@
 	"item.epicfight.netherite_dagger": "Netherite Dagger",
 	"item.epicfight.skillbook": "Skill Book",
 	"item.epicfight.glove": "Glove",
-	
+
 	"item.minecraft.potion.effect.blooming": "Blooming",
 	"item.minecraft.splash_potion.effect.blooming": "Splash potion of Blooming",
 	"item.minecraft.lingering_potion.effect.blooming": "Lingering potion of Blooming",
 	"item.minecraft.tipped_arrow.effect.blooming": "Arrow of Blooming",
-	
+
 	"item.epicfight.uchigatana.tooltip": "Sheathe Uchigatana after 5 seconds of inactivity and your next attack will be empowered.",
 	"itemGroup.epicfight.items": "EpicFight Items",
-	
+
 	"inventory.epicfight.guide_innate_tooltip": "[%s] to see Innate skill",
-	
+
 	"key.epicfight.combat": "Epic Fight Combat",
 	"key.epicfight.gui": "Epic Fight GUI",
 	"key.epicfight.system": "Epic Fight System",
-	
+
 	"key.epicfight.show_tooltip": "Show Weapon Innate Skill Tooltip",
 	"key.epicfight.switch_mode": "Toggle Battle/Mining Mode",
 	"key.epicfight.attack": "Attack",
@@ -363,7 +363,19 @@
 	"key.epicfight.mover_skill": "Mobility Skill",
 	"key.epicfight.config": "Open Configuration Screen",
 	"key.epicfight.switch_vanilla_model_debug": "Switch Vanilla Model Debugging",
-	
+
+  "key.epicfight.show_tooltip.description": "Displays the tooltip of your weapon's innate skill when the inventory screen is open",
+  "key.epicfight.switch_mode.description": "Switches between combat and mining modes",
+  "key.epicfight.attack.description": "Performs a basic attack with your equipped weapon",
+  "key.epicfight.weapon_innate_skill.description": "Activates the innate skill of your equipped weapon",
+  "key.epicfight.skill_gui.description": "Opens the skill editor GUI to customize your skills",
+  "key.epicfight.dodge.description": "Performs a dodge maneuver to avoid attacks",
+  "key.epicfight.guard.description": "Blocks incoming attacks with your weapon",
+  "key.epicfight.lock_on.description": "Locks onto the nearest target for easier combat",
+  "key.epicfight.mover_skill.description": "Uses a skill that enhances movement or mobility",
+  "key.epicfight.config.description": "Opens the mod configuration screen",
+  "key.epicfight.switch_vanilla_model_debug.description": "Toggles debugging for vanilla player models",
+
 	"skill.epicfight.dancing_edge": "Dancing Edge",
 	"skill.epicfight.dancing_edge.tooltip": "Cut down enemies with a lethal flourish! It strikes 3 times",
 	"skill.epicfight.battojutsu": "Battojutsu",
@@ -451,20 +463,20 @@
 	"skill.epicfight.guard.category": "Guard",
 	"skill.epicfight.identity.category": "Identity",
 	"skill.epicfight.mover.category": "Mobility",
-	
+
 	"skill_tree.epicfight.battleborn": "Battleborn",
-	
+
 	"painting.epicfight.epicfight_logo.title": "The martial Herobrine",
 	"painting.epicfight.epicfight_logo.author": "Gui Brabo",
-	
+
 	"pack.epicfight_legacy.title": "Epic Fight Legacy",
-	
+
 	"tag.damage_type.epicfight.is_melee": "Melee",
 	"tag.damage_type.minecraft.is_projectile": "Projectile",
 	"tag.damage_type.minecraft.is_fire": "Fire",
 	"tag.damage_type.epicfight.is_magic": "Magic",
 	"tag.damage_type.minecraft.is_explosion": "Explosion",
-	
+
 	"epicfight.tip.weight": "Weight shortens stun, raises skill stamina use, and slows attack speed, especially on fast items.",
 	"epicfight.tip.stun_armor": "Stun Armor extends the time between stuns, boosting overall resilience and defense.",
 	"epicfight.tip.knockback": "The Knockback enchantment functions to amplify the stun duration upon impact.",
@@ -481,12 +493,12 @@
 	"epicfight.tip.combat_mode": "Switch between mining and combat modes by pressing it's default key, 'R'.",
 	"epicfight.tip.weapon_charge": "Your weapon will be charged up when you strike entities. You can use weapon innate skill when weapon charge is full",
 	"epicfight.tip.weapon_innate": "Each weapon has its innate skill. You can execute a skill with a weapon innate keybind",
-	
+
 	"datapack_edit.model_player.collider": "Collider",
 	"datapack_edit.model_player.item": "Item",
 	"datapack_edit.model_player.trail": "Trail",
 	"datapack_edit.model_player.trail.tooltip": "Defines a trail effect information of an animation.",
-	
+
 	"datapack_edit.import_animation": "Import Animation",
 	"datapack_edit.import_animation.place_tooltip": "Drag & drop the animation files you want to import here.",
 	"datapack_edit.import_animation.type": "Type",
@@ -528,12 +540,12 @@
 	"datapack_edit.import_animation.client_data.end_time.tooltip": "Defines an end time of a trail effect in an animation time",
 	"datapack_edit.import_animation.client_data.joint": "Joint",
 	"datapack_edit.import_animation.client_data.joint.tooltip": "Defines a parent joint of a trail effect",
-	
+
 	"datapack_edit.import_model": "Import Model",
 	"datapack_edit.import_model.meshes": "Meshes",
 	"datapack_edit.import_model.armatures": "Armatures",
 	"datapack_edit.export_with_exceptions": "Export Anyway!",
-	
+
 	"datapack_edit.collider": "Collider",
 	"datapack_edit.collider.tooltip": "Defines a collider of a weapon. Get from the collider registry or define a custom one\n(mandatory)",
 	"datapack_edit.item_capability.collider.tooltip": "Defines a collider of a weapon. Will apply a collider from a weapon type if this is empty\n(optional)",
@@ -543,12 +555,12 @@
 	"datapack_edit.collider.center.tooltip": "Center location of a collider\n(mandatory)",
 	"datapack_edit.collider.size": "Size",
 	"datapack_edit.collider.size.tooltip": "Size of a collider (Only positive values are allowed)\n(mandatory)",
-	
+
 	"datapack_edit.style": "Style",
 	"datapack_edit.styles": "Styles",
 	"datapack_edit.styles.tooltip.mandatory": "Styles of a weapon\n(mandatory)",
 	"datapack_edit.styles.tooltip.optional": "Styles of a weapon\n(optional)",
-	
+
 	"datapack_edit.weapon_type.category": "Category",
 	"datapack_edit.weapon_type.category.tooltip": "Defines a weapon category\n(mandatory)",
 	"datapack_edit.weapon_type.hit_particle": "Hit Particle",
@@ -571,21 +583,21 @@
 	"datapack_edit.weapon_type.living_animations.tooltip": "Defines living animations overrided by a weapon",
 	"datapack_edit.weapon_type.living_animations.modifiers": "Modifiers",
 	"datapack_edit.weapon_type.living_animations.modifiers.tooltip": "Defines overrided animations when holding a weapon",
-	
+
 	"datapack_edit.weapon_type.styles.default": "Default",
 	"datapack_edit.weapon_type.styles.default.tooltip": "A default style (mandatory)",
 	"datapack_edit.weapon_type.styles.condition": "Condition",
 	"datapack_edit.weapon_type.styles.condition.tooltip": "Defines conditions that determine when a player have this style",
 	"datapack_edit.weapon_type.styles.parameters": "Parameters",
 	"datapack_edit.weapon_type.styles.parameters.tooltip": "Defines parameters of a condition",
-	
+
 	"datapack_edit.weapon_type.combos.combo_attacks": "Combo Attacks",
 	"datapack_edit.weapon_type.combos.combo_attacks.tooltip": "Defines combo attacks of a weapon\n(mandatory)",
 	"datapack_edit.weapon_type.combos.dash_attak": "Dash Attack",
 	"datapack_edit.weapon_type.combos.dash_attak.tooltip": "Defines a dash attack of a weapon\n(mandatory)",
 	"datapack_edit.weapon_type.combos.air_slash": "Air Slash",
 	"datapack_edit.weapon_type.combos.air_slash.tooltip": "Defines a jump attack of a weapon\n(mandatory)",
-	
+
 	"datapack_edit.item_capability.item_type": "Item Type",
 	"datapack_edit.item_capability.item_type.tooltip": "Defines if an item is armor or weapon\n(mandatory)",
 	"datapack_edit.item_capability.attributes": "Attributes",
@@ -608,7 +620,7 @@
 	"datapack_edit.item_capability.texture_path.tooltip": "Defines a texture of a trail effect\n(mandatory)",
 	"datapack_edit.item_capability.particle_type": "Particle Type",
 	"datapack_edit.item_capability.particle_type.tooltip": "Defines a particle type of a trail effect\n(mandatory)",
-	
+
 	"datapack_edit.mob_patch.disabled": "Disabled",
 	"datapack_edit.mob_patch.disabled.tooltip": "Disables epic fight style combat\n(optional)",
 	"datapack_edit.mob_patch.preset": "Preset",
@@ -640,14 +652,14 @@
 	"datapack_edit.mob_patch.combat_behavior": "Combat Behavior",
 	"datapack_edit.mob_patch.combat_behavior.tooltip": "Defines attack movesets of an entity\n(mandatory)",
 	"datapack_edit.mob_patch.humanoid_combat_behavior": "Humanoid Combat Behavior",
-	
+
 	"datapack_edit.mob_patch.humanoid_weapon_motions.weapon_categories": "Weapon Categories",
 	"datapack_edit.mob_patch.humanoid_weapon_motions.weapon_categories.tooltip": "Defines weapon categories that own a living animation set",
 	"datapack_edit.mob_patch.humanoid_weapon_motions.style": "Style",
 	"datapack_edit.mob_patch.humanoid_weapon_motions.style.tooltip": "Defines a style of weapon categories",
 	"datapack_edit.mob_patch.humanoid_weapon_motions.living_animations": "Living Animations",
 	"datapack_edit.mob_patch.humanoid_weapon_motions.living_animations.tooltip": "Defines living animations based on weapon categories and its style",
-	
+
 	"datapack_edit.mob_patch.combat_behavior.weight": "Weight",
 	"datapack_edit.mob_patch.combat_behavior.weight.tooltip": "Defines a chance to select this behavior",
 	"datapack_edit.mob_patch.combat_behavior.cooldown": "Cooldown",
@@ -662,13 +674,13 @@
 	"datapack_edit.mob_patch.combat_behavior.parameters.tooltip": "Defines parameters of a condition",
 	"datapack_edit.mob_patch.combat_behavior.animation": "Animation",
 	"datapack_edit.mob_patch.combat_behavior.animation.tooltip": "Defines an attack animation",
-	
+
 	"epicfight.messages.test_version_warning_line1": "Epic Fight is testing version.",
 	"epicfight.messages.test_version_warning_line2": "(%s)",
 	"epicfight.messages.version_notifier": "EpicFight-%s",
-	
+
 	"epicfight.messages.shader_transform_fail": "Failed to create shader %s. Don't turn on animation shader in your environment...",
 	"epicfight.messages.mode_switching_disabled": "Switching vanilla/epicfight mode is disabled in this world. Enable the gamerule or ask for a server operator.",
-	
+
 	"eof": "eof"
 }


### PR DESCRIPTION
This makes [Epic Fight: Controlify](https://www.curseforge.com/minecraft/mc-mods/epic-fight-controlify) (my custom addon) not needed anymore, only [Controlify: Forgified](https://www.curseforge.com/minecraft/mc-mods/controlify-forgified-unofficial) (optional).

This eliminates the confusing differences between 1.20.1 and 1.21.1 branches, since that is affecting addons that are trying to support Controlify on 1.20.1, such as Invincible and Sword Soaring.

With this change, the 1.21.1 and 1.20.1 branches are less diverged due to #2133. These differences exist due to #2133 and other 1.21.1 PRs.