### PR TITLE
[1.21.1] Fix Weapon Innate Skill Tooltip

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -241,7 +241,7 @@ public final class InputManager {
             //  If it works correctly, remove this "if" block
             //  along with the isPhysicalKeyDownInternalWorkaround() method.
             //  For more details, see: https://github.com/Epic-Fight/epicfight/issues/2174
-            return isPhysicalKeyDownInternalWorkaround(keyMapping);
+            return isPhysicalKeyDown(keyMapping);
         }
         return isDown;
     }
@@ -279,7 +279,7 @@ public final class InputManager {
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated(forRemoval = true)
     @ApiStatus.Internal
-    private static boolean isPhysicalKeyDownInternalWorkaround(@NotNull KeyMapping keyMapping) {
+    private static boolean isPhysicalKeyDown(@NotNull KeyMapping keyMapping) {
         final InputConstants.Key key = keyMapping.getKey();
         final int keyValue = key.getValue();
         final long windowPointer = Minecraft.getInstance().getWindow().getWindow();

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -57,6 +57,13 @@ public final class InputManager {
         return controllerMod.getInputMode().supportsController();
     }
 
+    // TODO: Review the design of isActionActive() and isActionPhysicallyActive()
+    //  fully, while testing and ensuring the behavior consistency across controller and mouse/keyboard inputs.
+    //  When this regression appeared: https://github.com/Epic-Fight/epicfight/issues/2196
+    //  it happened only on vanilla mouse/keyboard but not controllers,
+    //  this is a strong sign that there is behavior inconsistency between different inputs.
+    //  Related: https://github.com/Epic-Fight/epicfight/issues/2194
+
     /**
      * Returns whether the given input action is active during this tick, following Minecraft’s internal behavior.
      * May return <code>false</code> while a screen is open, even if the physical input is held down.
@@ -72,7 +79,7 @@ public final class InputManager {
      * It should not be used while a screen is open.
      *
      * @param action the input action to check
-     * @return true if the action is active, this tick according to Minecraft’s internal behavior; false otherwise
+     * @return true if the action is active, this tick according to Minecraft’s internals; false otherwise
      * @see InputType
      */
     public static boolean isActionActive(@NotNull EpicFightInputActions action) {
@@ -85,6 +92,34 @@ public final class InputManager {
             case KEYBOARD_MOUSE -> isKeyDown(action.keyMapping());
             case CONTROLLER -> controllerMod.getBinding(action).isDigitalActiveNow();
             case MIXED -> isKeyDown(action.keyMapping()) || controllerMod.getBinding(action).isDigitalActiveNow();
+        };
+    }
+
+    /**
+     * Returns whether the given input action is currently physically active this tick.
+     * <p>
+     * Unlike {@link #isActionActive}, this method is independent of the Minecraft behavior and internals:
+     * <ul>
+     *     <li>Ignores vanilla GUI filtering (always checks the physical key state).</li>
+     *     <li>Bypasses the mouse multiple-keybind sharing bug (present in versions before 1.21.10).</li>
+     * </ul>
+     * <p>
+     * Controllers are handled the same as {@link #isActionActive}.
+     *
+     * @param action the input action to check
+     * @return true, if the action is active, this tick regardless of Minecraft’s internals; false otherwise
+     */
+    public static boolean isActionPhysicallyActive(@NotNull EpicFightInputActions action) {
+        final IEpicFightControllerMod controllerMod = getControllerModApi();
+        if (controllerMod == null) {
+            return isPhysicalKeyDown(action.keyMapping());
+        }
+
+        return switch (controllerMod.getInputMode()) {
+            case KEYBOARD_MOUSE -> isPhysicalKeyDown(action.keyMapping());
+            case CONTROLLER -> controllerMod.getBinding(action).isDigitalActiveNow();
+            case MIXED ->
+                    isPhysicalKeyDown(action.keyMapping()) || controllerMod.getBinding(action).isDigitalActiveNow();
         };
     }
 

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -58,7 +58,8 @@ public final class InputManager {
     }
 
     /**
-     * Returns whether the given input action is currently active this tick.
+     * Returns whether the given input action is active during this tick, following Minecraft’s internal behavior.
+     * May return <code>false</code> while a screen is open, even if the physical input is held down.
      * <p>
      * Checks the action state depending on the current input mode:
      * <ul>
@@ -67,10 +68,11 @@ public final class InputManager {
      *     <li>{@link InputMode#MIXED}: true if either the key mapping is down or the controller binding state is active.</li>
      * </ul>
      * If no controller mod is present, only the key mapping is checked.
-     * This is usually useful for continuous actions.
+     * This is usually useful for in-game continuous actions.
+     * It should not be used while a screen is open.
      *
      * @param action the input action to check
-     * @return true if the action is currently active in this tick; false otherwise
+     * @return true if the action is active, this tick according to Minecraft’s internal behavior; false otherwise
      * @see InputType
      */
     public static boolean isActionActive(@NotNull EpicFightInputActions action) {

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -57,29 +57,23 @@ public final class InputManager {
         return controllerMod.getInputMode().supportsController();
     }
 
-    // TODO: Review the design of isActionActive() and isActionPhysicallyActive()
-    //  fully, while testing and ensuring the behavior consistency across controller and mouse/keyboard inputs.
-    //  When this regression appeared: https://github.com/Epic-Fight/epicfight/issues/2196
-    //  it happened only on vanilla mouse/keyboard but not controllers,
-    //  this is a strong sign that there is behavior inconsistency between different inputs.
-    //  Related: https://github.com/Epic-Fight/epicfight/issues/2194
-
     /**
-     * Returns whether the given input action is active during this tick, following Minecraft’s internal behavior.
-     * May return <code>false</code> while a screen is open, even if the physical input is held down.
-     * <p>
-     * Checks the action state depending on the current input mode:
+     * Returns whether the given input action is active during this tick.
+     * The behavior differs depending on the input source:
      * <ul>
-     *     <li>{@link InputMode#KEYBOARD_MOUSE}: whether the key mapping is down.</li>
-     *     <li>{@link InputMode#CONTROLLER}: whether the controller binding digital state is active.</li>
-     *     <li>{@link InputMode#MIXED}: true if either the key mapping is down or the controller binding state is active.</li>
+     *   <li><b>Keyboard/Mouse:</b> Follows Minecraft’s internal behavior.
+     *   May return <code>false</code> while a screen is open, even if the physical key is held down.</li>
+     *   <li><b>Controller:</b> The behavior is handled externally and is irrelevant to this method.
+     *   It is usually determined by an input context during the
+     *   controller binding registration (third-party API),
+     *   which decides whether to return <code>false</code> or <code>true</code> when the physical input is down.</li>
      * </ul>
-     * If no controller mod is present, only the key mapping is checked.
+     * <p>
+     * If no controller mod is present, only the {@link KeyMapping} (Keyboard/Mouse) is checked.
      * This is usually useful for in-game continuous actions.
      * It should not be used while a screen is open.
      *
      * @param action the input action to check
-     * @return true if the action is active, this tick according to Minecraft’s internals; false otherwise
      * @see InputType
      */
     public static boolean isActionActive(@NotNull EpicFightInputActions action) {
@@ -98,16 +92,21 @@ public final class InputManager {
     /**
      * Returns whether the given input action is currently physically active this tick.
      * <p>
-     * Unlike {@link #isActionActive}, this method is independent of the Minecraft behavior and internals:
+     * The behavior differs depending on the input source:
      * <ul>
-     *     <li>Ignores vanilla GUI filtering (always checks the physical key state).</li>
-     *     <li>Bypasses the mouse multiple-keybind sharing bug (present in versions before 1.21.10).</li>
+     *   <li><b>Keyboard/Mouse:</b> Always checks the physical key state, ignoring vanilla GUI filtering
+     *   and bypassing the <a href="https://github.com/Epic-Fight/epicfight/issues/2174">mouse multiple-keybind sharing bug</a>
+     *   (present in versions before 1.21.10).</li>
+     *   <li><b>Controller:</b> Similarly to {@link #isActionActive},
+     *   the behavior is handled externally and is irrelevant to this method.</li>
      * </ul>
      * <p>
-     * Controllers are handled the same as {@link #isActionActive}.
+     * If no controller mod is present, only the {@link KeyMapping} (Keyboard/Mouse) is checked.
+     * This is usually useful for GUI continuous actions.
+     * It should not be used in-game with no screens.
      *
      * @param action the input action to check
-     * @return true, if the action is active, this tick regardless of Minecraft’s internals; false otherwise
+     * @see #isActionActive
      */
     public static boolean isActionPhysicallyActive(@NotNull EpicFightInputActions action) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
@@ -275,8 +274,7 @@ public final class InputManager {
             //  (This is not an issue with keyboard inputs.)
             //  When porting to 1.21.10 or 1.22, test the weapon's innate skill
             //  without this condition.
-            //  If it works correctly, remove this "if" block
-            //  along with the isPhysicalKeyDownInternalWorkaround() method.
+            //  If it works correctly, remove this "if" block.
             //  For more details, see: https://github.com/Epic-Fight/epicfight/issues/2174
             return isPhysicalKeyDown(keyMapping);
         }
@@ -302,19 +300,13 @@ public final class InputManager {
      * For more details, see
      * <a href="https://github.com/Epic-Fight/epicfight/issues/2174">Epic Fight issue #2174</a>.
      * <p>
-     * <b>Project maintainers:</b> This method should be completely removed when porting to 1.21.10 or 1.22.
-     * Its only usage is in {@link InputManager#isActionActive}. After removal, verify that the weapon's
-     * innate skill still works as intended.
-     * <p>
      * Note: At the time of writing, this workaround is confirmed to be unnecessary in 1.21.10,
      * but may still (though unlikely) be required in 1.22 or later versions.
-     *
-     * @deprecated This method will be removed when Epic Fight migrates to 1.22. It currently exists
-     * only to address inconsistencies in Minecraft’s internal behavior.
+     * This is also useful when a screen is open,
+     * since {@link #isKeyDown(KeyMapping)} will return <code>false</code>.
+     * <p>
      * See <a href="https://github.com/Epic-Fight/epicfight/issues/2170">issue #2170</a> for details.
      */
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    @Deprecated(forRemoval = true)
     @ApiStatus.Internal
     private static boolean isPhysicalKeyDown(@NotNull KeyMapping keyMapping) {
         final InputConstants.Key key = keyMapping.getKey();

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -661,7 +661,7 @@ public class RenderEngine implements IEventBasedEngine {
 		if (ClientConfig.showEpicFightAttributesInTooltip && event.getEntity() != null && event.getEntity().level().isClientSide) {
 			EpicFightCapabilities.getUnparameterizedEntityPatch(event.getEntity(), LocalPlayerPatch.class).ifPresent(playerpatch -> {
 				EpicFightCapabilities.getItemCapability(event.getItemStack()).ifPresent(itemCapability -> {
-					if (InputManager.isActionActive(EpicFightInputActions.WEAPON_INNATE_SKILL_TOOLTIP)) {
+					if (InputManager.isActionPhysicallyActive(EpicFightInputActions.WEAPON_INNATE_SKILL_TOOLTIP)) {
 						Skill weaponInnateSkill = itemCapability.getInnateSkill(playerpatch, event.getItemStack());
 						
 						if (weaponInnateSkill != null) {


### PR DESCRIPTION
Fixes #2196. For an easier review, review each commit separately (steps).

The `RELEASE_NOTES.md` does not need to be updated, as the recent changes that introduced this regression have not been published yet for 1.21.1.

The `isPhysicalKeyDownInternalWorkaround` is no longer a temporary workaround that can be removed in MC 1.21.10, because now it's actually required to support the weapon innate skill tooltip or the use of a `KeyMapping` when a screen is open. I renamed it to `isPhysicalKeyDown`, though I still kept it private, because exposing it would violate the whole idea of `InputManager`, which is to hide these details.