### PR TITLE
[1.21.1] Move all classes inside "yesman.epicfight.kubejs" to "yesman.epicfight.compat.kubejs" for better organization

### DIFF
--- a/src/main/java/yesman/epicfight/compat/kubejs/CallbackUtils.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/CallbackUtils.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs;
+package yesman.epicfight.compat.kubejs;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;

--- a/src/main/java/yesman/epicfight/compat/kubejs/EFUtilsJS.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/EFUtilsJS.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs;
+package yesman.epicfight.compat.kubejs;
 
 import dev.latvian.mods.kubejs.typings.Info;
 import net.neoforged.api.distmarker.Dist;

--- a/src/main/java/yesman/epicfight/compat/kubejs/EpicFightKubeJSPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/EpicFightKubeJSPlugin.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs;
+package yesman.epicfight.compat.kubejs;
 
 import dev.latvian.mods.kubejs.plugin.KubeJSPlugin;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
@@ -12,7 +12,7 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
-import yesman.epicfight.kubejs.skill.CustomSkill;
+import yesman.epicfight.compat.kubejs.skill.CustomSkill;
 import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.registry.entries.EpicFightSkillDataKeys;
 import yesman.epicfight.skill.Skill;

--- a/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomChargeableSkill.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomChargeableSkill.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs.skill;
+package yesman.epicfight.compat.kubejs.skill;
 
 import java.util.Arrays;
 import java.util.function.Consumer;

--- a/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomPassiveSkill.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomPassiveSkill.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs.skill;
+package yesman.epicfight.compat.kubejs.skill;
 
 import dev.latvian.mods.kubejs.typings.Info;
 import net.minecraft.client.gui.GuiGraphics;

--- a/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomSkill.java
+++ b/src/main/java/yesman/epicfight/compat/kubejs/skill/CustomSkill.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.kubejs.skill;
+package yesman.epicfight.compat.kubejs.skill;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.Event;
 import yesman.epicfight.client.gui.BattleModeGui;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
-import yesman.epicfight.kubejs.CallbackUtils;
+import yesman.epicfight.compat.kubejs.CallbackUtils;
 import yesman.epicfight.registry.entries.EpicFightCreativeTabs;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.skill.SkillBuilder;

--- a/src/main/resources/kubejs.plugins.txt
+++ b/src/main/resources/kubejs.plugins.txt
@@ -1,1 +1,1 @@
-yesman.epicfight.kubejs.EpicFightKubeJSPlugin
+yesman.epicfight.compat.kubejs.EpicFightKubeJSPlugin


### PR DESCRIPTION
Fixes #2199.

This is a non-breaking change. This can be backported to 1.20.1.