### PR TITLE
[1.21.1] Move SodiumFakeBlockRenderer to compat.sodium.client package

### DIFF
--- a/src/main/java/yesman/epicfight/compat/iris/IRISCompat.java
+++ b/src/main/java/yesman/epicfight/compat/iris/IRISCompat.java
@@ -5,7 +5,7 @@ import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import yesman.epicfight.client.events.engine.RenderEngine;
-import yesman.epicfight.client.renderer.SodiumFakeBlockRenderer;
+import yesman.epicfight.compat.sodium.client.SodiumFakeBlockRenderer;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 import yesman.epicfight.compat.ICompatModule;
 

--- a/src/main/java/yesman/epicfight/compat/sodium/client/SodiumFakeBlockRenderer.java
+++ b/src/main/java/yesman/epicfight/compat/sodium/client/SodiumFakeBlockRenderer.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.client.renderer;
+package yesman.epicfight.compat.sodium.client;
 
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -38,6 +38,8 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import yesman.epicfight.client.renderer.EpicFightRenderTypes;
+import yesman.epicfight.client.renderer.FakeBlockRenderer;
 
 @OnlyIn(Dist.CLIENT)
 public class SodiumFakeBlockRenderer implements FakeBlockRenderer {


### PR DESCRIPTION
For consistency reasons.

### Backporting this PR to 1.20.1?

This can't be backported to 1.20.1 without backporting these PRs first:

- #2168
- #2169
- #2176
- #2181

Which I recommend we do, though it will break [Epic Fight x Iron's Spells: Enhanced Animations](https://www.curseforge.com/minecraft/mc-mods/epic-fight-x-irons-spells-enhanced-animations) since it imports [PlayerAnimatorCompat](https://github.com/domanhthang2110/efiscompat/blob/master/src/main/java/com/yukami/efiscompat/mixin/MixinPlayerAnimatorCompat.java#L14).
The fix should be fairly simple, just one line change.

I could send a PR to them, and it's technically fine to introduce, as it modifies an internal Epic Fight API rather than a public API.

#### Alternative for future direction

Maybe we could provide them with an event (supported API) so they won't need to depend on `PlayerAnimatorCompat` anymore (to avoid future breakage and better behavior).
The use case is to override or disable Player Animator compatibility (added in #1901), as they provide explicit Epic Fight support for Iron's Spells.