### PR TITLE
[1.21.1] Arrow keys navigation for skill editor screen

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,12 @@
 - Added a client config to allow skipping the third-person front perspective when
   toggling the camera perspective (i.e., F5).
   [#2205](https://github.com/Epic-Fight/epicfight/issues/2205)
+- Improved arrow key navigation (`↑`, `↓`, `→`, `←`) in the skill editor screen, including proper scrolling support. [#2203](https://github.com/Epic-Fight/epicfight/issues/2203)
+- **[Controlify]** Added native controller support for the skill editor screen and disabled virtual mouse behavior.
+
+### Fixed
+
+- Fixed a bug that allowed the player to replace the current skill slot even during cooldown.
 
 ## [21.13.5] - 2025-11-12
 

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -46,7 +46,7 @@ public class SkillEditScreen extends Screen {
 	
 	private static final int MAX_SKILL_OPTIONS_ROWS = 6;
 	private static final int MAX_SLOT_ROWS = 9;
-	private static final int STRIDE = 18;
+	private static final int STRIDE = SlotButton.SIZE;
 
 	private final Player player;
 	private final PlayerSkills skills;
@@ -295,11 +295,12 @@ public class SkillEditScreen extends Screen {
 	
 	@OnlyIn(Dist.CLIENT)
 	class SlotButton extends Button {
+        private static final int SIZE = 18;
 		private final SkillContainer skillContainer;
 		private final Component slotExplanation;
 		
 		public SlotButton(int x, int y, SkillContainer skillContainer, OnPress pressedAction, Component tooltipMessage) {
-			super(x, y, 18, 18, Component.empty(), pressedAction, Button.DEFAULT_NARRATION);
+			super(x, y, SIZE, SIZE, Component.empty(), pressedAction, Button.DEFAULT_NARRATION);
 			
 			this.skillContainer = skillContainer;
 			this.slotExplanation = tooltipMessage;

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -24,6 +24,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.data.reloader.SkillReloadListener;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.network.EpicFightNetworkManager;
@@ -134,7 +135,7 @@ public class SkillEditScreen extends Screen {
 									.setActive(this.skills.getSkillContainer(skill) == null)
 								);
 								
-								widgetHeight.add(26);
+								widgetHeight.add(EquipSkillButton.SPACING);
 							});
 							
 							for (Button shownButton : this.equipSkillButtons) {
@@ -232,7 +233,7 @@ public class SkillEditScreen extends Screen {
 						--this.start;
 						
 						for (Button button : this.equipSkillButtons) {
-							button.setY(button.getY() + 26);
+							button.setY(button.getY() + EquipSkillButton.SPACING);
 						}
 						
 						return true;
@@ -242,7 +243,7 @@ public class SkillEditScreen extends Screen {
 						++this.start;
 						
 						for (Button button : this.equipSkillButtons) {
-							button.setY(button.getY() - 26);
+							button.setY(button.getY() - EquipSkillButton.SPACING);
 						}
 						
 						return true;
@@ -343,7 +344,7 @@ public class SkillEditScreen extends Screen {
 		}
 		
 		@Override
-		protected void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+		protected void renderWidget(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
 			if (this.up && scroll != 0) guiGraphics.blit(SCROLL_ARROW_UP, this.getX(), this.getY(), this.width, this.height, 0, 0, 16, 16, 16, 16);
 			else if (!this.up && scroll != maxScroll) guiGraphics.blit(SCROLL_ARROW_DOWN, this.getX(), this.getY(), this.width, this.height, 0, 0, 16, 16, 16, 16);
 		}
@@ -356,6 +357,8 @@ public class SkillEditScreen extends Screen {
 	
 	@OnlyIn(Dist.CLIENT)
 	class EquipSkillButton extends Button {
+        private static final int SPACING = 26;
+
 		private final Skill skill;
 
 		public EquipSkillButton(int x, int y, int width, int height, Skill skill, Component title, OnPress pressedAction) {
@@ -371,10 +374,10 @@ public class SkillEditScreen extends Screen {
 			
 			RenderSystem.enableBlend();
 			guiGraphics.blit(this.skill.getSkillTexture(), this.getX() + 5, this.getY() + 4, 16, 16, 0, 0, 128, 128, 128, 128);
-			guiGraphics.drawString(font, this.getMessage(), this.getX() + 26, this.getY() + 2, -1, false);
+			guiGraphics.drawString(font, this.getMessage(), this.getX() + SPACING, this.getY() + 2, -1, false);
 			
 			if (!this.active) {
-				guiGraphics.drawString(font, Component.literal(skills.getSkillContainer(this.skill).getSlot().toString().toLowerCase(Locale.ROOT)), this.getX()+26, this.getY() + 12, 16736352, false);
+				guiGraphics.drawString(font, Component.literal(skills.getSkillContainer(this.skill).getSlot().toString().toLowerCase(Locale.ROOT)), this.getX() + EquipSkillButton.SPACING, this.getY() + 12, 16736352, false);
 			}
 		}
 		
@@ -415,7 +418,7 @@ public class SkillEditScreen extends Screen {
                 int diff = (start - nextStart);
 
                 for (Button button : buttons) {
-                    button.setY(button.getY() + 26 * diff);
+                    button.setY(button.getY() + EquipSkillButton.SPACING * diff);
                 }
 
                 SkillEditScreen.this.start = nextStart;

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -333,6 +333,35 @@ public class SkillEditScreen extends Screen {
 				this.setTooltip(Tooltip.create(this.slotExplanation));
 			}
 		}
+
+        @Override
+        public void setFocused(boolean focused) {
+            super.setFocused(focused);
+
+            // Supports key arrow navigation
+            maybeScroll();
+        }
+
+        private void maybeScroll() {
+            if (SkillEditScreen.this.maxScroll == 0) {
+                return;
+            }
+            final int scroll = SkillEditScreen.this.scroll;
+
+            final int index = slotButtons.values().stream().toList().indexOf(this);
+            final int relativeIndex = index - scroll;
+
+            final boolean needsScrollDown = relativeIndex >= (MAX_SLOT_ROWS - 1);
+            final boolean needsScrollTop = relativeIndex == 0;
+
+            if (needsScrollDown || needsScrollTop) {
+                if (needsScrollDown) {
+                    scrollDown();
+                } else {
+                    scrollUp();
+                }
+            }
+        }
 	}
 	
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -46,7 +46,7 @@ public class SkillEditScreen extends Screen {
 	private static final int MAX_SKILL_OPTIONS_ROWS = 6;
 	private static final int MAX_SLOT_ROWS = 9;
 	private static final int STRIDE = 18;
-	
+
 	private final Player player;
 	private final PlayerSkills skills;
 	private final Map<SkillSlot, SlotButton> slotButtons = new LinkedHashMap<> ();
@@ -307,7 +307,8 @@ public class SkillEditScreen extends Screen {
 		
 		@Override
 		protected void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-			int y = ((this.isHovered || selectedSlotButton == this) && !this.skillContainer.onReplaceCooldown()) ? 35 : 17;
+            this.active = !this.skillContainer.onReplaceCooldown();
+			int y = ((this.isHoveredOrFocused() || selectedSlotButton == this) && !this.skillContainer.onReplaceCooldown()) ? 35 : 17;
 			guiGraphics.blit(SKILL_EDIT_UI, this.getX(), this.getY(), 237, y, this.width, this.height);
 			
 			if (!this.skillContainer.isEmpty()) {
@@ -323,17 +324,12 @@ public class SkillEditScreen extends Screen {
 				float lerp = Mth.clampedLerp(0.0F, 16.0F, 1.0F - (float)this.skillContainer.getReplaceCooldown() / maxCooldown);
 				guiGraphics.fill(this.getX() + 1, this.getY() + 1 + (int)lerp, this.getX() + 17, this.getY() + 17, 0x78000000);
 				
-				if (this.isHovered) {
+				if (this.isHoveredOrFocused()) {
 					this.setTooltip(Tooltip.create(Component.translatable(EpicFightMod.format("gui.%s.container_on_cooldown"), this.skillContainer.getReplaceCooldown() / 20)));
 				}
 			} else {
 				this.setTooltip(Tooltip.create(this.slotExplanation));
 			}
-		}
-		
-		@Override
-		protected boolean clicked(double mouseX, double mouseY) {
-			return super.clicked(mouseX, mouseY) && !this.skillContainer.onReplaceCooldown();
 		}
 	}
 	
@@ -370,7 +366,7 @@ public class SkillEditScreen extends Screen {
 		@Override
 		public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
 			this.isHovered = mouseX >= this.getX() && mouseY >= this.getY() && mouseX < this.getX() + this.width && mouseY < this.getY() + this.height;
-			int texY = (this.isHovered || !this.active) ? 224 : 200;
+			int texY = (this.isHoveredOrFocused() || !this.active) ? 224 : 200;
 			guiGraphics.blit(SKILL_EDIT_UI, this.getX(), this.getY(), 0, texY, this.width, this.height);
 			
 			RenderSystem.enableBlend();
@@ -396,6 +392,35 @@ public class SkillEditScreen extends Screen {
 			
 			return super.mouseClicked(x, y, pressType);
 		}
+
+        @Override
+        public void setFocused(boolean focused) {
+            super.setFocused(focused);
+
+            // Supports key arrow navigation
+            maybeScroll();
+        }
+
+        private void maybeScroll() {
+            final List<EquipSkillButton> buttons = SkillEditScreen.this.equipSkillButtons;
+            final int start = SkillEditScreen.this.start;
+            final int maxRows = MAX_SKILL_OPTIONS_ROWS;
+
+            final int i = buttons.indexOf(this);
+            final boolean isOutsideVisibleRowsAtBottom = i >= start + maxRows;
+            final boolean isOutsideVisibleRowsAtTop = i < start;
+
+            if (isOutsideVisibleRowsAtBottom || isOutsideVisibleRowsAtTop) {
+                int nextStart = (isOutsideVisibleRowsAtBottom) ? Math.max(0, i - maxRows + 1) : i;
+                int diff = (start - nextStart);
+
+                for (Button button : buttons) {
+                    button.setY(button.getY() + 26 * diff);
+                }
+
+                SkillEditScreen.this.start = nextStart;
+            }
+        }
 		
 		protected boolean clickedNoCountActive(double x, double y) {
 			return this.visible && x >= (double) this.getX() && y >= (double) this.getY() && x < (double) (this.getX() + this.width) && y < (double) (this.getY() + this.height);

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -386,7 +386,7 @@ public class SkillEditScreen extends Screen {
 	}
 	
 	@OnlyIn(Dist.CLIENT)
-	class EquipSkillButton extends Button {
+	public class EquipSkillButton extends Button {
         private static final int SPACING = 26;
 
 		private final Skill skill;
@@ -417,14 +417,18 @@ public class SkillEditScreen extends Screen {
 				boolean flag = this.clickedNoCountActive(x, y);
 				
 				if (flag) {
-					this.playDownSound(Minecraft.getInstance().getSoundManager());
-					minecraft.setScreen(new SkillBookScreen(player, this.skill, null, SkillEditScreen.this));
+					openSkillInfoScreen();
 					return true;
 				}
 			}
 			
 			return super.mouseClicked(x, y, pressType);
 		}
+
+        public void openSkillInfoScreen() {
+            this.playDownSound(Minecraft.getInstance().getSoundManager());
+            minecraft.setScreen(new SkillBookScreen(player, this.skill, null, SkillEditScreen.this));
+        }
 
         @Override
         public void setFocused(boolean focused) {

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -533,12 +533,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             super(screen);
         }
 
-        @Override
-        public VirtualMouseBehaviour virtualMouseBehaviour() {
-            // The skill edit screen does not natively support controllers.
-            // To save development time, we work around this issue by enforcing the virtual mouse.
-            return VirtualMouseBehaviour.ENABLED;
-        }
+        // Placeholder screen processor. Does nothing currently. Retained for potential future use.
     }
 
     private static class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -21,7 +21,6 @@ import dev.isxander.controlify.screenop.ScreenProcessor;
 import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
-import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -533,7 +532,17 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             super(screen);
         }
 
-        // Placeholder screen processor. Does nothing currently. Retained for potential future use.
+        private static final InputBindingSupplier OPEN_SKILL_INFO = ControlifyBindings.GUI_ABSTRACT_ACTION_1;
+
+        @Override
+        protected void handleButtons(ControllerEntity controller) {
+            super.handleButtons(controller);
+
+            if (this.screen.getFocused() instanceof SkillEditScreen.EquipSkillButton equipSkillButton &&
+                    OPEN_SKILL_INFO.on(controller).guiPressed().get()) {
+                equipSkillButton.openSkillInfoScreen();
+            }
+        }
     }
 
     private static class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {

--- a/src/main/java/yesman/epicfight/skill/SkillContainer.java
+++ b/src/main/java/yesman/epicfight/skill/SkillContainer.java
@@ -447,7 +447,11 @@ public class SkillContainer {
 	public float getDurationRatio(float partialTicks) {
 		return this.skill != null && this.maxDuration > 0 ? (this.prevDuration + ((this.duration - this.prevDuration) * partialTicks)) / this.maxDuration : 0;
 	}
-	
+
+    /**
+     * Returns whether the player is currently on cooldown for replacing a skill.
+     * The player must not be in Creative mode for the cooldown to apply.
+     */
 	public boolean onReplaceCooldown() {
 		return this.replaceCooldown > 0 && !this.executor.getOriginal().isCreative();
 	}


### PR DESCRIPTION
Fixes #2203

### Credit

- [yesssssman](https://github.com/yesssssman/) — implemented the equip skill buttons scrolling.  
- [P1nero](https://github.com/GaylordFockerCN/) — the fix in [their mod](https://github.com/GaylordFockerCN/DialogueLib/commit/43a54b0858877386d8610bb0817d48efdb13a275#diff-48e7f67abff128a29bdf4c2c6d075926e962e9c16df0a228a72d0ba66705651dL7-L30) helped me understand that the issue is related to focus and state checking.

### 1.20.1

#2210
