### PR TITLE
[1.21.1] Displays the skill slot button tooltips when navigating via a controller (Controlify)

### DIFF
--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -21,7 +21,9 @@ import dev.isxander.controlify.screenop.ScreenProcessor;
 import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
+import net.minecraft.client.InputType;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.Slot;
@@ -542,6 +544,35 @@ public class ControlifyCompat implements ControlifyEntrypoint {
                     OPEN_SKILL_INFO.on(controller).guiPressed().get()) {
                 equipSkillButton.openSkillInfoScreen();
             }
+        }
+
+        @Override
+        protected void setInitialFocus() {
+            // Intentionally empty. Do NOT call super.setInitialFocus().
+        }
+
+        @Override
+        public void onWidgetRebuild() {
+            super.onWidgetRebuild();
+            setInputTypeWorkaround();
+        }
+
+        /**
+         * Controlify intentionally avoids setting Minecraft's input type to
+         * {@link InputType#KEYBOARD_ARROW} because keyboard and controller inputs behave
+         * differently.
+         * However, {@link SkillEditScreen} was built mainly for mouse users,
+         * and some GUI elements—like skill slot names—are shown only via tooltips, which
+         * appear only when the input type is {@link InputType#KEYBOARD_ARROW}.
+         * <p>
+         * To support controller users without extra rework, the input type is set here
+         * manually.
+         * As a result, {@link #setInitialFocus()} must remain empty, since
+         * Minecraft handles focus automatically whenever the input type is not
+         * {@link InputType#NONE}, which is what Controlify normally uses.
+         */
+        private void setInputTypeWorkaround() {
+            Minecraft.getInstance().setLastInputType(InputType.KEYBOARD_ARROW);
         }
     }
 


### PR DESCRIPTION
Right now, when controller users open the skill editor screen and then navigate, the tooltip won't get displayed since Minecraft's input type is kept `NONE` intentionally by Controlify.

So even if a skill slot button is focused, the tooltip won't render until the player switches to keyboard and then switches back to a controller, which is inconvenient. This PR fixes that.

> [!NOTE]
> **FYI:** Usually, it's better to design a good GUI that works with a mouse, keyboard, arrow navigation, or a controller. In this case, since we don't plan to rework, a good workaround is to show the tooltip when using a controller, just like with mouse or keyboard arrow navigation.

<img width="409" height="392" alt="image" src="https://github.com/user-attachments/assets/735b4bcb-2c8a-4c3f-a81d-f1539e768373" />

* *Related #2203*

There is no reason to update the `RELEASE_NOTES.md` due to this change, since this is part of "**[Controlify]** Added native controller support" entry, which is unreleased yet.


### 1.20.1

#2219
