### PR TITLE
[1.21.1] Fix Shoulder Surfing Compatibility Entrypoint not registered

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@
 ### Fixed
 
 - Fixed a bug that allowed the player to replace the current skill slot even during cooldown.
+- **Fixed:** The **Shoulder Surfing compatibility module** was not being registered,
+  causing issues with its intended functionality.
 
 ## [21.13.5] - 2025-11-12
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,10 +149,9 @@ dependencies {
     // First-person compatibility (optional)
     compileOnly "maven.modrinth:first-person-model:QWJDSZiH" // 2.5.0
     
-    // Shoulder Surfing Reloaded compatibility (optional, have to choose one)
-
-    compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993797" // API only (https://www.curseforge.com/minecraft/mc-mods/shoulder-surfing-reloaded/files/6993792)
-    //compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993795" // Actual mod file (for test)
+    // Shoulder Surfing Reloaded compatibility (optional, uncomment the runtimeOnly to test the mod)
+    compileOnly "curse.maven:shoulder-surfing-reloaded-243190:6993797" // API only
+    //runtimeOnly "curse.maven:shoulder-surfing-reloaded-243190:6993795" // Full mod JAR file
 
     // Change "compileOnly" to "implementation" for testing in-game.
     compileOnly("dev.isxander:controlify:${project.controlify_version}") {

--- a/src/main/resources/shouldersurfing_plugin.json
+++ b/src/main/resources/shouldersurfing_plugin.json
@@ -1,3 +1,3 @@
 {
-  "entrypoint": "yesman.epicfight.compat.ShoulderSurfingCompat"
+  "entrypoint": "yesman.epicfight.compat.shouldersurfing.ShoulderSurfingCompat"
 }


### PR DESCRIPTION
Shoulder Surfing compatibility added in #2112 but broken due to refactoring of #2168.
This PR fixes that.

There is no reason to backport to 1.20.1, as #2168 targets only 1.21.1.