### PR TITLE
[1.21.1] Refactor mod compatibility module checks

### DIFF
--- a/src/main/java/yesman/epicfight/compat/ICompatModule.java
+++ b/src/main/java/yesman/epicfight/compat/ICompatModule.java
@@ -11,7 +11,7 @@ import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.main.EpicFightSharedConstants;
 
 public interface ICompatModule {
-	public static void loadCompatModule(IEventBus modEventBus, Class<? extends ICompatModule> compatModule) {
+	static void loadCompatModule(IEventBus modEventBus, Class<? extends ICompatModule> compatModule) {
 		try {
 			Constructor<? extends ICompatModule> constructor = compatModule.getConstructor();
 			ICompatModule compatModuleInstance = constructor.newInstance();
@@ -22,12 +22,12 @@ public interface ICompatModule {
 				compatModuleInstance.onModEventBusClient(modEventBus);
 				compatModuleInstance.onGameEventBusClient(NeoForge.EVENT_BUS);
 			}
-			
-			EpicFightMod.LOGGER.info("Loaded mod compat: " + compatModule.getSimpleName());
+
+            EpicFightMod.LOGGER.info("Loaded mod compatibility module: {}", compatModule.getSimpleName());
 		} catch (ModLoadingException e) {
 			throw e;
 		} catch (Exception e) {
-			EpicFightMod.LOGGER.error("Failed to load mod compat: " + e.getMessage());
+            EpicFightMod.LOGGER.error("Failed to load mod compatibility module: {}", e.getMessage());
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/yesman/epicfight/compat/MinecraftMod.java
+++ b/src/main/java/yesman/epicfight/compat/MinecraftMod.java
@@ -1,0 +1,51 @@
+package yesman.epicfight.compat;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.compat.azurelib.AzureLibArmorCompat;
+import yesman.epicfight.compat.azurelib.AzureLibCompat;
+import yesman.epicfight.compat.curiosapi.CuriosCompat;
+import yesman.epicfight.compat.firstperson.FirstPersonCompat;
+import yesman.epicfight.compat.geckolib.GeckolibCompat;
+import yesman.epicfight.compat.iris.IRISCompat;
+import yesman.epicfight.compat.playeranimator.PlayerAnimatorCompat;
+import yesman.epicfight.compat.skinlayer3d.SkinLayer3DCompat;
+import yesman.epicfight.compat.vampirism.VampirismCompat;
+import yesman.epicfight.compat.werewolves.WerewolvesCompat;
+
+// List of mods with custom compatibility modules.
+// Only includes mods requiring manual registration via ICompatModule.
+// Mods with official API entry-points (e.g., Shoulder Surfing, Controlify, JEI, KubeJS) are excluded.
+public enum MinecraftMod {
+    VAMPIRISM("vampirism", false, VampirismCompat.class),
+    WEREWOLVES("werewolves", false, WerewolvesCompat.class),
+    CURIOS_API("curios", false, CuriosCompat.class),
+    GECKO_LIB("geckolib", true, GeckolibCompat.class),
+    AZURE_LIB("azurelib", true, AzureLibCompat.class),
+    AZURE_LIB_ARMOR("azurelibarmor", true, AzureLibArmorCompat.class),
+    FIRST_PERSON("firstperson", true, FirstPersonCompat.class),
+    SKIN_LAYERS_3D("skinlayers3d", true, SkinLayer3DCompat.class),
+    IRIS("iris", true, IRISCompat.class),
+    PLAYER_ANIMATOR("playeranimator", true, PlayerAnimatorCompat.class);
+
+    private final @NotNull String modId;
+    private final boolean isClientOnly;
+    private final @NotNull Class<? extends ICompatModule> compatibilityModule;
+
+    MinecraftMod(@NotNull String modId, boolean isClientOnly, @NotNull Class<? extends ICompatModule> compatibilityModule) {
+        this.modId = modId;
+        this.isClientOnly = isClientOnly;
+        this.compatibilityModule = compatibilityModule;
+    }
+
+    public @NotNull String getModId() {
+        return modId;
+    }
+
+    public boolean isClientOnly() {
+        return isClientOnly;
+    }
+
+    public @NotNull Class<? extends ICompatModule> getCompatibilityModule() {
+        return compatibilityModule;
+    }
+}

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -178,52 +178,56 @@ public class EpicFightMod {
     	
     	EpicFightRegistries.DEFERRED_REGISTRIES.forEach(deferredRegistry -> deferredRegistry.register(modEventBus));
 
+        loadModCompatibilityModules(modEventBus);
+	}
+
+    private void loadModCompatibilityModules(@NotNull IEventBus modEventBus) {
         // TODO: Improve "ICompatModule"s registration by avoiding duplicating "ModList.get().isLoaded()".
         //  Make sure we're not duplicating the mod ID anywhere else, like in "GeckolibMixinPlugin".
         //  ALso, extract this in a separate function and avoid duplicating "ICompatModule.loadCompatModule" too.
-		
-		if (ModList.get().isLoaded("vampirism")) {
-			ICompatModule.loadCompatModule(modEventBus, VampirismCompat.class);
-		}
-        
+
+        if (ModList.get().isLoaded("vampirism")) {
+            ICompatModule.loadCompatModule(modEventBus, VampirismCompat.class);
+        }
+
         if (ModList.get().isLoaded("werewolves")) {
-			ICompatModule.loadCompatModule(modEventBus, WerewolvesCompat.class);
-		}
-        
+            ICompatModule.loadCompatModule(modEventBus, WerewolvesCompat.class);
+        }
+
         if (ModList.get().isLoaded("curios")) {
-			ICompatModule.loadCompatModule(modEventBus, CuriosCompat.class);
-		}
-        
-		if (EpicFightSharedConstants.isPhysicalClient()) {
-			modEventBus.addListener(ComputeShaderProvider::epicfight$registerComputeShaders);
-			
-			if (ModList.get().isLoaded("geckolib")) {
-				ICompatModule.loadCompatModule(modEventBus, GeckolibCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("azurelib")) {
-				ICompatModule.loadCompatModule(modEventBus, AzureLibCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("azurelibarmor")) {
-				ICompatModule.loadCompatModule(modEventBus, AzureLibArmorCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("firstperson")) {
-				ICompatModule.loadCompatModule(modEventBus, FirstPersonCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("skinlayers3d")) {
-				ICompatModule.loadCompatModule(modEventBus, SkinLayer3DCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("iris")) {
-				ICompatModule.loadCompatModule(modEventBus, IRISCompat.class);
-			}
-			
-			if (ModList.get().isLoaded("playeranimator")) {
-				ICompatModule.loadCompatModule(modEventBus, PlayerAnimatorCompat.class);
-			}
+            ICompatModule.loadCompatModule(modEventBus, CuriosCompat.class);
+        }
+
+        if (EpicFightSharedConstants.isPhysicalClient()) {
+            modEventBus.addListener(ComputeShaderProvider::epicfight$registerComputeShaders);
+
+            if (ModList.get().isLoaded("geckolib")) {
+                ICompatModule.loadCompatModule(modEventBus, GeckolibCompat.class);
+            }
+
+            if (ModList.get().isLoaded("azurelib")) {
+                ICompatModule.loadCompatModule(modEventBus, AzureLibCompat.class);
+            }
+
+            if (ModList.get().isLoaded("azurelibarmor")) {
+                ICompatModule.loadCompatModule(modEventBus, AzureLibArmorCompat.class);
+            }
+
+            if (ModList.get().isLoaded("firstperson")) {
+                ICompatModule.loadCompatModule(modEventBus, FirstPersonCompat.class);
+            }
+
+            if (ModList.get().isLoaded("skinlayers3d")) {
+                ICompatModule.loadCompatModule(modEventBus, SkinLayer3DCompat.class);
+            }
+
+            if (ModList.get().isLoaded("iris")) {
+                ICompatModule.loadCompatModule(modEventBus, IRISCompat.class);
+            }
+
+            if (ModList.get().isLoaded("playeranimator")) {
+                ICompatModule.loadCompatModule(modEventBus, PlayerAnimatorCompat.class);
+            }
 
             if (ModList.get().getModFiles().stream().anyMatch(modFile -> {
                 try {
@@ -235,8 +239,8 @@ public class EpicFightMod {
             })) {
                 ICompatModule.loadCompatModule(modEventBus, MCreatorPlayerAnimationsCompat.class);
             }
-		}
-	}
+        }
+    }
     
     /**
      * FML Lifecycle Events

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -52,17 +52,7 @@ import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen;
 import yesman.epicfight.client.renderer.patched.item.EpicFightItemProperties;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 import yesman.epicfight.compat.*;
-import yesman.epicfight.compat.azurelib.AzureLibArmorCompat;
-import yesman.epicfight.compat.azurelib.AzureLibCompat;
-import yesman.epicfight.compat.curiosapi.CuriosCompat;
-import yesman.epicfight.compat.firstperson.FirstPersonCompat;
-import yesman.epicfight.compat.geckolib.GeckolibCompat;
-import yesman.epicfight.compat.iris.IRISCompat;
 import yesman.epicfight.compat.mcreator.MCreatorPlayerAnimationsCompat;
-import yesman.epicfight.compat.playeranimator.PlayerAnimatorCompat;
-import yesman.epicfight.compat.skinlayer3d.SkinLayer3DCompat;
-import yesman.epicfight.compat.vampirism.VampirismCompat;
-import yesman.epicfight.compat.werewolves.WerewolvesCompat;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.config.CommonConfig;
 import yesman.epicfight.config.ServerConfig;
@@ -94,6 +84,8 @@ import yesman.epicfight.world.item.SkillBookItem;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -178,57 +170,29 @@ public class EpicFightMod {
     	
     	EpicFightRegistries.DEFERRED_REGISTRIES.forEach(deferredRegistry -> deferredRegistry.register(modEventBus));
 
+        if (EpicFightSharedConstants.isPhysicalClient()) {
+            modEventBus.addListener(ComputeShaderProvider::epicfight$registerComputeShaders);
+        }
         loadModCompatibilityModules(modEventBus);
 	}
 
+    private List<? extends Class<? extends ICompatModule>> getCompatibilityModules(final boolean isClientSide) {
+        return Arrays.stream(MinecraftMod.values())
+                .filter(mod -> ModList.get().isLoaded(mod.getModId()))
+                // Includes all mods on client. Skips client-only mods on server
+                .filter(mod -> isClientSide || !mod.isClientOnly())
+                .map(MinecraftMod::getCompatibilityModule)
+                .toList();
+    }
+
     private void loadModCompatibilityModules(@NotNull IEventBus modEventBus) {
-        // TODO: Improve "ICompatModule"s registration by avoiding duplicating "ModList.get().isLoaded()".
-        //  Make sure we're not duplicating the mod ID anywhere else, like in "GeckolibMixinPlugin".
-        //  ALso, extract this in a separate function and avoid duplicating "ICompatModule.loadCompatModule" too.
+        final boolean isClientSide = EpicFightSharedConstants.isPhysicalClient();
 
-        if (ModList.get().isLoaded("vampirism")) {
-            ICompatModule.loadCompatModule(modEventBus, VampirismCompat.class);
+        for (final Class<? extends ICompatModule> module : getCompatibilityModules(isClientSide)) {
+            ICompatModule.loadCompatModule(modEventBus, module);
         }
 
-        if (ModList.get().isLoaded("werewolves")) {
-            ICompatModule.loadCompatModule(modEventBus, WerewolvesCompat.class);
-        }
-
-        if (ModList.get().isLoaded("curios")) {
-            ICompatModule.loadCompatModule(modEventBus, CuriosCompat.class);
-        }
-
-        if (EpicFightSharedConstants.isPhysicalClient()) {
-            modEventBus.addListener(ComputeShaderProvider::epicfight$registerComputeShaders);
-
-            if (ModList.get().isLoaded("geckolib")) {
-                ICompatModule.loadCompatModule(modEventBus, GeckolibCompat.class);
-            }
-
-            if (ModList.get().isLoaded("azurelib")) {
-                ICompatModule.loadCompatModule(modEventBus, AzureLibCompat.class);
-            }
-
-            if (ModList.get().isLoaded("azurelibarmor")) {
-                ICompatModule.loadCompatModule(modEventBus, AzureLibArmorCompat.class);
-            }
-
-            if (ModList.get().isLoaded("firstperson")) {
-                ICompatModule.loadCompatModule(modEventBus, FirstPersonCompat.class);
-            }
-
-            if (ModList.get().isLoaded("skinlayers3d")) {
-                ICompatModule.loadCompatModule(modEventBus, SkinLayer3DCompat.class);
-            }
-
-            if (ModList.get().isLoaded("iris")) {
-                ICompatModule.loadCompatModule(modEventBus, IRISCompat.class);
-            }
-
-            if (ModList.get().isLoaded("playeranimator")) {
-                ICompatModule.loadCompatModule(modEventBus, PlayerAnimatorCompat.class);
-            }
-
+        if (isClientSide) {
             if (ModList.get().getModFiles().stream().anyMatch(modFile -> {
                 try {
                     Path dataPath = modFile.getFile().findResource("data");


### PR DESCRIPTION
Cleans up the code for easier maintenance by removing duplicated `ModList#isLoaded` and `ICompatModule#loadCompatModule` calls, making it slightly easier to support Fabric. A small step forward.

Tested both the dedicated server and client game, with some mods installed, client-side only, and also on both sides.

As always, compare the differences by viewing each commit for an easier review (in the "Commits" tab).
