### PR TITLE
[1.21.1] Disable Epic Fight's TPS when any TPS mod is installed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,9 @@
 - An option to toggle lock-on snapping and auto target
 - An option to set the maximum distance that the player can focus entities
 - See the devlog [here](https://www.patreon.com/posts/tps-camera-and-141028682)
+- Epic Fight's TPS perspective will be automatically disabled when a conflicting mod, such
+  as [Shoulder Surfing Reloaded](https://modrinth.com/mod/shoulder-surfing-reloaded)
+  or [Better Third Person](https://modrinth.com/mod/better-third-person), is detected to prevent issues.
 
 ### Fixed
 

--- a/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisableState.java
+++ b/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisableState.java
@@ -1,0 +1,26 @@
+package yesman.epicfight.client.camera;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.config.ClientConfig;
+import yesman.epicfight.main.EpicFightMod;
+
+import java.util.Objects;
+
+public final class EpicFightTpsCameraDisableState {
+    private EpicFightTpsCameraDisableState() {
+    }
+
+    private static @Nullable EpicFightTpsCameraDisabledReason reason = null;
+
+    public static void disable(@NotNull EpicFightTpsCameraDisabledReason reason) {
+        Objects.requireNonNull(reason, "reason must not be null");
+        EpicFightTpsCameraDisableState.reason = reason;
+        EpicFightMod.LOGGER.info("Epic Fight TPS mode has been disabled due to a mod conflict with {}", reason.getModName());
+        ClientConfig.cameraMode = ClientConfig.TPSType.ALWAYS_BACK;
+    }
+
+    public static @Nullable EpicFightTpsCameraDisabledReason getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisabledReason.java
+++ b/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisabledReason.java
@@ -1,0 +1,24 @@
+package yesman.epicfight.client.camera;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Indicates why Epic Fight’s built-in third-person camera was disabled.
+ * <p>
+ * Epic Fight automatically turns off its own third-person mode when a
+ * compatible third-party camera mod is detected.
+ */
+public enum EpicFightTpsCameraDisabledReason {
+    ShoulderSurfing("Shoulder Surfing"),
+    BetterThirdPerson("Better Third Person");
+
+    final private @NotNull String modName;
+
+    EpicFightTpsCameraDisabledReason(@NotNull String modName) {
+        this.modName = modName;
+    }
+
+    public @NotNull String getModName() {
+        return modName;
+    }
+}

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -372,6 +372,23 @@ public class RenderEngine implements IEventBasedEngine {
 	public static boolean hitResultNotEquals(@Nullable HitResult hitResult, HitResult.Type hitType) {
 		return hitResult == null ? true : !hitType.equals(hitResult.getType());
 	}
+
+    /**
+     * @deprecated Left for Shoulder Surfing Backward-Compatibility.
+     * <a href="https://github.com/Exopandora/ShoulderSurfing/issues/359#issuecomment-3551814165">Related issue</a>
+     */
+    @Deprecated(forRemoval = true)
+    public void correctCamera(ViewportEvent.ComputeCameraAngles event, float partialTicks) {
+        event.getCamera().setRotation(1.0F, 1.0F);
+    }
+
+    /**
+     * @deprecated Left for Shoulder Surfing Backward-Compatibility.
+     * <a href="https://github.com/Exopandora/ShoulderSurfing/issues/359#issuecomment-3551814165">Related issue</a>
+     */
+    @Deprecated(forRemoval = true)
+    public void setRangedWeaponThirdPerson(ViewportEvent.ComputeCameraAngles event, CameraType pov, double partialTicks) {
+    }
 	
 	/******************
 	 * Forge Event listeners

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
@@ -11,6 +11,8 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.transformer.HumanoidModelBaker;
 import yesman.epicfight.api.utils.ParseUtil;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisableState;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisabledReason;
 import yesman.epicfight.client.events.engine.RenderEngine;
 import yesman.epicfight.client.gui.datapack.screen.MessageScreen;
 import yesman.epicfight.client.gui.widgets.ColorSlider;
@@ -79,6 +81,15 @@ public class EpicFightGraphicOptionScreen extends EpicFightOptionSubScreen {
             button.setMessage(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective." + ParseUtil.toLowerCase(ClientConfig.cameraMode.name()))));
             cameraSetupButton.active = ClientConfig.cameraMode.hasTPSTransition();
         }).pos(this.width / 2 - 165, this.height / 4 + buttonHeight).size(160, 20).tooltip(Tooltip.create(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective.tooltip")))).build();
+
+        final EpicFightTpsCameraDisabledReason tpsDisabledReason = EpicFightTpsCameraDisableState.getReason();
+        if (tpsDisabledReason != null) {
+            cameraTypeButton.active = false;
+            final Tooltip disabledReasonTooltip = Tooltip.create(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective.disabled_due_to_mod_conflict"), tpsDisabledReason.getModName()));
+
+            cameraTypeButton.setTooltip(disabledReasonTooltip);
+            cameraSetupButton.setTooltip(disabledReasonTooltip);
+        }
 
         cameraSetupButton.active = ClientConfig.cameraMode.hasTPSTransition();
         this.optionsList.addSmall(cameraTypeButton, cameraSetupButton);

--- a/src/main/java/yesman/epicfight/compat/MinecraftMod.java
+++ b/src/main/java/yesman/epicfight/compat/MinecraftMod.java
@@ -3,6 +3,7 @@ package yesman.epicfight.compat;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.compat.azurelib.AzureLibArmorCompat;
 import yesman.epicfight.compat.azurelib.AzureLibCompat;
+import yesman.epicfight.compat.betterthirdperson.BetterThirdPersonCompat;
 import yesman.epicfight.compat.curiosapi.CuriosCompat;
 import yesman.epicfight.compat.firstperson.FirstPersonCompat;
 import yesman.epicfight.compat.geckolib.GeckolibCompat;
@@ -25,7 +26,9 @@ public enum MinecraftMod {
     FIRST_PERSON("firstperson", true, FirstPersonCompat.class),
     SKIN_LAYERS_3D("skinlayers3d", true, SkinLayer3DCompat.class),
     IRIS("iris", true, IRISCompat.class),
-    PLAYER_ANIMATOR("playeranimator", true, PlayerAnimatorCompat.class);
+    PLAYER_ANIMATOR("playeranimator", true, PlayerAnimatorCompat.class),
+    BETTER_THIRD_PERSON("betterthirdperson", true, BetterThirdPersonCompat.class),
+    ;
 
     private final @NotNull String modId;
     private final boolean isClientOnly;

--- a/src/main/java/yesman/epicfight/compat/betterthirdperson/BetterThirdPersonCompat.java
+++ b/src/main/java/yesman/epicfight/compat/betterthirdperson/BetterThirdPersonCompat.java
@@ -1,0 +1,33 @@
+package yesman.epicfight.compat.betterthirdperson;
+
+import net.neoforged.bus.api.IEventBus;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisableState;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisabledReason;
+import yesman.epicfight.compat.ICompatModule;
+
+// Disables the Epic Fight's TPS perspective when this mod is installed,
+// otherwise, both mods will make modifications to the vanilla third-person back perspective,
+// which results in buggy behavior.
+// Note: This does not support the "Better Third Person" mod,
+// features like dodge, attack, and lock-on may not work with Epic Fight.
+public final class BetterThirdPersonCompat implements ICompatModule {
+    @Override
+    public void onModEventBus(IEventBus eventBus) {
+
+    }
+
+    @Override
+    public void onGameEventBus(IEventBus eventBus) {
+
+    }
+
+    @Override
+    public void onModEventBusClient(IEventBus eventBus) {
+        EpicFightTpsCameraDisableState.disable(EpicFightTpsCameraDisabledReason.BetterThirdPerson);
+    }
+
+    @Override
+    public void onGameEventBusClient(IEventBus eventBus) {
+
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
+++ b/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
@@ -10,6 +10,8 @@ import yesman.epicfight.api.client.input.handlers.InputManager;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisableState;
+import yesman.epicfight.client.camera.EpicFightTpsCameraDisabledReason;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
 /**
@@ -48,6 +50,7 @@ public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
     public void register(IShoulderSurfingRegistrar registrar) {
         registrar.registerCameraCouplingCallback(new ForceCameraCouplingWhenAttackingCallback());
         registrar.registerCameraCouplingCallback(new ForceCameraCouplingWhenHoldingSkillCallback());
+        EpicFightTpsCameraDisableState.disable(EpicFightTpsCameraDisabledReason.ShoulderSurfing);
     }
 
     private static class ForceCameraCouplingWhenAttackingCallback implements ICameraCouplingCallback {

--- a/src/main/resources/assets/epicfight/lang/en_us.json
+++ b/src/main/resources/assets/epicfight/lang/en_us.json
@@ -203,6 +203,7 @@
   "gui.epicfight.tps_perspective.always_back": "TPS Perspective: Always back",
   "gui.epicfight.tps_perspective.when_aiming": "TPS Perspective: When aiming",
   "gui.epicfight.tps_perspective.always": "TPS Perspective: Always",
+  "gui.epicfight.tps_perspective.disabled_due_to_mod_conflict": "Epic Fight's TPS perspective is disabled because it conflicts with '%s' mod.\n\nTo enable Epic Fight's TPS perspective, uninstall the conflicting mod and set the camera mode from 'Always Back' to 'Always' after launching the game.",
   "gui.epicfight.tps_setup": "TPS Setup",
   "gui.epicfight.show_attributes.on": "Attributes Tooltip: ON",
   "gui.epicfight.show_attributes.off": "Attributes Tooltip: OFF",


### PR DESCRIPTION
Automatically disables Epic Fight's TPS camera when third-party TPS mods are installed to avoid conflicts or undefined/buggy behavior.

This was done to avoid breaking the expected behavior of existing modpacks, and to prevent inconvenience for a better user experience.

<img width="1698" height="1008" alt="image" src="https://github.com/user-attachments/assets/efa836a7-c40d-4e2c-a489-ff0a9894e2f5" />

<img width="1704" height="994" alt="image" src="https://github.com/user-attachments/assets/9bb123a1-9d57-4bd2-93b6-75d8f66085df" />
