### PR TITLE
[1.21.1] Rename EpicFightInputActions to EpicFightInputAction to follow Java enum naming conventions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,11 @@
   causing issues with its intended functionality.
 - Fixed the mining crosshair not to show in vanilla mode
 
+### For Devs
+
+- Rename the experimental enum `EpicFightInputActions` to `EpicFightInputAction` to follow Java naming
+  conventions. [#2194](https://github.com/Epic-Fight/epicfight/issues/2194)
+
 ## [21.13.5] - 2025-11-12
 
 ### Fixed

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
@@ -435,7 +435,7 @@ public final class EpicFightCameraAPI {
             cancel.setValue(this.isTPSMode() || this.lockingOnTarget);
 
             if (cancel.booleanValue()) {
-                float modifier = !this.lockingOnTarget || InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY) ? 0.15F : (ClientConfig.lockOnQuickShift ? 0.005F : 0.0F);
+                float modifier = !this.lockingOnTarget || InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY) ? 0.15F : (ClientConfig.lockOnQuickShift ? 0.005F : 0.0F);
                 this.setCameraRotations(Mth.clamp(this.cameraXRot + (float)dx * modifier, -90.0F, 90.0F), this.cameraYRot + (float)dy * modifier, false);
 
                 if (ClientConfig.lockOnQuickShift && this.quickShiftDelay <= 0) {
@@ -535,13 +535,13 @@ public final class EpicFightCameraAPI {
 
             if (!entityHitResult.getEntity().is(this.focusingEntity)) {
                 if (entityHitResult.getEntity() instanceof LivingEntity livingentity) {
-                    if (!(entityHitResult.getEntity() instanceof ArmorStand) && (!this.lockingOnTarget || InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY))) {
+                    if (!(entityHitResult.getEntity() instanceof ArmorStand) && (!this.lockingOnTarget || InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY))) {
                         this.focusingEntity = livingentity;
                     }
                 } else if (entityHitResult.getEntity() instanceof PartEntity<?> partEntity) {
                     Entity parent = partEntity.getParent();
 
-                    if (parent instanceof LivingEntity parentLivingEntity && (!this.lockingOnTarget || InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY))) {
+                    if (parent instanceof LivingEntity parentLivingEntity && (!this.lockingOnTarget || InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY))) {
                         this.focusingEntity = parentLivingEntity;
                     }
                 } else {
@@ -637,7 +637,7 @@ public final class EpicFightCameraAPI {
             float desiredYRot = 0.0F;
 
             // Handle camera lock-on
-            if (this.focusingEntity != null && this.lockingOnTarget && !this.isLerpingFpv() && !InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY)) {
+            if (this.focusingEntity != null && this.lockingOnTarget && !this.isLerpingFpv() && !InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY)) {
                 Vec3 povPos = tpsMode ? cameraPos : localPlayer.getEyePosition();
                 Vec3 targetPos = tpsMode ? this.focusingEntity.getBoundingBox().getCenter() : this.focusingEntity.getEyePosition();
                 Vec3 toTarget = targetPos.subtract(povPos);
@@ -662,7 +662,7 @@ public final class EpicFightCameraAPI {
 
                 desiredXRot = (float)MathUtils.getXRotOfVector(playerToTarget);
                 desiredYRot = (float)MathUtils.getYRotOfVector(playerToTarget);
-            } else if (this.lockingOnTarget && InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY)) {
+            } else if (this.lockingOnTarget && InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY)) {
                 desiredXRot = this.cameraXRot;
                 desiredYRot = this.cameraYRot;
             } else if (tpsMode) { // Handle camera tps rotation
@@ -814,7 +814,7 @@ public final class EpicFightCameraAPI {
                 }
                 return true;
             } else if (this.minecraft.options.getCameraType() == CameraType.FIRST_PERSON) {
-                if (!InputManager.isActionActive(EpicFightInputActions.LOCK_ON_SHIFT_FREELY)) {
+                if (!InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY)) {
                     camera.getEntity().setXRot(Mth.rotLerp(partialTick, this.cameraXRotO, this.cameraXRot));
                     camera.getEntity().setYRot(Mth.rotLerp(partialTick, this.cameraYRotO, this.cameraYRot));
                 } else {

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
@@ -3,7 +3,6 @@ package yesman.epicfight.api.client.input.action;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
@@ -17,10 +16,9 @@ import java.util.*;
  * an Epic Fight custom key mapping. These mappings only support keyboard and mouse input.
  * Controller input is not directly supported to avoid dependencies on third-party controller mods.
  * <p>
- * For implementation details, refer to {@link EpicFightInputActions#keyMapping()}.
+ * For implementation details, refer to {@link #keyMapping()}.
  */
-@ApiStatus.Experimental
-public enum EpicFightInputActions implements InputAction {
+public enum EpicFightInputAction implements InputAction {
     /**
      * Corresponds to Minecraft's default "Attack/Destroy" action.
      * <p>
@@ -77,7 +75,7 @@ public enum EpicFightInputActions implements InputAction {
         return isVanilla;
     }
 
-    EpicFightInputActions(final boolean isVanilla) {
+    EpicFightInputAction(final boolean isVanilla) {
         this.id = InputAction.ENUM_MANAGER.assign(this);
         this.isVanilla = isVanilla;
     }
@@ -121,11 +119,11 @@ public enum EpicFightInputActions implements InputAction {
         };
     }
 
-    private static final @NotNull Map<KeyMapping, EpicFightInputActions> BY_KEY_MAPPING;
+    private static final @NotNull Map<KeyMapping, EpicFightInputAction> BY_KEY_MAPPING;
 
     static {
-        Map<KeyMapping, EpicFightInputActions> map = new HashMap<>();
-        for (EpicFightInputActions action : values()) {
+        Map<KeyMapping, EpicFightInputAction> map = new HashMap<>();
+        for (EpicFightInputAction action : values()) {
             map.put(action.keyMapping(), action);
         }
         BY_KEY_MAPPING = Collections.unmodifiableMap(map);
@@ -137,7 +135,7 @@ public enum EpicFightInputActions implements InputAction {
      * @param keyMapping the key mapping; must not be {@code null}
      * @return the corresponding action, or null if none matches
      */
-    public static @Nullable EpicFightInputActions fromKeyMapping(@NotNull KeyMapping keyMapping) {
+    public static @Nullable EpicFightInputAction fromKeyMapping(@NotNull KeyMapping keyMapping) {
         return BY_KEY_MAPPING.get(keyMapping);
     }
 
@@ -145,12 +143,12 @@ public enum EpicFightInputActions implements InputAction {
      * Returns a set of all Epic Fight actions that are not part of the vanilla
      * Minecraft key mappings.
      *
-     * @return a set containing all non-vanilla {@link EpicFightInputActions}
-     * @see EpicFightInputActions#isVanilla
+     * @return a set containing all non-vanilla {@link EpicFightInputAction}
+     * @see EpicFightInputAction#isVanilla
      */
-    public static @NotNull Set<EpicFightInputActions> nonVanillaActions() {
-        Set<EpicFightInputActions> result = EnumSet.noneOf(EpicFightInputActions.class);
-        for (EpicFightInputActions action : EpicFightInputActions.values()) {
+    public static @NotNull Set<EpicFightInputAction> nonVanillaActions() {
+        Set<EpicFightInputAction> result = EnumSet.noneOf(EpicFightInputAction.class);
+        for (EpicFightInputAction action : EpicFightInputAction.values()) {
             if (!action.isVanilla()) result.add(action);
         }
         return result;

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.PlayerInputState;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 
 /**
  * Represents an integration layer for third-party controller mods used by Epic Fight.
@@ -46,9 +46,9 @@ public interface IEpicFightControllerMod {
     /**
      * Retrieves the universal controller binding for a given Epic Fight input action.
      * <p>
-     * This method maps actions such as {@link EpicFightInputActions#JUMP},
-     * {@link EpicFightInputActions#ATTACK}, and
-     * {@link EpicFightInputActions#MOVE_FORWARD} to the corresponding controller
+     * This method maps actions such as {@link EpicFightInputAction#JUMP},
+     * {@link EpicFightInputAction#ATTACK}, and
+     * {@link EpicFightInputAction#MOVE_FORWARD} to the corresponding controller
      * buttons or axes.
      * </p>
      *
@@ -58,11 +58,11 @@ public interface IEpicFightControllerMod {
      * @see ControllerBinding
      */
     @NotNull
-    ControllerBinding getBinding(EpicFightInputActions action);
+    ControllerBinding getBinding(EpicFightInputAction action);
 
     /**
      * Retrieves the current input state.
-     * This is used internally by Epic Fight to perform actions such as {@link EpicFightInputActions#DODGE}.
+     * This is used internally by Epic Fight to perform actions such as {@link EpicFightInputAction#DODGE}.
      *
      * @return a {@link PlayerInputState} representing the current input state.
      */
@@ -80,5 +80,5 @@ public interface IEpicFightControllerMod {
      * @param action2 the second input action
      * @return {@code true} if both actions are bound to the same controller button; {@code false} otherwise
      */
-    boolean isBoundToSameButton(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2);
+    boolean isBoundToSameButton(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2);
 }

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteInputActionTrigger.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/DiscreteInputActionTrigger.java
@@ -4,13 +4,13 @@ import net.minecraft.client.KeyMapping;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 
 /**
- * Handles triggering of a discrete (one-time) {@link EpicFightInputActions}
+ * Handles triggering of a discrete (one-time) {@link EpicFightInputAction}
  * based on the current input state.
  * <p>
  * Consumers of this API provide only the "what to do" for each action;
@@ -35,7 +35,7 @@ public final class DiscreteInputActionTrigger {
      * Called on every client tick to potentially trigger the provided callback for a given input action.
      * <p>
      * Determines *when* to trigger the action; consumers define *how* it executes.
-     * For example, for {@link EpicFightInputActions#OPEN_SKILL_SCREEN}, this method decides when to call
+     * For example, for {@link EpicFightInputAction#OPEN_SKILL_SCREEN}, this method decides when to call
      * the callback that opens the screen, but not how the screen is opened.
      * <p>
      * Consumers do not need to know any keyboard/mouse or controller input internals.
@@ -43,7 +43,7 @@ public final class DiscreteInputActionTrigger {
      * @param action  The input action to monitor.
      * @param handler The callback to run when the action triggers.
      */
-    public static void triggerOnPress(EpicFightInputActions action, DiscreteActionHandler handler) {
+    public static void triggerOnPress(EpicFightInputAction action, DiscreteActionHandler handler) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         final KeyMapping keyMapping = action.keyMapping();
         if (controllerMod == null) {

--- a/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/handlers/InputManager.java
@@ -16,7 +16,7 @@ import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.client.event.InputEvent;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.PlayerInputState;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding.InputType;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
@@ -76,7 +76,7 @@ public final class InputManager {
      * @param action the input action to check
      * @see InputType
      */
-    public static boolean isActionActive(@NotNull EpicFightInputActions action) {
+    public static boolean isActionActive(@NotNull EpicFightInputAction action) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod == null) {
             return isKeyDown(action.keyMapping());
@@ -108,7 +108,7 @@ public final class InputManager {
      * @param action the input action to check
      * @see #isActionActive
      */
-    public static boolean isActionPhysicallyActive(@NotNull EpicFightInputActions action) {
+    public static boolean isActionPhysicallyActive(@NotNull EpicFightInputAction action) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod == null) {
             return isPhysicalKeyDown(action.keyMapping());
@@ -134,7 +134,7 @@ public final class InputManager {
      * @param handler    The callback to invoke when the action triggers.
      * @see DiscreteInputActionTrigger#triggerOnPress Internal implementation details.
      */
-    public static void triggerOnPress(@NotNull EpicFightInputActions action, boolean interactionKeyEventCheck, @NotNull DiscreteActionHandler handler) {
+    public static void triggerOnPress(@NotNull EpicFightInputAction action, boolean interactionKeyEventCheck, @NotNull DiscreteActionHandler handler) {
         DiscreteInputActionTrigger.triggerOnPress(action, (context) -> {
             if (context.triggeredByController() || !interactionKeyEventCheck) {
                 handler.onAction(context);
@@ -146,12 +146,12 @@ public final class InputManager {
     }
 
     /**
-     * Convenience overload of {@link #triggerOnPress(EpicFightInputActions, boolean, DiscreteActionHandler)}
+     * Convenience overload of {@link #triggerOnPress(EpicFightInputAction, boolean, DiscreteActionHandler)}
      * for callbacks that do not require the {@link DiscreteActionHandler.Context}.
      *
-     * @see #triggerOnPress(EpicFightInputActions, boolean, DiscreteActionHandler)
+     * @see #triggerOnPress(EpicFightInputAction, boolean, DiscreteActionHandler)
      */
-    public static void triggerOnPress(@NotNull EpicFightInputActions action, boolean interactionKeyEventCheck, @NotNull Runnable runnable) {
+    public static void triggerOnPress(@NotNull EpicFightInputAction action, boolean interactionKeyEventCheck, @NotNull Runnable runnable) {
         triggerOnPress(action, interactionKeyEventCheck, (context) -> runnable.run());
     }
 
@@ -165,7 +165,7 @@ public final class InputManager {
      * @param action2 the second input action
      * @return true if both actions are triggered by the same key or controller button; false otherwise
      */
-    public static boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2) {
+    public static boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
             return controllerMod.isBoundToSameButton(action, action2);
@@ -236,7 +236,7 @@ public final class InputManager {
      * This method replaces the legacy internal {@link ControlEngine#isKeyPressed}.
      */
     @SuppressWarnings("JavadocReference")
-    private static void runKeyboardMouseEvent(@NotNull EpicFightInputActions action, @NotNull DiscreteActionHandler handler) {
+    private static void runKeyboardMouseEvent(@NotNull EpicFightInputAction action, @NotNull DiscreteActionHandler handler) {
         final KeyMapping keyMapping = action.keyMapping();
 
         final InputConstants.Key key = keyMapping.getKey();

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -34,7 +34,7 @@ import org.lwjgl.glfw.GLFW;
 import yesman.epicfight.api.animation.types.EntityState;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.PlayerInputState;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
@@ -83,7 +83,7 @@ public class ControlEngine implements IEventBasedEngine {
 	private int reserveCounter;
     /**
      * <b>DEPRECATED:</b> This field is retained for backward compatibility and should not be used
-     * for comparisons or method calls on this instance. In future updates, {@link EpicFightInputActions}
+     * for comparisons or method calls on this instance. In future updates, {@link EpicFightInputAction}
      * will be stored directly instead of a vanilla {@link KeyMapping}.
      *
      * <p>Do not rely on this field for new functionality. For mapping a {@link KeyMapping} to an
@@ -99,7 +99,7 @@ public class ControlEngine implements IEventBasedEngine {
      * <b>DEPRECATED:</b> Consider using {@link ControlEngine#isCurrentHoldingAction} or 
      * {@link ControlEngine#isCurrentHoldingActionActive} instead of directly 
      * accessing or comparing this field. This field is retained for backward 
-     * compatibility; in future updates, {@link EpicFightInputActions} will be 
+     * compatibility; in future updates, {@link EpicFightInputAction} will be
      * stored directly instead of a vanilla {@link KeyMapping}.
      *
      * @see ControlEngine#mapKeyMappingToAction
@@ -145,29 +145,29 @@ public class ControlEngine implements IEventBasedEngine {
 			return;
 		}
 		
-        InputManager.triggerOnPress(EpicFightInputActions.OPEN_SKILL_SCREEN, false, this::openSkillEditor);
+        InputManager.triggerOnPress(EpicFightInputAction.OPEN_SKILL_SCREEN, false, this::openSkillEditor);
         
-        InputManager.triggerOnPress(EpicFightInputActions.OPEN_CONFIG_SCREEN, false, this::openConfig);
+        InputManager.triggerOnPress(EpicFightInputAction.OPEN_CONFIG_SCREEN, false, this::openConfig);
         
-        InputManager.triggerOnPress(EpicFightInputActions.SWITCH_VANILLA_MODEL_DEBUGGING, false, this::switchVanillaModelDebugging);
+        InputManager.triggerOnPress(EpicFightInputAction.SWITCH_VANILLA_MODEL_DEBUGGING, false, this::switchVanillaModelDebugging);
         
-        InputManager.triggerOnPress(EpicFightInputActions.ATTACK, true, this::maybeAttack);
+        InputManager.triggerOnPress(EpicFightInputAction.ATTACK, true, this::maybeAttack);
         
-        InputManager.triggerOnPress(EpicFightInputActions.DODGE, true, this::maybeDodge);
+        InputManager.triggerOnPress(EpicFightInputAction.DODGE, true, this::maybeDodge);
         
-        if (InputManager.isActionActive(EpicFightInputActions.GUARD)) this.maybeGuard();
+        if (InputManager.isActionActive(EpicFightInputAction.GUARD)) this.maybeGuard();
         
-        InputManager.triggerOnPress(EpicFightInputActions.WEAPON_INNATE_SKILL, true, this::handleSeparateWeaponInnateSkill);
+        InputManager.triggerOnPress(EpicFightInputAction.WEAPON_INNATE_SKILL, true, this::handleSeparateWeaponInnateSkill);
         
-        InputManager.triggerOnPress(EpicFightInputActions.MOBILITY, true, this::maybePerformMoverSkill);
+        InputManager.triggerOnPress(EpicFightInputAction.MOBILITY, true, this::maybePerformMoverSkill);
         
-        InputManager.triggerOnPress(EpicFightInputActions.SWITCH_MODE, false, this::switchMode);
+        InputManager.triggerOnPress(EpicFightInputAction.SWITCH_MODE, false, this::switchMode);
 
-        InputManager.triggerOnPress(EpicFightInputActions.LOCK_ON, false, this::toggleLockOnState);
+        InputManager.triggerOnPress(EpicFightInputAction.LOCK_ON, false, this::toggleLockOnState);
 
-        InputManager.triggerOnPress(EpicFightInputActions.LOCK_ON_SHIFT_LEFT, false, this::searchNewTargetFromLeft);
+        InputManager.triggerOnPress(EpicFightInputAction.LOCK_ON_SHIFT_LEFT, false, this::searchNewTargetFromLeft);
 
-        InputManager.triggerOnPress(EpicFightInputActions.LOCK_ON_SHIFT_RIGHT, false, this::searchNewTargetFromRight);
+        InputManager.triggerOnPress(EpicFightInputAction.LOCK_ON_SHIFT_RIGHT, false, this::searchNewTargetFromRight);
 
         if (shouldDisableSwapHandItems()) consumeSwapOffhandKeyClicks();
 		
@@ -181,16 +181,16 @@ public class ControlEngine implements IEventBasedEngine {
 		}
 		
 		if (this.weaponInnatePressToggle) {
-			if (!InputManager.isActionActive(EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+			if (!InputManager.isActionActive(EpicFightInputAction.WEAPON_INNATE_SKILL)) {
 				this.attackLightPressToggle = true;
 				this.weaponInnatePressToggle = false;
 				this.weaponInnatePressCounter = 0;
 			} else {
-				if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.WEAPON_INNATE_SKILL, EpicFightInputActions.ATTACK)) {
+				if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.WEAPON_INNATE_SKILL, EpicFightInputAction.ATTACK)) {
 					if (this.weaponInnatePressCounter > ClientConfig.longPressCounter) {
 						if (this.playerpatch.getSkill(SkillSlots.WEAPON_INNATE).sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
 							if (!this.player.isSpectator()) {
-								this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputActions.WEAPON_INNATE_SKILL);
+								this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputAction.WEAPON_INNATE_SKILL);
 							}
 						} else {
 							this.lockHotkeys();
@@ -215,7 +215,7 @@ public class ControlEngine implements IEventBasedEngine {
 				this.releaseAllServedKeys();
 			} else {
 				if (!this.player.isSpectator() && slot == SkillSlots.COMBO_ATTACKS) {
-					this.reserveKey(slot, EpicFightInputActions.ATTACK);
+					this.reserveKey(slot, EpicFightInputAction.ATTACK);
 				}
 			}
 			
@@ -227,12 +227,12 @@ public class ControlEngine implements IEventBasedEngine {
 		}
 		
 		if (this.sneakPressToggle) {
-			if (!InputManager.isActionActive(EpicFightInputActions.SNEAK)) {
+			if (!InputManager.isActionActive(EpicFightInputAction.SNEAK)) {
 				SkillSlot skillSlot = (this.playerpatch.getEntityState().knockDown()) ? SkillSlots.KNOCKDOWN_WAKEUP : SkillSlots.DODGE;
 				SkillContainer skill = this.playerpatch.getSkill(skillSlot);
 
 				if (skill.sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
-					this.reserveKey(skillSlot, EpicFightInputActions.SNEAK);
+					this.reserveKey(skillSlot, EpicFightInputAction.SNEAK);
 				}
 				
 				this.sneakPressToggle = false;
@@ -341,11 +341,11 @@ public class ControlEngine implements IEventBasedEngine {
     }
 
     private void maybeAttack() {
-        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.ATTACK)) {
+        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.ATTACK)) {
             return;
         }
-        final EpicFightInputActions vanillaAttack = EpicFightInputActions.VANILLA_ATTACK_DESTROY;
-        final EpicFightInputActions epicFightAttack = EpicFightInputActions.ATTACK;
+        final EpicFightInputAction vanillaAttack = EpicFightInputAction.VANILLA_ATTACK_DESTROY;
+        final EpicFightInputAction epicFightAttack = EpicFightInputAction.ATTACK;
 
         boolean shouldPlayAttackAnimation = this.playerpatch.canPlayAttackAnimation();
         if (vanillaAttack.keyMapping().getKey() == epicFightAttack.keyMapping().getKey() &&
@@ -354,7 +354,7 @@ public class ControlEngine implements IEventBasedEngine {
         }
 
         if (shouldPlayAttackAnimation) {
-            if (!InputManager.isBoundToSamePhysicalInput(epicFightAttack, EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+            if (!InputManager.isBoundToSamePhysicalInput(epicFightAttack, EpicFightInputAction.WEAPON_INNATE_SKILL)) {
                 SkillContainer airSlash = this.playerpatch.getSkill(SkillSlots.AIR_SLASH);
                 SkillSlot slot = (this.tickSinceLastJump > 0 && airSlash.getSkill() != null && airSlash.getSkill().canExecute(airSlash)) ? SkillSlots.AIR_SLASH : SkillSlots.COMBO_ATTACKS;
                 SkillCastEvent skillCastEvent = this.playerpatch.getSkill(slot).sendCastRequest(this.playerpatch, this);
@@ -382,10 +382,10 @@ public class ControlEngine implements IEventBasedEngine {
     }
 
     private void maybeDodge() {
-        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.DODGE)) {
+        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.DODGE)) {
             return;
         }
-        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.DODGE, EpicFightInputActions.SNEAK)) {
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.DODGE, EpicFightInputAction.SNEAK)) {
             if (this.player.getVehicle() == null) {
                 if (!this.sneakPressToggle) {
                     this.sneakPressToggle = true;
@@ -396,13 +396,13 @@ public class ControlEngine implements IEventBasedEngine {
             SkillContainer skill = this.playerpatch.getSkill(skillCategory);
 
             if (!skill.isEmpty() && skill.sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
-                this.reserveKey(SkillSlots.DODGE, EpicFightInputActions.DODGE);
+                this.reserveKey(SkillSlots.DODGE, EpicFightInputAction.DODGE);
             }
         }
     }
 
     private void maybeGuard() {
-        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.GUARD)) {
+        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.GUARD)) {
             return;
         }
         boolean shouldCancelGuard = false;
@@ -418,7 +418,7 @@ public class ControlEngine implements IEventBasedEngine {
 
             if (skillCastEvent.shouldReserveKey()) {
                 if (!this.player.isSpectator()) {
-                    this.reserveKey(SkillSlots.GUARD, EpicFightInputActions.GUARD);
+                    this.reserveKey(SkillSlots.GUARD, EpicFightInputAction.GUARD);
                 }
             } else {
                 this.lockHotkeys();
@@ -427,13 +427,13 @@ public class ControlEngine implements IEventBasedEngine {
     }
 
     private void handleSeparateWeaponInnateSkill() {
-        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+        if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.WEAPON_INNATE_SKILL)) {
             return;
         }
-        if (!InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.ATTACK, EpicFightInputActions.WEAPON_INNATE_SKILL)) {
+        if (!InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.ATTACK, EpicFightInputAction.WEAPON_INNATE_SKILL)) {
             if (this.playerpatch.getSkill(SkillSlots.WEAPON_INNATE).sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
                 if (!this.player.isSpectator()) {
-                    this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputActions.WEAPON_INNATE_SKILL);
+                    this.reserveKey(SkillSlots.WEAPON_INNATE, EpicFightInputAction.WEAPON_INNATE_SKILL);
                 }
             } else {
                 this.lockHotkeys();
@@ -446,7 +446,7 @@ public class ControlEngine implements IEventBasedEngine {
             return;
         }
         
-        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.MOBILITY, EpicFightInputActions.JUMP)) {
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.MOBILITY, EpicFightInputAction.JUMP)) {
             SkillContainer skillContainer = this.playerpatch.getSkill(SkillSlots.MOVER);
 
             if (!skillContainer.isEmpty()) {
@@ -491,7 +491,7 @@ public class ControlEngine implements IEventBasedEngine {
 		PlayerInputState inputState = InputManager.getInputState(input);
 		
 		if (this.moverPressToggle) {
-			if (!InputManager.isActionActive(EpicFightInputActions.JUMP)) {
+			if (!InputManager.isActionActive(EpicFightInputAction.JUMP)) {
 				this.moverPressToggle = false;
 				this.moverPressCounter = 0;
 				
@@ -528,8 +528,8 @@ public class ControlEngine implements IEventBasedEngine {
      * <b>DEPRECATED:</b> This method is retained for backward compatibility and will 
      * be removed in a future release. Do not use it for new code.
      * <p>Instead of using this method, use
-     * {@link #reserveKey(SkillSlot, EpicFightInputActions)}, which works directly
-     * with {@link EpicFightInputActions}.</p>
+     * {@link #reserveKey(SkillSlot, EpicFightInputAction)}, which works directly
+     * with {@link EpicFightInputAction}.</p>
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated(forRemoval = true)
@@ -539,7 +539,7 @@ public class ControlEngine implements IEventBasedEngine {
 		this.reserveCounter = 8;
 	}
 
-    private void reserveKey(SkillSlot slot, EpicFightInputActions action) {
+    private void reserveKey(SkillSlot slot, EpicFightInputAction action) {
         reserveKey(slot, action.keyMapping());
     }
 	
@@ -689,7 +689,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     public static void setSprintingKeyStateNotDown() {
-        KeyMapping.set(EpicFightInputActions.SPRINT.keyMapping().getKey(), false);
+        KeyMapping.set(EpicFightInputAction.SPRINT.keyMapping().getKey(), false);
     }
 
     /**
@@ -770,7 +770,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeVanillaAttackKeyClicks() {
-        makeUnpressed(EpicFightInputActions.VANILLA_ATTACK_DESTROY.keyMapping());
+        makeUnpressed(EpicFightInputAction.VANILLA_ATTACK_DESTROY.keyMapping());
     }
 
     /**
@@ -788,7 +788,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeSwapOffhandKeyClicks() {
-        makeUnpressed(EpicFightInputActions.SWAP_OFF_HAND.keyMapping());
+        makeUnpressed(EpicFightInputAction.SWAP_OFF_HAND.keyMapping());
     }
 
     /**
@@ -821,17 +821,17 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeDropKeyClicks() {
-        makeUnpressed(EpicFightInputActions.DROP.keyMapping());
+        makeUnpressed(EpicFightInputAction.DROP.keyMapping());
     }
 
     /**
      * Maps a {@link KeyMapping} to its corresponding input action, if defined.
      * <p>
-     * Each {@link EpicFightInputActions} enum constant has an associated {@link KeyMapping},
-     * but not every {@link KeyMapping} corresponds to an {@link EpicFightInputActions}, so this may return {@code null}.
+     * Each {@link EpicFightInputAction} enum constant has an associated {@link KeyMapping},
+     * but not every {@link KeyMapping} corresponds to an {@link EpicFightInputAction}, so this may return {@code null}.
      * Using {@link KeyMapping} directly does not support controllers.
      * <p>
-     * Ideally, this workaround should not exist. The code should depend on {@link EpicFightInputActions} directly
+     * Ideally, this workaround should not exist. The code should depend on {@link EpicFightInputAction} directly
      * instead of storing {@link KeyMapping} instances. However, since some classes and Epic Fight addons still rely on:
      * <ul>
      *   <li>{@link HoldableSkill#getKeyMapping}</li>
@@ -844,8 +844,8 @@ public class ControlEngine implements IEventBasedEngine {
      * Sometimes, it makes sense to use this method, for example, if you're using an event such as {@link InputEvent.InteractionKeyMappingTriggered},
      * which provides only a {@link KeyMapping}.
      */
-    private static @Nullable EpicFightInputActions mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
-        return EpicFightInputActions.fromKeyMapping(keyMapping);
+    private static @Nullable EpicFightInputAction mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
+        return EpicFightInputAction.fromKeyMapping(keyMapping);
     }
 
     /**
@@ -855,11 +855,11 @@ public class ControlEngine implements IEventBasedEngine {
      * @return {@code true} if the given action is currently held; otherwise {@code false}
      * @see ControlEngine#mapKeyMappingToAction
      */
-    private boolean isCurrentHoldingAction(@NotNull EpicFightInputActions other) {
+    private boolean isCurrentHoldingAction(@NotNull EpicFightInputAction other) {
         if (currentHoldingKey == null) {
             return false;
         }
-        final EpicFightInputActions currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        final EpicFightInputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
         if (currentHoldingAction == null) {
             // Fallback for legacy or custom key mappings.
             // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
@@ -873,7 +873,7 @@ public class ControlEngine implements IEventBasedEngine {
         if (currentHoldingKey == null) {
             return false;
         }
-        final EpicFightInputActions currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        final EpicFightInputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
         if (currentHoldingAction == null) {
             // Fallback for legacy or custom key mappings.
             // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
@@ -959,7 +959,7 @@ public class ControlEngine implements IEventBasedEngine {
 	private void epicfight$interactionKeyMappingTriggered(InputEvent.InteractionKeyMappingTriggered event) {
         if (this.minecraft.player == null || this.minecraft.hitResult == null) return;
 
-        final EpicFightInputActions triggeredAction = mapKeyMappingToAction(event.getKeyMapping());
+        final EpicFightInputAction triggeredAction = mapKeyMappingToAction(event.getKeyMapping());
 
         if (triggeredAction == null) {
             // The key mapping corresponds to a fixed vanilla action (attack, pick block, or use item).
@@ -968,8 +968,8 @@ public class ControlEngine implements IEventBasedEngine {
         }
 
 		if (
-            triggeredAction == EpicFightInputActions.VANILLA_ATTACK_DESTROY &&
-            InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.ATTACK, EpicFightInputActions.VANILLA_ATTACK_DESTROY) &&
+            triggeredAction == EpicFightInputAction.VANILLA_ATTACK_DESTROY &&
+            InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.ATTACK, EpicFightInputAction.VANILLA_ATTACK_DESTROY) &&
 			this.minecraft.hitResult.getType() == HitResult.Type.BLOCK &&
 			ClientConfig.combatPreferredItems.contains(this.player.getMainHandItem().getItem())
 		) {
@@ -983,8 +983,8 @@ public class ControlEngine implements IEventBasedEngine {
 		}
 		
 		if (
-			triggeredAction == EpicFightInputActions.USE &&
-			InputManager.isBoundToSamePhysicalInput(EpicFightInputActions.USE, EpicFightInputActions.GUARD) &&
+			triggeredAction == EpicFightInputAction.USE &&
+			InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.USE, EpicFightInputAction.GUARD) &&
 			(
 				ClientConfig.keyConflictResolveScope.cancelInteraction() ||
 				ClientConfig.keyConflictResolveScope.cancelItemUse()

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -55,7 +55,7 @@ import org.joml.Vector3f;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.client.animation.AnimationSubFileReader;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.neoevent.PatchedRenderersEvent;
@@ -452,7 +452,7 @@ public class RenderEngine implements IEventBasedEngine {
 		if (ClientConfig.showEpicFightAttributesInTooltip && event.getEntity() != null && event.getEntity().level().isClientSide) {
 			EpicFightCapabilities.getUnparameterizedEntityPatch(event.getEntity(), LocalPlayerPatch.class).ifPresent(playerpatch -> {
 				EpicFightCapabilities.getItemCapability(event.getItemStack()).ifPresent(itemCapability -> {
-					if (InputManager.isActionPhysicallyActive(EpicFightInputActions.WEAPON_INNATE_SKILL_TOOLTIP)) {
+					if (InputManager.isActionPhysicallyActive(EpicFightInputAction.WEAPON_INNATE_SKILL_TOOLTIP)) {
 						Skill weaponInnateSkill = itemCapability.getInnateSkill(playerpatch, event.getItemStack());
 						
 						if (weaponInnateSkill != null) {

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
@@ -36,7 +36,7 @@ import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings.
 import yesman.epicfight.api.client.animation.Layer;
 import yesman.epicfight.api.client.animation.property.ClientAnimationProperties;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.client.events.engine.ControlEngine;
@@ -180,7 +180,7 @@ public class LocalPlayerPatch extends AbstractClientPlayerPatch<LocalPlayer> {
 	
 	@Override
 	public boolean shouldBlockMoving() {
-		return InputManager.isActionActive(EpicFightInputActions.MOVE_BACKWARD) || InputManager.isActionActive(EpicFightInputActions.SNEAK);
+		return InputManager.isActionActive(EpicFightInputAction.MOVE_BACKWARD) || InputManager.isActionActive(EpicFightInputAction.SNEAK);
 	}
 	
 	@Override

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -38,7 +38,7 @@ import org.joml.Vector2f;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.PlayerInputState;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
@@ -146,7 +146,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         /**
-         * Maps a non-vanilla {@link EpicFightInputActions} to its corresponding translation keys.
+         * Maps a non-vanilla {@link EpicFightInputAction} to its corresponding translation keys.
          *
          * @param action the non-vanilla action to get the translation key for
          * @return a {@link TranslationKeys} instance containing the translation keys for the name and description
@@ -154,7 +154,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
          *                                  is only relevant for Epic Fight custom input binds.
          *                                  Vanilla input binds are handled internally by Controlify.
          */
-        private static @NotNull TranslationKeys fromAction(@NotNull EpicFightInputActions action) {
+        private static @NotNull TranslationKeys fromAction(@NotNull EpicFightInputAction action) {
             return switch (action) {
                 case ATTACK -> new TranslationKeys("key.epicfight.attack", "key.epicfight.attack.description");
                 case DODGE -> new TranslationKeys("key.epicfight.dodge", "key.epicfight.dodge.description");
@@ -191,7 +191,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             };
         }
 
-        private static @NotNull Component getNameOf(@NotNull EpicFightInputActions action) {
+        private static @NotNull Component getNameOf(@NotNull EpicFightInputAction action) {
             return fromAction(action).getNameComponent();
         }
     }
@@ -229,7 +229,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private static void registerInputBindings(ControlifyBindApi registrar) {
-        for (EpicFightInputActions action : EpicFightInputActions.nonVanillaActions()) {
+        for (EpicFightInputAction action : EpicFightInputAction.nonVanillaActions()) {
             registerInputBinding(registrar, action);
         }
     }
@@ -238,7 +238,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
      * Registers a non-vanilla input binding with Controlify.
      * <p>
      * Must <strong>only</strong> be called for non-vanilla
-     * {@link EpicFightInputActions}. Vanilla actions are already registered
+     * {@link EpicFightInputAction}. Vanilla actions are already registered
      * and calling this with one will throw {@link IllegalArgumentException}.
      * <p>
      * <strong>Type-safety and exhaustive checking:</strong><br>
@@ -255,7 +255,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     @SuppressWarnings("UnusedReturnValue") // Read Javadocs of this method before removing.
     private static @NotNull InputBindingSupplier registerInputBinding(
             @NotNull ControlifyBindApi registrar,
-            @NotNull EpicFightInputActions action
+            @NotNull EpicFightInputAction action
     ) {
         final Component combatCategory = Component.translatable(EpicFightKeyMappings.InputCategories.COMBAT);
         final Component guiCategory = Component.translatable(EpicFightKeyMappings.InputCategories.GUI);
@@ -349,7 +349,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private static @NotNull InputBindingBuilder applyCommonBindingProperties(
-            @NotNull EpicFightInputActions action,
+            @NotNull EpicFightInputAction action,
             @NotNull InputBindingBuilder builder
     ) {
         final TranslationKeys translationKeys = TranslationKeys.fromAction(action);
@@ -363,7 +363,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
                 .addKeyCorrelation(keyMappingToIgnore);
     }
 
-    private static @NotNull ResourceLocation getBindingId(@NotNull EpicFightInputActions action) {
+    private static @NotNull ResourceLocation getBindingId(@NotNull EpicFightInputAction action) {
         final String path = switch (action) {
             // Project maintainers: if you change any ID (e.g., "attack"), update assets/controlify too.
             case ATTACK -> "attack";
@@ -430,7 +430,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }));
     }
 
-    private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputActions action) {
+    private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
         final InputBindingSupplier bindingSupplier = switch (action) {
             // Minecraft Vanilla actions
             case VANILLA_ATTACK_DESTROY -> ControlifyBindings.ATTACK;
@@ -503,7 +503,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         @Override
-        public @NotNull ControllerBinding getBinding(EpicFightInputActions action) {
+        public @NotNull ControllerBinding getBinding(EpicFightInputAction action) {
             return new ControllerBindingImpl(getControlifyBinding(action));
         }
 
@@ -530,7 +530,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         @Override
-        public boolean isBoundToSameButton(@NotNull EpicFightInputActions action, @NotNull EpicFightInputActions action2) {
+        public boolean isBoundToSameButton(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
             final Input input1 = getControlifyBinding(action).boundInput();
             final Input input2 = getControlifyBinding(action2).boundInput();
             return input1.getRelevantInputs().equals(input2.getRelevantInputs());

--- a/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
+++ b/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
@@ -5,7 +5,7 @@ import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingPlugin;
 import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistrar;
 
 import net.minecraft.client.Minecraft;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
@@ -56,7 +56,7 @@ public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
     private static class ForceCameraCouplingWhenAttackingCallback implements ICameraCouplingCallback {
         @Override
         public boolean isForcingCameraCoupling(Minecraft minecraft) {
-            return InputManager.isActionActive(EpicFightInputActions.ATTACK) || InputManager.isActionActive(EpicFightInputActions.VANILLA_ATTACK_DESTROY);
+            return InputManager.isActionActive(EpicFightInputAction.ATTACK) || InputManager.isActionActive(EpicFightInputAction.VANILLA_ATTACK_DESTROY);
         }
     }
 

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -37,7 +37,7 @@ import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.client.animation.property.JointMaskReloadListener;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.model.ItemSkinsReloadListener;
 import yesman.epicfight.api.client.model.Meshes;
@@ -165,7 +165,7 @@ public class EpicFightMod {
     	Faction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, Factions.class);
     	EntityPairingPacketType.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EntityPairingPacketTypes.class);
     	if (EpicFightSharedConstants.isPhysicalClient()) {
-            InputAction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EpicFightInputActions.class);
+            InputAction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EpicFightInputAction.class);
         }
     	
     	EpicFightRegistries.DEFERRED_REGISTRIES.forEach(deferredRegistry -> deferredRegistry.register(modEventBus));

--- a/src/main/java/yesman/epicfight/skill/modules/HoldableSkill.java
+++ b/src/main/java/yesman/epicfight/skill/modules/HoldableSkill.java
@@ -4,6 +4,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.nbt.CompoundTag;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.network.server.SPSkillFeedback;
 import yesman.epicfight.skill.Skill;
@@ -48,16 +49,16 @@ public interface HoldableSkill {
      * Retrieves the keybind of this skill.
      * <p>
      * If the returned {@link KeyMapping} corresponds to an action defined in
-     * {@link yesman.epicfight.api.client.input.action.EpicFightInputActions#keyMapping()},
+     * {@link EpicFightInputAction#keyMapping()},
      * controller input will be supported as well. Otherwise, the skill will only
      * support keyboard and mouse input. This is related to the workaround implemented in the internal
      * {@link ControlEngine#mapKeyMappingToAction}.
      * <p>
      * In future updates, this method may be deprecated in favor of returning
-     * {@link yesman.epicfight.api.client.input.action.EpicFightInputActions}
+     * {@link EpicFightInputAction}
      * (OR {@link yesman.epicfight.api.client.input.action.InputAction}) directly,
      * eliminating the need for {@link ControlEngine#mapKeyMappingToAction} to support controllers.
-     * @see yesman.epicfight.api.client.input.action.EpicFightInputActions
+     * @see EpicFightInputAction
      * @see ControlEngine#mapKeyMappingToAction
      */
     @SuppressWarnings({"JavadocReference", "deprecation"})

--- a/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
+++ b/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
@@ -13,7 +13,7 @@ import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.MovementDirection;
-import yesman.epicfight.api.client.input.action.EpicFightInputActions;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.handlers.InputManager;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.PlayerPatchEvent;
@@ -157,6 +157,6 @@ public class PhantomAscentSkill extends Skill {
 	}
 
     private static boolean isJumpActionPressed() {
-        return InputManager.isActionActive(EpicFightInputActions.JUMP);
+        return InputManager.isActionActive(EpicFightInputAction.JUMP);
     }
 }


### PR DESCRIPTION
Part-fi_x of #2194 (one item from the checklist)


This is a change to an experimental API as documented in the WIKI, Javadoc and the `Experimental` annotation:

```md
* <b>Warning:</b> This API is currently marked as experimental.
 * This designation does not imply that the implementation is of an 'experimental' quality,
 * but rather indicates that classes, methods, and fields may be subject to renaming, relocation, or removal.
 * The Epic Fight team reserves the right to modify or completely remove any components of the API at any time,
 * without prior notice.
```

Changes are automated using the IDEA refactoring tool and manually reviewed.

Addons don't use this API yet, which means now this is the perfect time to fix before they adopt `EpicFightInputActions`.