### PR TITLE
[Docs] Add a link reference to Nvidia resource about skinned model

### DIFF
--- a/docs/entity-model.md
+++ b/docs/entity-model.md
@@ -1,0 +1,7 @@
+# Entity Model
+
+This document is a WIP that explains how the player and other entity models work in Epic Fight model.
+
+## References
+
+* [Nvidia Mesh Skinning](https://developer.download.nvidia.com/assets/gamedev/docs/skinning.pdf)


### PR DESCRIPTION
Adds a link to Nvidia mesh skinning as a reference in the GitHub repo so others can refer to it in the future.

For now, this is just to not lose track of this, but someday we should consider designing a more detailed guide, maybe with diagrams and examples too.
This could also be in the WIKI, too, though this is useful for other developers.