### PR TITLE
[1.21.1] Allow third-party mods to use Epic Fight's InputAction

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,9 @@
 - Rename the experimental enum `EpicFightInputActions` to `EpicFightInputAction` to follow Java naming
   conventions. [#2194](https://github.com/Epic-Fight/epicfight/issues/2194)
 - Removed AirSlash and its related fields (SkillCategory, SkillSlot) to merge air slash and combo attacks as one skill
+- Updated the experimental Epic Fight's input API to support using custom input actions that are not a
+  `EpicFightInputAction`.
+  [#2194](https://github.com/Epic-Fight/epicfight/issues/2194)
 
 ### For Devs
 

--- a/src/main/java/yesman/epicfight/api/client/input/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/InputManager.java
@@ -12,10 +12,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.client.input.DiscreteInputActionTrigger;
+
+import java.util.function.Function;
 
 /// High-level input API that abstracts direct interactions with [KeyMapping]
 /// and supports controllers if an Epic Fight controller mod implementation is present
@@ -76,17 +79,8 @@ public final class InputManager {
     ///
     /// @param action the input action to check
     /// @see ControllerBinding
-    public static boolean isActionActive(@NotNull EpicFightInputAction action) {
-        final IEpicFightControllerMod controllerMod = getControllerModApi();
-        if (controllerMod == null) {
-            return isKeyDown(action.keyMapping());
-        }
-
-        return switch (controllerMod.getInputMode()) {
-            case KEYBOARD_MOUSE -> isKeyDown(action.keyMapping());
-            case CONTROLLER -> controllerMod.getBinding(action).isDigitalActiveNow();
-            case MIXED -> isKeyDown(action.keyMapping()) || controllerMod.getBinding(action).isDigitalActiveNow();
-        };
+    public static boolean isActionActive(@NotNull InputAction action) {
+        return checkAction(action, InputManager::isKeyDown);
     }
 
     /// Returns whether the given input action is currently physically active this tick.
@@ -104,17 +98,26 @@ public final class InputManager {
     ///
     /// @param action the input action to check
     /// @see #isActionActive
-    public static boolean isActionPhysicallyActive(@NotNull EpicFightInputAction action) {
+    public static boolean isActionPhysicallyActive(@NotNull InputAction action) {
+        return checkAction(action, InputManager::isPhysicalKeyDown);
+    }
+
+    /// Shared internal utility between [#isActionActive] and [#isActionPhysicallyActive] to handle the differences.
+    private static boolean checkAction(@NotNull InputAction action, @NotNull Function<KeyMapping, Boolean> keyboardCheck) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod == null) {
-            return isPhysicalKeyDown(action.keyMapping());
+            return keyboardCheck.apply(action.keyMapping());
         }
 
         return switch (controllerMod.getInputMode()) {
-            case KEYBOARD_MOUSE -> isPhysicalKeyDown(action.keyMapping());
-            case CONTROLLER -> controllerMod.getBinding(action).isDigitalActiveNow();
-            case MIXED ->
-                    isPhysicalKeyDown(action.keyMapping()) || controllerMod.getBinding(action).isDigitalActiveNow();
+            case KEYBOARD_MOUSE -> keyboardCheck.apply(action.keyMapping());
+            case CONTROLLER -> action.controllerBinding()
+                    .map(ControllerBinding::isDigitalActiveNow)
+                    .orElse(keyboardCheck.apply(action.keyMapping()));
+            case MIXED -> keyboardCheck.apply(action.keyMapping())
+                    || action.controllerBinding()
+                    .map(ControllerBinding::isDigitalActiveNow)
+                    .orElse(false);
         };
     }
 
@@ -123,15 +126,13 @@ public final class InputManager {
     /// @param action  The input action to monitor and trigger.
     /// @param handler The callback to invoke when the action triggers.
     /// @see DiscreteInputActionTrigger#triggerOnPress Internal implementation details.
-    public static void triggerOnPress(@NotNull EpicFightInputAction action, @NotNull DiscreteActionHandler handler) {
+    public static void triggerOnPress(@NotNull InputAction action, @NotNull DiscreteActionHandler handler) {
         DiscreteInputActionTrigger.triggerOnPress(action, handler);
     }
 
-    /// Convenience overload of [#triggerOnPress(EpicFightInputAction, DiscreteActionHandler)]
+    /// Convenience overload of [#triggerOnPress(InputAction, DiscreteActionHandler)]
     /// for callbacks that do not require the [DiscreteActionHandler.Context].
-    ///
-    /// @see #triggerOnPress(EpicFightInputAction, DiscreteActionHandler)
-    public static void triggerOnPress(@NotNull EpicFightInputAction action, @NotNull Runnable runnable) {
+    public static void triggerOnPress(@NotNull InputAction action, @NotNull Runnable runnable) {
         triggerOnPress(action, (context) -> runnable.run());
     }
 
@@ -164,7 +165,7 @@ public final class InputManager {
     /// **Note:** [InputMode#MIXED] is currently unsupported and its behavior is undefined.
     ///
     /// @param vanillaInput the Minecraft vanilla [Input] which will be mapped to a [PlayerInputState];
-    ///                                                                                                                                                                                                                                                                                         ignored if using a controller.
+    ///                                                                                                                                                                                                                                                                                                                                                                         ignored if using a controller.
     /// @return an immutable [PlayerInputState] representing the current input state.
     /// @see InputManager#setInputState
     @NotNull

--- a/src/main/java/yesman/epicfight/api/client/input/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/InputManager.java
@@ -146,7 +146,7 @@ public final class InputManager {
     public static boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
-            return controllerMod.isBoundToSameButton(action, action2);
+            return controllerMod.isBoundToSamePhysicalInput(action, action2);
         }
 
         final KeyMapping keyMapping1 = action.keyMapping();

--- a/src/main/java/yesman/epicfight/api/client/input/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/InputManager.java
@@ -12,7 +12,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
-import yesman.epicfight.api.client.input.controller.ControllerBinding.InputType;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.client.input.DiscreteInputActionTrigger;
@@ -75,7 +75,7 @@ public final class InputManager {
     /// It should not be used while a screen is open.
     ///
     /// @param action the input action to check
-    /// @see InputType
+    /// @see ControllerBinding
     public static boolean isActionActive(@NotNull EpicFightInputAction action) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod == null) {
@@ -120,8 +120,8 @@ public final class InputManager {
 
     /// Called on every client tick to potentially trigger the provided callback for a given input action.
     ///
-    /// @param action                   The input action to monitor and trigger.
-    /// @param handler                  The callback to invoke when the action triggers.
+    /// @param action  The input action to monitor and trigger.
+    /// @param handler The callback to invoke when the action triggers.
     /// @see DiscreteInputActionTrigger#triggerOnPress Internal implementation details.
     public static void triggerOnPress(@NotNull EpicFightInputAction action, @NotNull DiscreteActionHandler handler) {
         DiscreteInputActionTrigger.triggerOnPress(action, handler);
@@ -164,7 +164,7 @@ public final class InputManager {
     /// **Note:** [InputMode#MIXED] is currently unsupported and its behavior is undefined.
     ///
     /// @param vanillaInput the Minecraft vanilla [Input] which will be mapped to a [PlayerInputState];
-    ///                                                                                                                                                                                                                                                 ignored if using a controller.
+    ///                                                                                                                                                                                                                                                                                         ignored if using a controller.
     /// @return an immutable [PlayerInputState] representing the current input state.
     /// @see InputManager#setInputState
     @NotNull

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
@@ -5,7 +5,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
+import yesman.epicfight.compat.controlify.EpicFightControlifyControllerMod;
 
 import java.util.*;
 
@@ -109,6 +112,14 @@ public enum EpicFightInputAction implements InputAction {
             case OPEN_CONFIG_SCREEN -> EpicFightKeyMappings.OPEN_CONFIG_SCREEN;
             case SWITCH_VANILLA_MODEL_DEBUGGING -> EpicFightKeyMappings.SWITCH_VANILLA_MODEL_DEBUGGING;
         };
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull ControllerBinding> controllerBinding() {
+        if (EpicFightControllerModProvider.get() == null) {
+            throw new IllegalStateException("controllerBinding() must not be called when the controller mod is not installed");
+        }
+        return Optional.of(EpicFightControlifyControllerMod.getBinding(this));
     }
 
     private static final @NotNull Map<KeyMapping, EpicFightInputAction> BY_KEY_MAPPING;

--- a/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
@@ -4,28 +4,46 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.client.KeyMapping;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.utils.ExtensibleEnum;
 import yesman.epicfight.api.utils.ExtensibleEnumManager;
 
+import java.util.Optional;
+
 /// Represents a client-side input action in Epic Fight mod.
 ///
-/// Each action is associated with a Minecraft vanilla [KeyMapping], which
-/// only supports keyboard and mouse input.
+/// Each action is associated with:
 ///
-/// Controller input is not directly supported to avoid depending on third-party controller mods.
+/// - a Minecraft vanilla [KeyMapping] (supports keyboard and mouse only).
+/// - a [ControllerBinding], which is an abstraction around the input binding from
+///  third-party controller mods (supports controller only).
+///
+/// **Important:** This class must be called **only on the client**.
 @ApiStatus.Experimental
 public interface InputAction extends ExtensibleEnum {
     ExtensibleEnumManager<InputAction> ENUM_MANAGER = new ExtensibleEnumManager<>("input_action");
 
     /// Returns the Minecraft vanilla [KeyMapping] associated with this action.
     ///
-    /// Note: This mapping only supports keyboard and mouse input and does not support controllers.
-    /// Consumers should consider using a different API when possible to take advantage of
-    /// the current supported controller mod implementation.
-    ///
-    /// **Important:** This method must be called **only on the client**.
+    /// **Note:** This only supports keyboard and mouse input and does not support controllers.
     ///
     /// @return the vanilla [KeyMapping] for this action
+    /// @see #controllerBinding
     @NotNull
     KeyMapping keyMapping();
+
+    /// Returns the universal controller binding associated with this action, if available.
+    ///
+    /// This method may return [Optional#empty()] if the action does not support controller input.
+    ///
+    /// **Important:** Consumers must **not** call this method if the controller mod is not installed,
+    /// since the creation of a [ControllerBinding] requires depending on APIs from the controller mod.
+    ///
+    /// If this was called and the controller mod was not installed, the behavior is undefined and depends
+    /// on the implementation details.
+    /// Usually a [ClassNotFoundException] or [IllegalStateException] is thrown.
+    ///
+    /// @return the [ControllerBinding] for this action, or [Optional#empty()] if not supported
+    /// @see ControllerBinding
+    @NotNull Optional<@NotNull ControllerBinding> controllerBinding();
 }

--- a/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
@@ -1,7 +1,6 @@
 package yesman.epicfight.api.client.input.controller;
 
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /// Represents a controller button or analogue stick axis.
@@ -9,7 +8,21 @@ import org.jetbrains.annotations.NotNull;
 ///
 /// Serves a similar role to Minecraft's vanilla [net.minecraft.client.KeyMapping],
 /// but for controller input instead of keyboard or mouse.
-@ApiStatus.Experimental
+///
+/// ### Input signals
+///
+/// Controller inputs can be either analogue or digital:
+///
+/// - **Analogue:** Inputs with a continuous range of values (e.g., 0.0 to 1.0), such as the movement axes
+/// of a stick or triggers.
+/// - **Digital:** Inputs that are binary,
+/// such as buttons or stick presses (e.g., L3/R3), which are either pressed or released.
+///
+/// **Note:** A single physical control can produce multiple input types.
+/// For example:
+///
+/// - moving a left stick generates analogue signals (X/Y axes)
+/// - pressing the stick down generates a separate digital input
 public interface ControllerBinding {
     /// The ID of the binding (e.g., `epicfight:attack`).
     ///
@@ -17,80 +30,29 @@ public interface ControllerBinding {
     @NotNull
     ResourceLocation id();
 
-    /// Defines the type of input represented by a [ControllerBinding].
-    ///
-    /// Inputs can be either analogue or digital.
-    ///
-    /// Note: A single physical control can produce multiple input types.
-    /// For example:
-    ///
-    /// - moving a left stick generates analogue signals (X/Y axes)
-    /// - pressing the stick down generates a separate digital input
-    enum InputType {
-        /// Inputs with a continuous range of values, such as the movement axes
-        /// of a stick or triggers (e.g., 0.0 to 1.0).
-        ANALOGUE,
-        /// Inputs that are binary,
-        /// such as buttons or stick presses (e.g., L3/R3), which are either pressed or released.
-        DIGITAL
-    }
-
-    /// Returns the type of this controller binding.
-    ///
-    /// @return the [InputType] of this binding
-    @NotNull
-    InputType getInputType();
-
-    /// Returns whether this binding represents an analogue input.
-    ///
-    /// @return true if analogue, false if digital.
-    /// @see InputType
-    default boolean isAnalogueType() {
-        return switch (getInputType()) {
-            case ANALOGUE -> true;
-            case DIGITAL -> false;
-        };
-    }
-
     /// Returns whether the digital state is currently active in this tick.
     ///
-    /// This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
-    ///
     /// @return the current digital state, this tick.
-    /// @see InputType#DIGITAL
     boolean isDigitalActiveNow();
 
     /// Returns whether the digital state was active in the previous tick.
     ///
-    /// This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
-    ///
     /// @return the previous digital state, 1 tick ago.
-    /// @see InputType#DIGITAL
     boolean wasDigitalActivePreviously();
 
     /// Returns whether the digital state was just pressed.
     ///
-    /// This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
-    ///
     /// @return true if the binding is pressed this tick and not pressed the previous tick.
-    /// @see InputType#DIGITAL
     boolean isDigitalJustPressed();
 
     /// Returns whether the digital state was just released.
     ///
-    /// This method is only applicable to digital inputs (e.g., buttons, pressing the stick down).
-    ///
     /// @return true if the binding is not pressed this tick and pressed the previous tick.
-    /// @see InputType#DIGITAL
     boolean isDigitalJustReleased();
 
     /// Returns the current analogue input value.
     ///
-    /// This method is only applicable to analogue inputs (e.g., left stick, right trigger).
-    /// For more details, refer to [InputType#ANALOGUE].
-    ///
     /// @return the current analogue value in the range `0.0`–`1.0`, representing this tick's state.
-    /// @see InputType#ANALOGUE
     float getAnalogueNow();
 
     /// Simulates a press of this binding.

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -29,19 +29,6 @@ public interface IEpicFightControllerMod {
     @NotNull
     InputMode getInputMode();
 
-    /// Retrieves the universal controller binding for a given Epic Fight input action.
-    ///
-    /// This method maps actions such as [EpicFightInputAction#JUMP],
-    /// [EpicFightInputAction#ATTACK], and
-    /// [EpicFightInputAction#MOVE_FORWARD] to the corresponding controller buttons or axes.
-    ///
-    /// @param action the Epic Fight input action to retrieve the binding for.
-    /// @return the [ControllerBinding] associated with the specified action,
-    /// providing both state and metadata about the input.
-    /// @see ControllerBinding
-    @NotNull
-    ControllerBinding getBinding(EpicFightInputAction action);
-
     /// Retrieves the current input state.
     /// This is used internally by Epic Fight to perform actions such as [EpicFightInputAction#DODGE].
     ///

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -53,9 +53,6 @@ public interface IEpicFightControllerMod {
 
     /// Checks whether the specified input actions are bound to the same controller button.
     ///
-    /// This comparison only applies to digital buttons (e.g., A, B, L3, R3) and does not
-    /// account for analogue inputs such as triggers or stick movements.
-    ///
     /// @param action  the first input action
     /// @param action2 the second input action
     /// @return `true` if both actions are bound to the same controller button; `false` otherwise

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -1,6 +1,5 @@
 package yesman.epicfight.api.client.input.controller;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.PlayerInputState;
@@ -21,7 +20,6 @@ import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 /// **Note:** This interface exposes low-level controller integration.
 /// Most consumers should use a higher-level abstraction unless direct access is necessary for functionality
 /// that cannot be achieved otherwise.
-@ApiStatus.Experimental
 public interface IEpicFightControllerMod {
     /// Returns the controller mod’s display name (e.g., `Controlify`).
     /// Intended for logging or debugging only; should not influence gameplay logic or be used as a workaround.
@@ -56,5 +54,5 @@ public interface IEpicFightControllerMod {
     /// @param action  the first input action
     /// @param action2 the second input action
     /// @return `true` if both actions are bound to the same controller button; `false` otherwise
-    boolean isBoundToSameButton(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2);
+    boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2);
 }

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -36,6 +36,7 @@ import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.PlayerInputState;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.InputManager;
+import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
 import yesman.epicfight.api.utils.FakeLevel;
@@ -541,7 +542,7 @@ public class ControlEngine implements IEventBasedEngine {
      * <b>DEPRECATED:</b> This method is retained for backward compatibility and will 
      * be removed in a future release. Do not use it for new code.
      * <p>Instead of using this method, use
-     * {@link #reserveKey(SkillSlot, EpicFightInputAction)}, which works directly
+     * {@link #reserveKey(SkillSlot, InputAction)}, which works directly
      * with {@link EpicFightInputAction}.</p>
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
@@ -552,7 +553,7 @@ public class ControlEngine implements IEventBasedEngine {
 		this.reserveCounter = 8;
 	}
 
-    private void reserveKey(SkillSlot slot, EpicFightInputAction action) {
+    private void reserveKey(SkillSlot slot, InputAction action) {
         reserveKey(slot, action.keyMapping());
     }
 	

--- a/src/main/java/yesman/epicfight/client/input/DiscreteInputActionTrigger.java
+++ b/src/main/java/yesman/epicfight/client/input/DiscreteInputActionTrigger.java
@@ -5,13 +5,14 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.api.client.input.DiscreteActionHandler;
 import yesman.epicfight.api.client.input.InputManager;
 
-/// Handles triggering of a discrete (one-time) [EpicFightInputAction]
+/// Handles triggering of a discrete (one-time) [InputAction]
 /// based on the current input state.
 ///
 /// Consumers of this API provide only the "what to do" for each action;
@@ -42,7 +43,7 @@ public final class DiscreteInputActionTrigger {
     ///
     /// @param action  The input action to monitor.
     /// @param handler The callback to run when the action triggers.
-    public static void triggerOnPress(EpicFightInputAction action, DiscreteActionHandler handler) {
+    public static void triggerOnPress(@NotNull InputAction action, @NotNull DiscreteActionHandler handler) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         final KeyMapping keyMapping = action.keyMapping();
         if (controllerMod == null) {
@@ -51,25 +52,32 @@ public final class DiscreteInputActionTrigger {
         }
 
         switch (controllerMod.getInputMode()) {
-            case MIXED -> {
-                final boolean handled = handleController(controllerMod.getBinding(action), handler);
-                if (handled) {
-                    return;
-                }
-                handleKeyboardAndMouse(keyMapping, handler);
-            }
-            case CONTROLLER -> handleController(controllerMod.getBinding(action), handler);
+            case MIXED -> action.controllerBinding()
+                    .ifPresentOrElse(
+                            controllerBinding -> {
+                                final boolean handled = handleController(controllerBinding, handler);
+                                if (!handled) {
+                                    handleKeyboardAndMouse(keyMapping, handler);
+                                }
+                            },
+                            () -> handleKeyboardAndMouse(keyMapping, handler)
+                    );
+            case CONTROLLER -> action.controllerBinding()
+                    .ifPresentOrElse(
+                            controllerBinding -> handleController(controllerBinding, handler),
+                            () -> handleKeyboardAndMouse(keyMapping, handler)
+                    );
             case KEYBOARD_MOUSE -> handleKeyboardAndMouse(keyMapping, handler);
         }
     }
 
-    private static void handleKeyboardAndMouse(KeyMapping keyMapping, DiscreteActionHandler handler) {
+    private static void handleKeyboardAndMouse(@NotNull KeyMapping keyMapping, @NotNull DiscreteActionHandler handler) {
         while (keyMapping.consumeClick()) {
             handler.onAction(createContext(false));
         }
     }
 
-    private static boolean handleController(ControllerBinding controllerBinding, DiscreteActionHandler handler) {
+    private static boolean handleController(@NotNull ControllerBinding controllerBinding, @NotNull DiscreteActionHandler handler) {
         if (controllerBinding.isDigitalJustPressed()) {
             handler.onAction(createContext(true));
             return true;

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -528,7 +528,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         @Override
-        public boolean isBoundToSameButton(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
+        public boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
             final Input input1 = getControlifyBinding(action).boundInput();
             final Input input2 = getControlifyBinding(action2).boundInput();
             return input1.getRelevantInputs().equals(input2.getRelevantInputs());

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyCompat.java
@@ -544,15 +544,6 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         @Override
-        public @NotNull InputType getInputType() {
-            if (inputBinding.boundInput().type() == dev.isxander.controlify.bindings.input.InputType.AXIS) {
-                return InputType.ANALOGUE;
-            }
-            EpicFightMod.LOGGER.error("The method ControllerBinding#getInputType is misleading and should not be called as it will be removed in future updates.");
-            return InputType.DIGITAL;
-        }
-
-        @Override
         public boolean isDigitalActiveNow() {
             return inputBinding.digitalNow();
         }

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyControllerBinding.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyControllerBinding.java
@@ -1,0 +1,47 @@
+package yesman.epicfight.compat.controlify;
+
+import dev.isxander.controlify.api.bind.InputBinding;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+
+@ApiStatus.Internal
+public record ControlifyControllerBinding(@NotNull InputBinding inputBinding) implements ControllerBinding {
+
+    @Override
+    @NotNull
+    public ResourceLocation id() {
+        return inputBinding.id();
+    }
+
+    @Override
+    public boolean isDigitalActiveNow() {
+        return inputBinding.digitalNow();
+    }
+
+    @Override
+    public boolean wasDigitalActivePreviously() {
+        return inputBinding.digitalPrev();
+    }
+
+    @Override
+    public boolean isDigitalJustPressed() {
+        return inputBinding.justPressed();
+    }
+
+    @Override
+    public boolean isDigitalJustReleased() {
+        return inputBinding.justReleased();
+    }
+
+    @Override
+    public float getAnalogueNow() {
+        return inputBinding.analogueNow();
+    }
+
+    @Override
+    public void emulatePress() {
+        inputBinding.fakePress();
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyBindContexts.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyBindContexts.java
@@ -1,0 +1,46 @@
+package yesman.epicfight.compat.controlify;
+
+import dev.isxander.controlify.api.bind.ControlifyBindApi;
+import dev.isxander.controlify.bindings.BindContext;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.main.EpicFightMod;
+
+public final class EpicFightControlifyBindContexts {
+    private EpicFightControlifyBindContexts() {
+    }
+
+    public static final class EpicFight {
+        private EpicFight() {
+        }
+
+        public static final BindContext COMBAT_MODE = new BindContext(
+                EpicFightMod.rl("epicfight_combat"),
+                mc -> {
+                    final boolean isInGame = isInGame(mc);
+                    return isInGame && ClientEngine.getInstance().isEpicFightMode();
+                }
+        );
+        public static final BindContext LOCK_ON = new BindContext(
+                EpicFightMod.rl("epicfight_lock_on"),
+                mc -> {
+                    final boolean isInGame = isInGame(mc);
+                    return isInGame && EpicFightCameraAPI.getInstance().isLockingOnTarget();
+                }
+        );
+
+        public static void register(@NotNull ControlifyBindApi registrar) {
+            registrar.registerBindContext(COMBAT_MODE);
+            registrar.registerBindContext(LOCK_ON);
+        }
+    }
+
+    public static final BindContext IN_GAME = BindContext.IN_GAME;
+    public static final BindContext ANY_SCREEN = BindContext.ANY_SCREEN;
+
+    public static boolean isInGame(@NotNull Minecraft mc) {
+        return mc.screen == null && mc.level != null && mc.player != null;
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
@@ -1,0 +1,109 @@
+package yesman.epicfight.compat.controlify;
+
+import dev.isxander.controlify.api.bind.InputBinding;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.bindings.input.Input;
+import dev.isxander.controlify.controller.ControllerEntity;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.input.InputMode;
+import yesman.epicfight.api.client.input.PlayerInputState;
+import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
+
+/// Allows Epic Fight to communicate with Controlify APIs without depending on their classes directly.
+@ApiStatus.Internal
+public class EpicFightControlifyControllerMod implements IEpicFightControllerMod {
+    @Override
+    public String getModName() {
+        return "Controlify";
+    }
+
+    @Override
+    public @NotNull InputMode getInputMode() {
+        return switch (EpicFightControlifyEntrypoint.getApi().currentInputMode()) {
+            case KEYBOARD_MOUSE -> InputMode.KEYBOARD_MOUSE;
+            case CONTROLLER -> InputMode.CONTROLLER;
+            case MIXED -> InputMode.MIXED;
+        };
+    }
+
+    @Override
+    public @NotNull ControllerBinding getBinding(EpicFightInputAction action) {
+        return new ControllerBindingImpl(getControlifyBinding(action));
+    }
+
+    public static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
+        return EpicFightControlifyEntrypoint.getControlifyBinding(action);
+    }
+
+    @Override
+    public @NotNull PlayerInputState getInputState() {
+        ControllerEntity controller = EpicFightControlifyEntrypoint.requireControllerEntity();
+
+        InputBinding forwardBind = ControlifyBindings.WALK_FORWARD.on(controller);
+        InputBinding backwardBind = ControlifyBindings.WALK_BACKWARD.on(controller);
+        InputBinding leftBind = ControlifyBindings.WALK_LEFT.on(controller);
+        InputBinding rightBind = ControlifyBindings.WALK_RIGHT.on(controller);
+        InputBinding jumpBind = ControlifyBindings.JUMP.on(controller);
+        InputBinding sneakBind = ControlifyBindings.SNEAK.on(controller);
+
+        float forwardImpulse = forwardBind.analogueNow() - backwardBind.analogueNow();
+        float leftImpulse = leftBind.analogueNow() - rightBind.analogueNow();
+
+        return new PlayerInputState(
+                leftImpulse, forwardImpulse,
+                forwardBind.digitalNow(), backwardBind.digitalNow(),
+                leftBind.digitalNow(), rightBind.digitalNow(),
+                jumpBind.digitalNow(), sneakBind.digitalNow()
+        );
+    }
+
+    @Override
+    public boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
+        final Input input1 = getControlifyBinding(action).boundInput();
+        final Input input2 = getControlifyBinding(action2).boundInput();
+        return input1.getRelevantInputs().equals(input2.getRelevantInputs());
+    }
+
+    private record ControllerBindingImpl(@NotNull InputBinding inputBinding) implements ControllerBinding {
+
+        @Override
+        @NotNull
+        public ResourceLocation id() {
+            return inputBinding.id();
+        }
+
+        @Override
+        public boolean isDigitalActiveNow() {
+            return inputBinding.digitalNow();
+        }
+
+        @Override
+        public boolean wasDigitalActivePreviously() {
+            return inputBinding.digitalPrev();
+        }
+
+        @Override
+        public boolean isDigitalJustPressed() {
+            return inputBinding.justPressed();
+        }
+
+        @Override
+        public boolean isDigitalJustReleased() {
+            return inputBinding.justReleased();
+        }
+
+        @Override
+        public float getAnalogueNow() {
+            return inputBinding.analogueNow();
+        }
+
+        @Override
+        public void emulatePress() {
+            inputBinding.fakePress();
+        }
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
@@ -4,7 +4,6 @@ import dev.isxander.controlify.api.bind.InputBinding;
 import dev.isxander.controlify.bindings.ControlifyBindings;
 import dev.isxander.controlify.bindings.input.Input;
 import dev.isxander.controlify.controller.ControllerEntity;
-import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.client.input.InputMode;
@@ -30,9 +29,8 @@ public class EpicFightControlifyControllerMod implements IEpicFightControllerMod
         };
     }
 
-    @Override
-    public @NotNull ControllerBinding getBinding(EpicFightInputAction action) {
-        return new ControllerBindingImpl(getControlifyBinding(action));
+    public static @NotNull ControllerBinding getBinding(@NotNull EpicFightInputAction action) {
+        return new ControlifyControllerBinding(getControlifyBinding(action));
     }
 
     public static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
@@ -66,44 +64,5 @@ public class EpicFightControlifyControllerMod implements IEpicFightControllerMod
         final Input input1 = getControlifyBinding(action).boundInput();
         final Input input2 = getControlifyBinding(action2).boundInput();
         return input1.getRelevantInputs().equals(input2.getRelevantInputs());
-    }
-
-    private record ControllerBindingImpl(@NotNull InputBinding inputBinding) implements ControllerBinding {
-
-        @Override
-        @NotNull
-        public ResourceLocation id() {
-            return inputBinding.id();
-        }
-
-        @Override
-        public boolean isDigitalActiveNow() {
-            return inputBinding.digitalNow();
-        }
-
-        @Override
-        public boolean wasDigitalActivePreviously() {
-            return inputBinding.digitalPrev();
-        }
-
-        @Override
-        public boolean isDigitalJustPressed() {
-            return inputBinding.justPressed();
-        }
-
-        @Override
-        public boolean isDigitalJustReleased() {
-            return inputBinding.justReleased();
-        }
-
-        @Override
-        public float getAnalogueNow() {
-            return inputBinding.analogueNow();
-        }
-
-        @Override
-        public void emulatePress() {
-            inputBinding.fakePress();
-        }
     }
 }

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -60,7 +60,7 @@ import java.util.Optional;
 // as the Epic Fight mod might not be loaded yet. For example, avoid referencing
 // EpicFightItems.UCHIGATANA.get() in onControlifyPreInit.
 @ApiStatus.Internal
-public class ControlifyCompat implements ControlifyEntrypoint {
+public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     @Override
     public void onControllersDiscovered(ControlifyApi controlify) {
     }
@@ -266,7 +266,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         return switch (action) {
             case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
                  MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
-                    "ControlifyCompat#registerInputBinding() must only be called for non-vanilla actions. " +
+                    "EpicFightControlifyEntrypoint#registerInputBinding() must only be called for non-vanilla actions. " +
                             "This action is vanilla and already registered by Controlify: " + action.name()
             );
             case ATTACK -> attack = registrar.registerBinding(
@@ -380,7 +380,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             case SWITCH_VANILLA_MODEL_DEBUGGING -> "switch_vanilla_mode_debugging";
             case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
                  MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
-                    "ControlifyCompat#getInputBindingId() must only be called for non-vanilla actions. " +
+                    "EpicFightControlifyEntrypoint#getInputBindingId() must only be called for non-vanilla actions. " +
                             "This action is vanilla and already registered by Controlify: " + action.name()
             );
         };

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -18,7 +18,6 @@ import dev.isxander.controlify.api.guide.InGameCtx;
 import dev.isxander.controlify.bindings.BindContext;
 import dev.isxander.controlify.bindings.ControlifyBindings;
 import dev.isxander.controlify.bindings.RadialIcons;
-import dev.isxander.controlify.bindings.input.Input;
 import dev.isxander.controlify.controller.ControllerEntity;
 import dev.isxander.controlify.screenop.ScreenProcessor;
 import dev.isxander.controlify.screenop.ScreenProcessorProvider;
@@ -37,11 +36,8 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector2f;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.InputMode;
-import yesman.epicfight.api.client.input.PlayerInputState;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
-import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
-import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
@@ -388,7 +384,7 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     }
 
     private static void registerModIntegration() {
-        EpicFightControllerModProvider.set(EpicFightMod.MODID, new ControlifyIntegration());
+        EpicFightControllerModProvider.set(EpicFightMod.MODID, new EpicFightControlifyControllerMod());
     }
 
     private static void registerEvents() {
@@ -428,7 +424,7 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         }));
     }
 
-    private static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
+    public static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
         final InputBindingSupplier bindingSupplier = switch (action) {
             // Minecraft Vanilla actions
             case VANILLA_ATTACK_DESTROY -> ControlifyBindings.ATTACK;
@@ -463,11 +459,11 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         return Objects.requireNonNull(binding, "The binding for the action " + action.name() + " is not yet registered.");
     }
 
-    private static @NotNull ControlifyApi getApi() {
+    public static @NotNull ControlifyApi getApi() {
         return ControlifyApi.get();
     }
 
-    private static @NotNull ControllerEntity requireControllerEntity() {
+    public static @NotNull ControllerEntity requireControllerEntity() {
         Optional<ControllerEntity> optionalControllerEntity = getApi().getCurrentController();
 
         if (optionalControllerEntity.isEmpty()) {
@@ -480,98 +476,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         }
 
         return optionalControllerEntity.get();
-    }
-
-    /**
-     * Allows Epic Fight to communicate with Controlify APIs without depending on their classes directly.
-     */
-    private static class ControlifyIntegration implements IEpicFightControllerMod {
-        @Override
-        public String getModName() {
-            return "Controlify";
-        }
-
-        @Override
-        public @NotNull InputMode getInputMode() {
-            return switch (getApi().currentInputMode()) {
-                case KEYBOARD_MOUSE -> InputMode.KEYBOARD_MOUSE;
-                case CONTROLLER -> InputMode.CONTROLLER;
-                case MIXED -> InputMode.MIXED;
-            };
-        }
-
-        @Override
-        public @NotNull ControllerBinding getBinding(EpicFightInputAction action) {
-            return new ControllerBindingImpl(getControlifyBinding(action));
-        }
-
-        @Override
-        public @NotNull PlayerInputState getInputState() {
-            ControllerEntity controller = requireControllerEntity();
-
-            InputBinding forwardBind = ControlifyBindings.WALK_FORWARD.on(controller);
-            InputBinding backwardBind = ControlifyBindings.WALK_BACKWARD.on(controller);
-            InputBinding leftBind = ControlifyBindings.WALK_LEFT.on(controller);
-            InputBinding rightBind = ControlifyBindings.WALK_RIGHT.on(controller);
-            InputBinding jumpBind = ControlifyBindings.JUMP.on(controller);
-            InputBinding sneakBind = ControlifyBindings.SNEAK.on(controller);
-
-            float forwardImpulse = forwardBind.analogueNow() - backwardBind.analogueNow();
-            float leftImpulse = leftBind.analogueNow() - rightBind.analogueNow();
-
-            return new PlayerInputState(
-                    leftImpulse, forwardImpulse,
-                    forwardBind.digitalNow(), backwardBind.digitalNow(),
-                    leftBind.digitalNow(), rightBind.digitalNow(),
-                    jumpBind.digitalNow(), sneakBind.digitalNow()
-            );
-        }
-
-        @Override
-        public boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
-            final Input input1 = getControlifyBinding(action).boundInput();
-            final Input input2 = getControlifyBinding(action2).boundInput();
-            return input1.getRelevantInputs().equals(input2.getRelevantInputs());
-        }
-    }
-
-    private record ControllerBindingImpl(@NotNull InputBinding inputBinding) implements ControllerBinding {
-
-        @Override
-        @NotNull
-        public ResourceLocation id() {
-            return inputBinding.id();
-        }
-
-        @Override
-        public boolean isDigitalActiveNow() {
-            return inputBinding.digitalNow();
-        }
-
-        @Override
-        public boolean wasDigitalActivePreviously() {
-            return inputBinding.digitalPrev();
-        }
-
-        @Override
-        public boolean isDigitalJustPressed() {
-            return inputBinding.justPressed();
-        }
-
-        @Override
-        public boolean isDigitalJustReleased() {
-            return inputBinding.justReleased();
-        }
-
-        @Override
-        public float getAnalogueNow() {
-            return inputBinding.analogueNow();
-        }
-
-        @Override
-        public void emulatePress() {
-            inputBinding.fakePress();
-        }
     }
 
     private static void registerScreenProcessors() {

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -13,7 +13,6 @@ import dev.isxander.controlify.api.guide.ContainerCtx;
 import dev.isxander.controlify.api.guide.Fact;
 import dev.isxander.controlify.api.guide.GuideDomainRegistry;
 import dev.isxander.controlify.api.guide.InGameCtx;
-import dev.isxander.controlify.bindings.BindContext;
 import dev.isxander.controlify.bindings.ControlifyBindings;
 import dev.isxander.controlify.bindings.RadialIcons;
 import dev.isxander.controlify.controller.ControllerEntity;
@@ -21,7 +20,6 @@ import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.Slot;
@@ -103,15 +101,13 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
             return Component.translatable(description());
         }
 
-        /**
-         * Maps a non-vanilla {@link EpicFightInputAction} to its corresponding translation keys.
-         *
-         * @param action the non-vanilla action to get the translation key for
-         * @return a {@link TranslationKeys} instance containing the translation keys for the name and description
-         * @throws IllegalArgumentException if the action is a vanilla action, since getting the translation keys in this class
-         *                                  is only relevant for Epic Fight custom input binds.
-         *                                  Vanilla input binds are handled internally by Controlify.
-         */
+        /// Maps a non-vanilla [EpicFightInputAction] to its corresponding translation keys.
+        ///
+        /// @param action the non-vanilla action to get the translation key for
+        /// @return a [TranslationKeys] instance containing the translation keys for the name and description
+        /// @throws IllegalArgumentException if the action is a vanilla action,
+        ///                                                                   since getting the translation keys in this class is only relevant for Epic Fight custom input binds.
+        ///                                                                   Vanilla input binds are handled internally by Controlify.
         private static @NotNull TranslationKeys fromAction(@NotNull EpicFightInputAction action) {
             return switch (action) {
                 case ATTACK -> new TranslationKeys(LangKeys.KEY_ATTACK, LangKeys.KEY_ATTACK_DESCRIPTION);
@@ -189,24 +185,22 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         }
     }
 
-    /**
-     * Registers a non-vanilla input binding with Controlify.
-     * <p>
-     * Must <strong>only</strong> be called for non-vanilla
-     * {@link EpicFightInputAction}. Vanilla actions are already registered
-     * and calling this with one will throw {@link IllegalArgumentException}.
-     * <p>
-     * <strong>Type-safety and exhaustive checking:</strong><br>
-     * Returns an {@link InputBindingSupplier} via a <em>switch expression</em>
-     * over all enum constants. The returned value is a dummy, used only
-     * to satisfy the Java compiler and enforce exhaustive handling. It is
-     * <strong>never used</strong> and has no effect on behavior.
-     *
-     * @param registrar the Controlify API used to register the binding
-     * @param action    the non-vanilla input action to register
-     * @return a dummy {@link InputBindingSupplier} for type-safety only
-     * @throws IllegalArgumentException if called with a vanilla input action
-     */
+    /// Registers a non-vanilla input binding with Controlify.
+    ///
+    /// Must **only** be called for non-vanilla [EpicFightInputAction].
+    /// Vanilla actions are already registered and calling this with one will throw [IllegalArgumentException].
+    ///
+    /// ### **Type-safety and exhaustive checking:**
+    ///
+    /// Returns an [InputBindingSupplier] via a *switch expression* over all enum constants.
+    /// The returned value is a dummy, used only
+    /// to satisfy the Java compiler and enforce exhaustive handling.
+    /// It is **never used** and has no effect on behavior.
+    ///
+    /// @param registrar the Controlify API used to register the binding
+    /// @param action    the non-vanilla input action to register
+    /// @return a dummy [InputBindingSupplier] for type-safety only
+    /// @throws IllegalArgumentException if called with a vanilla input action
     @SuppressWarnings("UnusedReturnValue") // Read Javadocs of this method before removing.
     private static @NotNull InputBindingSupplier registerInputBinding(
             @NotNull ControlifyBindApi registrar,

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -5,8 +5,6 @@ import dev.isxander.controlify.api.bind.ControlifyBindApi;
 import dev.isxander.controlify.api.bind.InputBinding;
 import dev.isxander.controlify.api.bind.InputBindingBuilder;
 import dev.isxander.controlify.api.bind.InputBindingSupplier;
-import dev.isxander.controlify.api.buttonguide.ButtonGuideApi;
-import dev.isxander.controlify.api.buttonguide.ButtonGuidePredicate;
 import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
 import dev.isxander.controlify.api.entrypoint.InitContext;
 import dev.isxander.controlify.api.entrypoint.PreInitContext;
@@ -19,11 +17,9 @@ import dev.isxander.controlify.bindings.BindContext;
 import dev.isxander.controlify.bindings.ControlifyBindings;
 import dev.isxander.controlify.bindings.RadialIcons;
 import dev.isxander.controlify.controller.ControllerEntity;
-import dev.isxander.controlify.screenop.ScreenProcessor;
 import dev.isxander.controlify.screenop.ScreenProcessorProvider;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
-import net.minecraft.client.InputType;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -43,6 +39,8 @@ import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.input.EpicFightInputCategories;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+import yesman.epicfight.compat.controlify.screenop.SkillBookScreenProcessor;
+import yesman.epicfight.compat.controlify.screenop.SkillEditScreenProcessor;
 import yesman.epicfight.generated.LangKeys;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.skill.SkillCategories;
@@ -487,94 +485,5 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
                 SkillBookScreen.class,
                 SkillBookScreenProcessor::new
         );
-    }
-
-    private static class SkillEditScreenProcessor extends ScreenProcessor<SkillEditScreen> {
-        public SkillEditScreenProcessor(SkillEditScreen screen) {
-            super(screen);
-        }
-
-        private static final InputBindingSupplier OPEN_SKILL_INFO = ControlifyBindings.GUI_ABSTRACT_ACTION_1;
-
-        @Override
-        protected void handleButtons(ControllerEntity controller) {
-            super.handleButtons(controller);
-
-            if (this.screen.getFocused() instanceof SkillEditScreen.EquipSkillButton equipSkillButton &&
-                    OPEN_SKILL_INFO.on(controller).guiPressed().get()) {
-                equipSkillButton.openSkillInfoScreen();
-            }
-        }
-
-        @Override
-        protected void setInitialFocus() {
-            // Intentionally empty. Do NOT call super.setInitialFocus().
-        }
-
-        @Override
-        public void onWidgetRebuild() {
-            super.onWidgetRebuild();
-            setInputTypeWorkaround();
-        }
-
-        /**
-         * Controlify intentionally avoids setting Minecraft's input type to
-         * {@link InputType#KEYBOARD_ARROW} because keyboard and controller inputs behave
-         * differently.
-         * However, {@link SkillEditScreen} was built mainly for mouse users,
-         * and some GUI elements—like skill slot names—are shown only via tooltips, which
-         * appear only when the input type is {@link InputType#KEYBOARD_ARROW}.
-         * <p>
-         * To support controller users without extra rework, the input type is set here
-         * manually.
-         * As a result, {@link #setInitialFocus()} must remain empty, since
-         * Minecraft handles focus automatically whenever the input type is not
-         * {@link InputType#NONE}, which is what Controlify normally uses.
-         */
-        private void setInputTypeWorkaround() {
-            Minecraft.getInstance().setLastInputType(InputType.KEYBOARD_ARROW);
-        }
-    }
-
-    private static class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {
-        public SkillBookScreenProcessor(SkillBookScreen screen) {
-            super(screen);
-        }
-
-        private static final InputBindingSupplier LEARN_SKILL = ControlifyBindings.GUI_PRESS;
-
-        @Override
-        protected void handleButtons(ControllerEntity controller) {
-            if (LEARN_SKILL.on(controller).guiPressed().get()) {
-                screen.getLearnButton().onPress();
-                playClackSound();
-            }
-            super.handleButtons(controller);
-        }
-
-        // The Skill Book screen has a single actionable button (the "learn skill" button).
-        // Controller navigation and focus are disabled, and only the primary controller
-        // button (e.g., X on DualSense) is used to trigger the action.
-
-        @Override
-        protected void setInitialFocus() {
-            // Intentionally empty. Do NOT call super.setInitialFocus().
-        }
-
-        @Override
-        protected void handleComponentNavigation(ControllerEntity controller) {
-            // Intentionally empty. Do NOT call super.handleComponentNavigation().
-        }
-
-        @Override
-        public void onWidgetRebuild() {
-            super.onWidgetRebuild();
-
-            ButtonGuideApi.addGuideToButton(
-                    this.screen.getLearnButton(),
-                    LEARN_SKILL,
-                    ButtonGuidePredicate.always()
-            );
-        }
     }
 }

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -71,7 +71,7 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     public void onControlifyPreInit(PreInitContext context) {
         final ControlifyBindApi registrar = ControlifyBindApi.get();
         registerCustomRadialIcons();
-        BindContexts.EpicFight.register(registrar);
+        EpicFightControlifyBindContexts.EpicFight.register(registrar);
         registerInputBindings(registrar);
         registerEvents();
         registerGuides(context.guideRegistries().inGame(), context.guideRegistries().container());
@@ -93,43 +93,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     private static InputBindingSupplier lockOnShiftLeft;
     private static InputBindingSupplier lockOnShiftRight;
     private static InputBindingSupplier lockOnShiftFreely;
-
-    private static final class BindContexts {
-        private BindContexts() {
-        }
-
-        private static final class EpicFight {
-            private EpicFight() {
-            }
-
-            private static final BindContext COMBAT_MODE = new BindContext(
-                    EpicFightMod.rl("epicfight_combat"),
-                    mc -> {
-                        final boolean isInGame = isInGame(mc);
-                        return isInGame && ClientEngine.getInstance().isEpicFightMode();
-                    }
-            );
-            private static final BindContext LOCK_ON = new BindContext(
-                    EpicFightMod.rl("epicfight_lock_on"),
-                    mc -> {
-                        final boolean isInGame = isInGame(mc);
-                        return isInGame && EpicFightCameraAPI.getInstance().isLockingOnTarget();
-                    }
-            );
-
-            public static void register(@NotNull ControlifyBindApi registrar) {
-                registrar.registerBindContext(COMBAT_MODE);
-                registrar.registerBindContext(LOCK_ON);
-            }
-        }
-
-        private static final BindContext IN_GAME = BindContext.IN_GAME;
-        private static final BindContext ANY_SCREEN = BindContext.ANY_SCREEN;
-
-        private static boolean isInGame(@NotNull Minecraft mc) {
-            return mc.screen == null && mc.level != null && mc.player != null;
-        }
-    }
 
     private record TranslationKeys(@NotNull String name, @NotNull String description) {
         private @NotNull Component getNameComponent() {
@@ -266,76 +229,76 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
             case ATTACK -> attack = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case MOBILITY -> mobility = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case GUARD -> guard = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case DODGE -> dodge = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case LOCK_ON -> lockOn = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(cameraCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case LOCK_ON_SHIFT_LEFT -> lockOnShiftLeft = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(cameraCategory)
-                            .allowedContexts(BindContexts.EpicFight.LOCK_ON)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.LOCK_ON)
             );
             case LOCK_ON_SHIFT_RIGHT -> lockOnShiftRight = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(cameraCategory)
-                            .allowedContexts(BindContexts.EpicFight.LOCK_ON)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.LOCK_ON)
             );
             case LOCK_ON_SHIFT_FREELY -> lockOnShiftFreely = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(cameraCategory)
-                            .allowedContexts(BindContexts.EpicFight.LOCK_ON)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.LOCK_ON)
             );
             case SWITCH_MODE -> switchMode = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(systemCategory)
-                            .allowedContexts(BindContexts.IN_GAME)
+                            .allowedContexts(EpicFightControlifyBindContexts.IN_GAME)
                             .radialCandidate(EpicFightRadialIcons.UCHIGATANA.getId())
             );
             case WEAPON_INNATE_SKILL -> weaponInnateSkill = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
-                            .allowedContexts(BindContexts.EpicFight.COMBAT_MODE)
+                            .allowedContexts(EpicFightControlifyBindContexts.EpicFight.COMBAT_MODE)
             );
             case WEAPON_INNATE_SKILL_TOOLTIP -> weaponInnateSkillTooltip = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(guiCategory)
-                            .allowedContexts(BindContexts.ANY_SCREEN)
+                            .allowedContexts(EpicFightControlifyBindContexts.ANY_SCREEN)
             );
             case OPEN_SKILL_SCREEN -> openSkillEditorScreen = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(guiCategory)
-                            .allowedContexts(BindContexts.IN_GAME)
+                            .allowedContexts(EpicFightControlifyBindContexts.IN_GAME)
                             .radialCandidate(EpicFightRadialIcons.SKILL_BOOK.getId())
             );
             case OPEN_CONFIG_SCREEN -> openConfigScreen = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(guiCategory)
-                            .allowedContexts(BindContexts.IN_GAME)
+                            .allowedContexts(EpicFightControlifyBindContexts.IN_GAME)
                             .radialCandidate(RadialIcons.getItem(Items.REDSTONE))
             );
             case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging = registrar.registerBinding(
                     builder ->
                             applyCommonBindingProperties(action, builder)
                                     .category(systemCategory)
-                                    .allowedContexts(BindContexts.IN_GAME)
+                                    .allowedContexts(EpicFightControlifyBindContexts.IN_GAME)
             );
         };
     }

--- a/src/main/java/yesman/epicfight/compat/controlify/screenop/SkillBookScreenProcessor.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/screenop/SkillBookScreenProcessor.java
@@ -1,0 +1,51 @@
+package yesman.epicfight.compat.controlify.screenop;
+
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.buttonguide.ButtonGuideApi;
+import dev.isxander.controlify.api.buttonguide.ButtonGuidePredicate;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.controller.ControllerEntity;
+import dev.isxander.controlify.screenop.ScreenProcessor;
+import yesman.epicfight.client.gui.screen.SkillBookScreen;
+
+public class SkillBookScreenProcessor extends ScreenProcessor<SkillBookScreen> {
+    public SkillBookScreenProcessor(SkillBookScreen screen) {
+        super(screen);
+    }
+
+    private static final InputBindingSupplier LEARN_SKILL = ControlifyBindings.GUI_PRESS;
+
+    @Override
+    protected void handleButtons(ControllerEntity controller) {
+        if (LEARN_SKILL.on(controller).guiPressed().get()) {
+            screen.getLearnButton().onPress();
+            playClackSound();
+        }
+        super.handleButtons(controller);
+    }
+
+    // The Skill Book screen has a single actionable button (the "learn skill" button).
+    // Controller navigation and focus are disabled, and only the primary controller
+    // button (e.g., X on DualSense) is used to trigger the action.
+
+    @Override
+    protected void setInitialFocus() {
+        // Intentionally empty. Do NOT call super.setInitialFocus().
+    }
+
+    @Override
+    protected void handleComponentNavigation(ControllerEntity controller) {
+        // Intentionally empty. Do NOT call super.handleComponentNavigation().
+    }
+
+    @Override
+    public void onWidgetRebuild() {
+        super.onWidgetRebuild();
+
+        ButtonGuideApi.addGuideToButton(
+                this.screen.getLearnButton(),
+                LEARN_SKILL,
+                ButtonGuidePredicate.always()
+        );
+    }
+}

--- a/src/main/java/yesman/epicfight/compat/controlify/screenop/SkillEditScreenProcessor.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/screenop/SkillEditScreenProcessor.java
@@ -1,0 +1,54 @@
+package yesman.epicfight.compat.controlify.screenop;
+
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.controller.ControllerEntity;
+import dev.isxander.controlify.screenop.ScreenProcessor;
+import net.minecraft.client.InputType;
+import net.minecraft.client.Minecraft;
+import yesman.epicfight.client.gui.screen.SkillEditScreen;
+
+public class SkillEditScreenProcessor extends ScreenProcessor<SkillEditScreen> {
+    public SkillEditScreenProcessor(SkillEditScreen screen) {
+        super(screen);
+    }
+
+    private static final InputBindingSupplier OPEN_SKILL_INFO = ControlifyBindings.GUI_ABSTRACT_ACTION_1;
+
+    @Override
+    protected void handleButtons(ControllerEntity controller) {
+        super.handleButtons(controller);
+
+        if (this.screen.getFocused() instanceof SkillEditScreen.EquipSkillButton equipSkillButton &&
+                OPEN_SKILL_INFO.on(controller).guiPressed().get()) {
+            equipSkillButton.openSkillInfoScreen();
+        }
+    }
+
+    @Override
+    protected void setInitialFocus() {
+        // Intentionally empty. Do NOT call super.setInitialFocus().
+    }
+
+    @Override
+    public void onWidgetRebuild() {
+        super.onWidgetRebuild();
+        setInputTypeWorkaround();
+    }
+
+    /// Controlify intentionally avoids setting Minecraft's input type to
+    /// [InputType#KEYBOARD_ARROW] because keyboard and controller inputs behave
+    /// differently.
+    /// However, [SkillEditScreen] was built mainly for mouse users,
+    /// and some GUI elements—like skill slot names—are shown only via tooltips, which
+    /// appear only when the input type is [InputType#KEYBOARD_ARROW].
+    /// <p>
+    /// To support controller users without extra rework, the input type is set here
+    /// manually.
+    /// As a result, [#setInitialFocus()] must remain empty, since
+    /// Minecraft handles focus automatically whenever the input type is not
+    /// [InputType#NONE], which is what Controlify normally uses.
+    private void setInputTypeWorkaround() {
+        Minecraft.getInstance().setLastInputType(InputType.KEYBOARD_ARROW);
+    }
+}

--- a/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
+++ b/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
@@ -1,1 +1,1 @@
-yesman.epicfight.compat.controlify.ControlifyCompat
+yesman.epicfight.compat.controlify.EpicFightControlifyEntrypoint


### PR DESCRIPTION
Allows third-party mods to register custom input binds while using Epic Fight's `InputManager` with an `InputAction` that is not a `EpicFightInputAction`.

This also fixes other items in the checklist of #2194