### PR TITLE
[1.21.1] Keep input APIs independent of EpicFightInputAction for better third-party support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,11 +13,11 @@
 - An option that you can always activate the TPS perspective, which was only activated when aiming with ranged weapons.
 - An option screen where you can set up the camera position in TPS perspective
 - An auto-tracking functionality that aligns the player's look to the crosshair when aiming and striking entities.
-- A new keybind that moves camera freely while locking on any entity to search another target
+- A new keybind that moves the camera freely while locking on any entity to search another target
 - A lock-on snapping feature that cycles lock-on entities in the screen by snapping mouse left or right
 - An auto-targeting functionality that searches a next target when the current lock-on entity is dead
 - An option to toggle lock-on snapping and auto target
-- An option to set the maximum distance that the player can focus entities
+- An option to set the maximum distance that the player can focus on entities
 - See the devlog [here](https://www.patreon.com/posts/tps-camera-and-141028682)
 - Epic Fight's TPS perspective will be automatically disabled when a conflicting mod, such
   as [Shoulder Surfing Reloaded](https://modrinth.com/mod/shoulder-surfing-reloaded)
@@ -37,14 +37,13 @@
 - Removed AirSlash and its related fields (SkillCategory, SkillSlot) to merge air slash and combo attacks as one skill
 - Updated the experimental Epic Fight's input API to support using custom input actions that are not a
   `EpicFightInputAction`.
+- Extracted vanilla input actions from `EpicFightInputAction` into `MinecraftInputAction`.
   [#2194](https://github.com/Epic-Fight/epicfight/issues/2194)
-
-### For Devs
-
+  [#2194](https://github.com/Epic-Fight/epicfight/issues/2194)
 - New API feature: Hooks
-    - Replaces the mod-loader event system into Epic Fight API, as we planning to support multi-loader developer environment
-    - The feautre is still WIP, supporting only events for EpicFightCameraAPI
-    - We will eventually replace all Forge/Neoforge events owned by Epic Fight into Hooks
+    - Replace the mod-loader event system into Epic Fight API, as we're planning to support multi-loader developer environment
+    - The feature is still WIP, supporting only events for EpicFightCameraAPI
+    - We will eventually replace all Forge/NeoForge events owned by Epic Fight into Hooks
 
 ## [21.13.5] - 2025-11-12
 

--- a/src/main/java/yesman/epicfight/api/client/input/InputManager.java
+++ b/src/main/java/yesman/epicfight/api/client/input/InputManager.java
@@ -11,13 +11,13 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
-import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 import yesman.epicfight.client.input.DiscreteInputActionTrigger;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /// High-level input API that abstracts direct interactions with [KeyMapping]
@@ -144,10 +144,14 @@ public final class InputManager {
     /// @param action  the first input action
     /// @param action2 the second input action
     /// @return `true` if both actions are triggered by the same key or controller button; `false` otherwise
-    public static boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
+    public static boolean isBoundToSamePhysicalInput(@NotNull InputAction action, @NotNull InputAction action2) {
         final IEpicFightControllerMod controllerMod = getControllerModApi();
         if (controllerMod != null && controllerMod.getInputMode() == InputMode.CONTROLLER) {
-            return controllerMod.isBoundToSamePhysicalInput(action, action2);
+            final Optional<ControllerBinding> optionalControllerBinding = action.controllerBinding();
+            final Optional<ControllerBinding> optionalControllerBinding2 = action2.controllerBinding();
+            if (optionalControllerBinding.isPresent() && optionalControllerBinding2.isPresent()) {
+                return optionalControllerBinding.get().isBoundToSamePhysicalInput(optionalControllerBinding2.get());
+            }
         }
 
         final KeyMapping keyMapping1 = action.keyMapping();

--- a/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/EpicFightInputAction.java
@@ -1,10 +1,7 @@
 package yesman.epicfight.api.client.input.action;
 
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.Options;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
@@ -22,76 +19,37 @@ import java.util.*;
 ///
 /// For implementation details, refer to [#keyMapping()].
 public enum EpicFightInputAction implements InputAction {
-    /// Corresponds to Minecraft's default "Attack/Destroy" action.
-    ///
-    /// This uses the vanilla [net.minecraft.client.Options#keyAttack] key mapping,
-    /// which is bound to the left mouse button by default.
-    /// It handles both attacking entities and breaking blocks in the base game.
-    VANILLA_ATTACK_DESTROY(true),
-    USE(true),
-    SWAP_OFF_HAND(true),
-    DROP(true),
-    TOGGLE_PERSPECTIVE(true),
-    ATTACK(false),
-    JUMP(true),
-    MOBILITY(false),
-    GUARD(false),
-    DODGE(false),
-    LOCK_ON(false),
-    LOCK_ON_SHIFT_LEFT(false),
-    LOCK_ON_SHIFT_RIGHT(false),
-    LOCK_ON_SHIFT_FREELY(false),
-    SWITCH_MODE(false),
-    WEAPON_INNATE_SKILL(false),
-    WEAPON_INNATE_SKILL_TOOLTIP(false),
-    MOVE_FORWARD(true),
-    MOVE_BACKWARD(true),
-    MOVE_LEFT(true),
-    MOVE_RIGHT(true),
-    SPRINT(true),
-    SNEAK(true),
-    OPEN_SKILL_SCREEN(false),
-    OPEN_CONFIG_SCREEN(false),
-    SWITCH_VANILLA_MODEL_DEBUGGING(false);
+    ATTACK,
+    MOBILITY,
+    GUARD,
+    DODGE,
+    LOCK_ON,
+    LOCK_ON_SHIFT_LEFT,
+    LOCK_ON_SHIFT_RIGHT,
+    LOCK_ON_SHIFT_FREELY,
+    SWITCH_MODE,
+    WEAPON_INNATE_SKILL,
+    WEAPON_INNATE_SKILL_TOOLTIP,
+    OPEN_SKILL_SCREEN,
+    OPEN_CONFIG_SCREEN,
+    SWITCH_VANILLA_MODEL_DEBUGGING;
 
     final private int id;
 
-    /// Indicates whether this input action corresponds to a standard Minecraft vanilla key mapping.
-    ///
-    /// Vanilla actions are those defined by the base game (e.g., attack, jump, move),
-    /// while non-vanilla actions are custom Epic Fight actions introduced by the mod.
-    final private boolean isVanilla;
-
-    /// Returns whether this input action corresponds to a vanilla Minecraft key mapping.
-    ///
-    /// @return `true` if this action is linked to a vanilla key mapping,
-    /// `false` if it is defined by the Epic Fight mod.
-    public boolean isVanilla() {
-        return isVanilla;
-    }
-
-    EpicFightInputAction(final boolean isVanilla) {
+    EpicFightInputAction() {
         this.id = InputAction.ENUM_MANAGER.assign(this);
-        this.isVanilla = isVanilla;
     }
 
     @Override
     public int universalOrdinal() {
-        return id;
+        return this.id;
     }
 
     @Override
     @NotNull
     public KeyMapping keyMapping() {
-        final Options options = Minecraft.getInstance().options;
         return switch (this) {
-            case VANILLA_ATTACK_DESTROY -> options.keyAttack;
-            case USE -> options.keyUse;
-            case SWAP_OFF_HAND -> options.keySwapOffhand;
-            case DROP -> options.keyDrop;
-            case TOGGLE_PERSPECTIVE -> options.keyTogglePerspective;
             case ATTACK -> EpicFightKeyMappings.ATTACK;
-            case JUMP -> options.keyJump;
             case MOBILITY -> EpicFightKeyMappings.MOVER_SKILL;
             case GUARD -> EpicFightKeyMappings.GUARD;
             case DODGE -> EpicFightKeyMappings.DODGE;
@@ -102,12 +60,6 @@ public enum EpicFightInputAction implements InputAction {
             case SWITCH_MODE -> EpicFightKeyMappings.SWITCH_MODE;
             case WEAPON_INNATE_SKILL -> EpicFightKeyMappings.WEAPON_INNATE_SKILL;
             case WEAPON_INNATE_SKILL_TOOLTIP -> EpicFightKeyMappings.WEAPON_INNATE_SKILL_TOOLTIP;
-            case MOVE_FORWARD -> options.keyUp;
-            case MOVE_BACKWARD -> options.keyDown;
-            case MOVE_LEFT -> options.keyLeft;
-            case MOVE_RIGHT -> options.keyRight;
-            case SPRINT -> options.keySprint;
-            case SNEAK -> options.keyShift;
             case OPEN_SKILL_SCREEN -> EpicFightKeyMappings.SKILL_EDIT;
             case OPEN_CONFIG_SCREEN -> EpicFightKeyMappings.OPEN_CONFIG_SCREEN;
             case SWITCH_VANILLA_MODEL_DEBUGGING -> EpicFightKeyMappings.SWITCH_VANILLA_MODEL_DEBUGGING;
@@ -122,33 +74,8 @@ public enum EpicFightInputAction implements InputAction {
         return Optional.of(EpicFightControlifyControllerMod.getBinding(this));
     }
 
-    private static final @NotNull Map<KeyMapping, EpicFightInputAction> BY_KEY_MAPPING;
-
-    static {
-        Map<KeyMapping, EpicFightInputAction> map = new HashMap<>();
-        for (EpicFightInputAction action : values()) {
-            map.put(action.keyMapping(), action);
-        }
-        BY_KEY_MAPPING = Collections.unmodifiableMap(map);
-    }
-
-    /// Gets the input action corresponding to a [KeyMapping].
-    ///
-    /// @param keyMapping the key mapping; must not be `null`
-    /// @return the corresponding action, or null if none matches
-    public static @Nullable EpicFightInputAction fromKeyMapping(@NotNull KeyMapping keyMapping) {
-        return BY_KEY_MAPPING.get(keyMapping);
-    }
-
-    /// Returns a set of all Epic Fight actions that are not part of the vanilla Minecraft key mappings.
-    ///
-    /// @return a set containing all non-vanilla [EpicFightInputAction]
-    /// @see EpicFightInputAction#isVanilla
-    public static @NotNull Set<EpicFightInputAction> nonVanillaActions() {
-        Set<EpicFightInputAction> result = EnumSet.noneOf(EpicFightInputAction.class);
-        for (EpicFightInputAction action : EpicFightInputAction.values()) {
-            if (!action.isVanilla()) result.add(action);
-        }
-        return result;
+    @Override
+    public boolean isVanilla() {
+        return false;
     }
 }

--- a/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/InputAction.java
@@ -4,11 +4,14 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.client.KeyMapping;
+import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.utils.ExtensibleEnum;
 import yesman.epicfight.api.utils.ExtensibleEnumManager;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /// Represents a client-side input action in Epic Fight mod.
 ///
@@ -46,4 +49,35 @@ public interface InputAction extends ExtensibleEnum {
     /// @return the [ControllerBinding] for this action, or [Optional#empty()] if not supported
     /// @see ControllerBinding
     @NotNull Optional<@NotNull ControllerBinding> controllerBinding();
+
+    /// Returns whether this input action corresponds to a vanilla standard Minecraft input bind.
+    ///
+    /// Vanilla actions are those defined by the base game (e.g., attack, jump, move),
+    /// while non-vanilla actions are custom Epic Fight actions introduced by the mod.
+    ///
+    /// @return `true` if this action is linked to a vanilla key mapping.
+    boolean isVanilla();
+
+    /// Returns a set of all input actions that are not part of the vanilla Minecraft input bindings.
+    ///
+    /// @return a set containing all non-vanilla [InputAction]
+    /// @see InputAction#isVanilla
+    static @NotNull Set<InputAction> nonVanillaActions() {
+        Set<InputAction> result = new HashSet<>();
+        for (InputAction action : InputAction.ENUM_MANAGER.universalValues()) {
+            if (!action.isVanilla()) result.add(action);
+        }
+        return result;
+    }
+
+    /// Gets the input action corresponding to a [KeyMapping].
+    ///
+    /// @param keyMapping the key mapping; must not be `null`
+    /// @return the corresponding action, or null if none matches
+    static @Nullable InputAction fromKeyMapping(@NotNull KeyMapping keyMapping) {
+        return InputAction.ENUM_MANAGER.universalValues().stream()
+                .filter(action -> action.keyMapping() == keyMapping)
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/yesman/epicfight/api/client/input/action/MinecraftInputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/MinecraftInputAction.java
@@ -1,0 +1,78 @@
+package yesman.epicfight.api.client.input.action;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.api.client.input.controller.ControllerBinding;
+import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
+import yesman.epicfight.compat.controlify.EpicFightControlifyControllerMod;
+
+import java.util.Optional;
+
+// TODO: Double confirm old EpicFightInputAction usages and doc comments
+
+public enum MinecraftInputAction implements InputAction {
+    JUMP,
+    /// Corresponds to Minecraft's default "Attack/Destroy" action.
+    ///
+    /// This uses the vanilla [net.minecraft.client.Options#keyAttack] key mapping,
+    /// which is bound to the left mouse button by default.
+    /// It handles both attacking entities and breaking blocks in the base game.
+    ATTACK_DESTROY,
+    USE,
+    SWAP_OFF_HAND,
+    DROP,
+    TOGGLE_PERSPECTIVE,
+    MOVE_FORWARD,
+    MOVE_BACKWARD,
+    MOVE_LEFT,
+    MOVE_RIGHT,
+    SPRINT,
+    SNEAK;
+
+    final private int id;
+
+    MinecraftInputAction() {
+        this.id = InputAction.ENUM_MANAGER.assign(this);
+    }
+
+    @Override
+    @NotNull
+    public KeyMapping keyMapping() {
+        final Options options = Minecraft.getInstance().options;
+        return switch (this) {
+            case USE -> options.keyUse;
+            case ATTACK_DESTROY -> options.keyAttack;
+            case SWAP_OFF_HAND -> options.keySwapOffhand;
+            case DROP -> options.keyDrop;
+            case TOGGLE_PERSPECTIVE -> options.keyTogglePerspective;
+            case JUMP -> options.keyJump;
+            case MOVE_FORWARD -> options.keyUp;
+            case MOVE_BACKWARD -> options.keyDown;
+            case MOVE_LEFT -> options.keyLeft;
+            case MOVE_RIGHT -> options.keyRight;
+            case SPRINT -> options.keySprint;
+            case SNEAK -> options.keyShift;
+        };
+    }
+
+    @Override
+    @NotNull
+    public Optional<@NotNull ControllerBinding> controllerBinding() {
+        if (EpicFightControllerModProvider.get() == null) {
+            throw new IllegalStateException("controllerBinding() must not be called when the controller mod is not installed");
+        }
+        return Optional.of(EpicFightControlifyControllerMod.getBinding(this));
+    }
+
+    @Override
+    public boolean isVanilla() {
+        return true;
+    }
+
+    @Override
+    public int universalOrdinal() {
+        return this.id;
+    }
+}

--- a/src/main/java/yesman/epicfight/api/client/input/action/MinecraftInputAction.java
+++ b/src/main/java/yesman/epicfight/api/client/input/action/MinecraftInputAction.java
@@ -10,8 +10,6 @@ import yesman.epicfight.compat.controlify.EpicFightControlifyControllerMod;
 
 import java.util.Optional;
 
-// TODO: Double confirm old EpicFightInputAction usages and doc comments
-
 public enum MinecraftInputAction implements InputAction {
     JUMP,
     /// Corresponds to Minecraft's default "Attack/Destroy" action.

--- a/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/ControllerBinding.java
@@ -59,4 +59,16 @@ public interface ControllerBinding {
     ///
     /// Can be used for GUI interactions or synthetic input from other systems.
     void emulatePress();
+
+    /// Returns a unique ID for the physical control.
+    /// The returned object must have a stable [Object#equals]/[Object#hashCode] implementation.
+    ///
+    /// @return a unique and comparable identifier for the physical control
+    @NotNull
+    Object physicalInputId();
+
+    /// Returns whether both controller bindings refer to the same physical control.
+    default boolean isBoundToSamePhysicalInput(@NotNull ControllerBinding other) {
+        return physicalInputId().equals(other.physicalInputId());
+    }
 }

--- a/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
+++ b/src/main/java/yesman/epicfight/api/client/input/controller/IEpicFightControllerMod.java
@@ -35,11 +35,4 @@ public interface IEpicFightControllerMod {
     /// @return a [PlayerInputState] representing the current input state.
     @NotNull
     PlayerInputState getInputState();
-
-    /// Checks whether the specified input actions are bound to the same controller button.
-    ///
-    /// @param action  the first input action
-    /// @param action2 the second input action
-    /// @return `true` if both actions are bound to the same controller button; `false` otherwise
-    boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2);
 }

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -37,6 +37,7 @@ import yesman.epicfight.api.client.input.PlayerInputState;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.InputManager;
 import yesman.epicfight.api.client.input.action.InputAction;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
 import yesman.epicfight.api.utils.FakeLevel;
@@ -241,14 +242,14 @@ public class ControlEngine implements IEventBasedEngine {
 			this.weaponInnatePressToggle = false;
 			this.weaponInnatePressCounter = 0;
 		}
-		
+
 		if (this.sneakPressToggle) {
-			if (!InputManager.isActionActive(EpicFightInputAction.SNEAK)) {
+			if (!InputManager.isActionActive(MinecraftInputAction.SNEAK)) {
 				SkillSlot skillSlot = (this.playerpatch.getEntityState().knockDown()) ? SkillSlots.KNOCKDOWN_WAKEUP : SkillSlots.DODGE;
 				SkillContainer skill = this.playerpatch.getSkill(skillSlot);
 
 				if (skill.sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
-					this.reserveKey(skillSlot, EpicFightInputAction.SNEAK);
+					this.reserveKey(skillSlot, MinecraftInputAction.SNEAK);
 				}
 				
 				this.sneakPressToggle = false;
@@ -360,12 +361,15 @@ public class ControlEngine implements IEventBasedEngine {
         if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.ATTACK)) {
             return;
         }
-        final EpicFightInputAction vanillaAttack = EpicFightInputAction.VANILLA_ATTACK_DESTROY;
+        final MinecraftInputAction vanillaAttack = MinecraftInputAction.ATTACK_DESTROY;
         final EpicFightInputAction epicFightAttack = EpicFightInputAction.ATTACK;
 
         boolean shouldPlayAttackAnimation = this.playerpatch.canPlayAttackAnimation();
         if (vanillaAttack.keyMapping().getKey() == epicFightAttack.keyMapping().getKey() &&
                 Minecraft.getInstance().hitResult != null && shouldPlayAttackAnimation) {
+            // Not needed for controller inputs.
+            // This is called for keyboard/mouse inputs to just reset the internal keymapping counter.
+            // It does not cancel the attack input, as that is handled in a mixin on the Minecraft class.
             consumeVanillaAttackKeyClicks();
         }
 
@@ -399,7 +403,7 @@ public class ControlEngine implements IEventBasedEngine {
         if (!this.playerpatch.isEpicFightMode() || isCurrentHoldingAction(EpicFightInputAction.DODGE)) {
             return;
         }
-        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.DODGE, EpicFightInputAction.SNEAK)) {
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.DODGE, MinecraftInputAction.SNEAK)) {
             if (this.player.getVehicle() == null) {
                 if (!this.sneakPressToggle) {
                     this.sneakPressToggle = true;
@@ -460,7 +464,7 @@ public class ControlEngine implements IEventBasedEngine {
             return;
         }
         
-        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.MOBILITY, EpicFightInputAction.JUMP)) {
+        if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.MOBILITY, MinecraftInputAction.JUMP)) {
             SkillContainer skillContainer = this.playerpatch.getSkill(SkillSlots.MOVER);
 
             if (!skillContainer.isEmpty()) {
@@ -505,7 +509,7 @@ public class ControlEngine implements IEventBasedEngine {
 		PlayerInputState inputState = InputManager.getInputState(input);
 		
 		if (this.moverPressToggle) {
-			if (!InputManager.isActionActive(EpicFightInputAction.JUMP)) {
+			if (!InputManager.isActionActive(MinecraftInputAction.JUMP)) {
 				this.moverPressToggle = false;
 				this.moverPressCounter = 0;
 				
@@ -703,7 +707,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     public static void setSprintingKeyStateNotDown() {
-        KeyMapping.set(EpicFightInputAction.SPRINT.keyMapping().getKey(), false);
+        KeyMapping.set(MinecraftInputAction.SPRINT.keyMapping().getKey(), false);
     }
 
     /**
@@ -784,7 +788,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeVanillaAttackKeyClicks() {
-        makeUnpressed(EpicFightInputAction.VANILLA_ATTACK_DESTROY.keyMapping());
+        makeUnpressed(MinecraftInputAction.ATTACK_DESTROY.keyMapping());
     }
 
     /**
@@ -802,7 +806,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeSwapOffhandKeyClicks() {
-        makeUnpressed(EpicFightInputAction.SWAP_OFF_HAND.keyMapping());
+        makeUnpressed(MinecraftInputAction.SWAP_OFF_HAND.keyMapping());
     }
 
     /**
@@ -835,7 +839,7 @@ public class ControlEngine implements IEventBasedEngine {
      */
     @SuppressWarnings("JavadocReference")
     private static void consumeDropKeyClicks() {
-        makeUnpressed(EpicFightInputAction.DROP.keyMapping());
+        makeUnpressed(MinecraftInputAction.DROP.keyMapping());
     }
 
     /**
@@ -858,8 +862,8 @@ public class ControlEngine implements IEventBasedEngine {
      * Sometimes, it makes sense to use this method, for example, if you're using an event such as {@link InputEvent.InteractionKeyMappingTriggered},
      * which provides only a {@link KeyMapping}.
      */
-    private static @Nullable EpicFightInputAction mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
-        return EpicFightInputAction.fromKeyMapping(keyMapping);
+    private static @Nullable InputAction mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
+        return InputAction.fromKeyMapping(keyMapping);
     }
 
     /**
@@ -869,11 +873,11 @@ public class ControlEngine implements IEventBasedEngine {
      * @return {@code true} if the given action is currently held; otherwise {@code false}
      * @see ControlEngine#mapKeyMappingToAction
      */
-    private boolean isCurrentHoldingAction(@NotNull EpicFightInputAction other) {
+    private boolean isCurrentHoldingAction(@NotNull InputAction other) {
         if (currentHoldingKey == null) {
             return false;
         }
-        final EpicFightInputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        final InputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
         if (currentHoldingAction == null) {
             // Fallback for legacy or custom key mappings.
             // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
@@ -887,7 +891,7 @@ public class ControlEngine implements IEventBasedEngine {
         if (currentHoldingKey == null) {
             return false;
         }
-        final EpicFightInputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
+        final InputAction currentHoldingAction = mapKeyMappingToAction(currentHoldingKey);
         if (currentHoldingAction == null) {
             // Fallback for legacy or custom key mappings.
             // This is IMPORTANT to prevent addon breakage; this allows custom keybinds from other mods,
@@ -973,7 +977,7 @@ public class ControlEngine implements IEventBasedEngine {
 	private void epicfight$interactionKeyMappingTriggered(InputEvent.InteractionKeyMappingTriggered event) {
         if (this.minecraft.player == null || this.minecraft.hitResult == null) return;
 
-        final EpicFightInputAction triggeredAction = mapKeyMappingToAction(event.getKeyMapping());
+        final InputAction triggeredAction = mapKeyMappingToAction(event.getKeyMapping());
 
         if (triggeredAction == null) {
             // The key mapping corresponds to a fixed vanilla action (attack, pick block, or use item).
@@ -982,8 +986,8 @@ public class ControlEngine implements IEventBasedEngine {
         }
 
 		if (
-            triggeredAction == EpicFightInputAction.VANILLA_ATTACK_DESTROY &&
-            InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.ATTACK, EpicFightInputAction.VANILLA_ATTACK_DESTROY) &&
+            triggeredAction == MinecraftInputAction.ATTACK_DESTROY &&
+            InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.ATTACK, MinecraftInputAction.ATTACK_DESTROY) &&
 			this.minecraft.hitResult.getType() == HitResult.Type.BLOCK &&
 			ClientConfig.combatPreferredItems.contains(this.player.getMainHandItem().getItem())
 		) {
@@ -997,8 +1001,8 @@ public class ControlEngine implements IEventBasedEngine {
 		}
 		
 		if (
-			triggeredAction == EpicFightInputAction.USE &&
-			InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.USE, EpicFightInputAction.GUARD) &&
+			triggeredAction == MinecraftInputAction.USE &&
+			InputManager.isBoundToSamePhysicalInput(MinecraftInputAction.USE, EpicFightInputAction.GUARD) &&
 			(
 				ClientConfig.keyConflictResolveScope.cancelInteraction() ||
 				ClientConfig.keyConflictResolveScope.cancelItemUse()

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -63,11 +63,11 @@ import java.util.Set;
 
 public class ControlEngine implements IEventBasedEngine {
 	private static final ControlEngine INSTANCE = new ControlEngine();
-	
+
 	public static ControlEngine getInstance() {
 		return INSTANCE;
 	}
-	
+
 	private final Set<CustomPacketPayload> packetsToSend = new HashSet<> ();
 	private final Minecraft minecraft;
 	private LocalPlayer player;
@@ -99,9 +99,9 @@ public class ControlEngine implements IEventBasedEngine {
 	private KeyMapping reservedKey;
 	private SkillSlot reservedOrHoldingSkillSlot;
     /**
-     * <b>DEPRECATED:</b> Consider using {@link ControlEngine#isCurrentHoldingAction} or 
-     * {@link ControlEngine#isCurrentHoldingActionActive} instead of directly 
-     * accessing or comparing this field. This field is retained for backward 
+     * <b>DEPRECATED:</b> Consider using {@link ControlEngine#isCurrentHoldingAction} or
+     * {@link ControlEngine#isCurrentHoldingActionActive} instead of directly
+     * accessing or comparing this field. This field is retained for backward
      * compatibility; in future updates, {@link EpicFightInputAction} will be
      * stored directly instead of a vanilla {@link KeyMapping}.
      *
@@ -111,15 +111,15 @@ public class ControlEngine implements IEventBasedEngine {
     @Deprecated
     private KeyMapping currentHoldingKey;
 	public Options options;
-	
+
 	private ControlEngine() {
 		this.minecraft = Minecraft.getInstance();
-		
+
 		if (this.minecraft != null) {
 			this.options = this.minecraft.options;
 		}
 	}
-	
+
 	public void reloadPlayerPatch(LocalPlayerPatch playerpatch) {
 		this.weaponInnatePressCounter = 0;
 		this.weaponInnatePressToggle = false;
@@ -129,19 +129,19 @@ public class ControlEngine implements IEventBasedEngine {
 		this.player = playerpatch.getOriginal();
 		this.playerpatch = playerpatch;
 	}
-	
+
 	public LocalPlayerPatch getPlayerPatch() {
 		return this.playerpatch;
 	}
-	
+
 	public boolean canPlayerMove(EntityState playerState) {
 		return !playerState.movementLocked() || this.player.jumpableVehicle() != null;
 	}
-	
+
 	public boolean canPlayerRotate(EntityState playerState) {
 		return !playerState.turningLocked() || this.player.jumpableVehicle() != null;
 	}
-	
+
 	public void handleEpicFightKeyMappings() {
 		// Pause here if playerpatch is null
 		if (this.playerpatch == null) {
@@ -189,16 +189,16 @@ public class ControlEngine implements IEventBasedEngine {
         InputManager.triggerOnPress(EpicFightInputAction.LOCK_ON_SHIFT_RIGHT, this::searchNewTargetFromRight);
 
         if (shouldDisableSwapHandItems()) consumeSwapOffhandKeyClicks();
-		
+
 		// Pause here if player is not in battle mode
 		if (!this.playerpatch.isEpicFightMode() || Minecraft.getInstance().isPaused()) {
 			return;
 		}
-		
+
 		if (this.player.tickCount - this.lastHotbarLockedTime > 20 && this.hotbarLocked) {
 			this.unlockHotkeys();
 		}
-		
+
 		if (this.weaponInnatePressToggle) {
 			if (!InputManager.isActionActive(EpicFightInputAction.WEAPON_INNATE_SKILL)) {
 				this.attackLightPressToggle = true;
@@ -214,7 +214,7 @@ public class ControlEngine implements IEventBasedEngine {
 						} else {
 							this.lockHotkeys();
 						}
-						
+
 						this.weaponInnatePressToggle = false;
 						this.weaponInnatePressCounter = 0;
 					} else {
@@ -223,10 +223,10 @@ public class ControlEngine implements IEventBasedEngine {
 				}
 			}
 		}
-		
+
 		if (this.attackLightPressToggle) {
 			SkillCastEvent skillCastEvent = this.playerpatch.getSkill(SkillSlots.COMBO_ATTACKS).sendCastRequest(this.playerpatch, this);
-			
+
 			if (skillCastEvent.isExecutable()) {
 				this.player.resetAttackStrengthTicker();
 				this.releaseAllServedKeys();
@@ -235,9 +235,9 @@ public class ControlEngine implements IEventBasedEngine {
 					this.reserveKey(SkillSlots.COMBO_ATTACKS, EpicFightInputAction.ATTACK);
 				}
 			}
-			
+
 			this.lockHotkeys();
-			
+
 			this.attackLightPressToggle = false;
 			this.weaponInnatePressToggle = false;
 			this.weaponInnatePressCounter = 0;
@@ -251,7 +251,7 @@ public class ControlEngine implements IEventBasedEngine {
 				if (skill.sendCastRequest(this.playerpatch, this).shouldReserveKey()) {
 					this.reserveKey(skillSlot, MinecraftInputAction.SNEAK);
 				}
-				
+
 				this.sneakPressToggle = false;
 				this.sneakPressCounter = 0;
 			} else {
@@ -263,16 +263,16 @@ public class ControlEngine implements IEventBasedEngine {
 				}
 			}
 		}
-		
+
 		if (this.currentHoldingKey != null) {
 			SkillContainer container = this.playerpatch.getSkill(this.reservedOrHoldingSkillSlot);
-			
+
 			if (!container.isEmpty()) {
 				if (container.getSkill() instanceof HoldableSkill) {
 					if (!this.isCurrentHoldingActionActive()) {
 						this.holdingFinished = true;
 					}
-					
+
 					if (container.getSkill() instanceof ChargeableSkill chargingSkill) {
 						if (this.holdingFinished) {
 							if (this.playerpatch.getSkillChargingTicks() > chargingSkill.getMinChargingTicks()) {
@@ -298,12 +298,12 @@ public class ControlEngine implements IEventBasedEngine {
 				}
 			}
 		}
-		
+
 		if (this.reservedKey != null) {
 			if (this.reserveCounter > 0) {
 				SkillContainer skill = this.playerpatch.getSkill(this.reservedOrHoldingSkillSlot);
 				this.reserveCounter--;
-				
+
 				if (skill.getSkill() != null) {
 					if (skill.sendCastRequest(this.playerpatch, this).isExecutable()) {
 						this.releaseAllServedKeys();
@@ -344,7 +344,7 @@ public class ControlEngine implements IEventBasedEngine {
         if (playerSkills == null) {
             return;
         }
-        
+
         this.minecraft.setScreen(new SkillEditScreen(this.player, playerSkills));
     }
 
@@ -424,13 +424,13 @@ public class ControlEngine implements IEventBasedEngine {
             return;
         }
         boolean shouldCancelGuard = false;
-        
+
         if (this.playerpatch.isHoldingAny()) {
             shouldCancelGuard = true;
         } else if (ShieldItem.class.isAssignableFrom(this.player.getMainHandItem().getItem().getClass()) || ShieldItem.class.isAssignableFrom(this.player.getOffhandItem().getItem().getClass())) {
             shouldCancelGuard = true;
         }
-        
+
         if (!shouldCancelGuard) {
             SkillCastEvent skillCastEvent = this.playerpatch.getSkill(SkillSlots.GUARD).sendCastRequest(this.playerpatch, this);
 
@@ -463,7 +463,7 @@ public class ControlEngine implements IEventBasedEngine {
         if (!this.playerpatch.isEpicFightMode() || this.playerpatch.isHoldingAny()) {
             return;
         }
-        
+
         if (InputManager.isBoundToSamePhysicalInput(EpicFightInputAction.MOBILITY, MinecraftInputAction.JUMP)) {
             SkillContainer skillContainer = this.playerpatch.getSkill(SkillSlots.MOVER);
 
@@ -507,12 +507,12 @@ public class ControlEngine implements IEventBasedEngine {
     private PlayerInputState inputTick(Input input) {
 		if (this.tickSinceLastJump > 0) this.tickSinceLastJump--;
 		PlayerInputState inputState = InputManager.getInputState(input);
-		
+
 		if (this.moverPressToggle) {
 			if (!InputManager.isActionActive(MinecraftInputAction.JUMP)) {
 				this.moverPressToggle = false;
 				this.moverPressCounter = 0;
-				
+
 				if (this.player.onGround()) {
 					this.player.noJumpDelay = 0;
                     inputState = inputState.withJumping(true);
@@ -522,7 +522,7 @@ public class ControlEngine implements IEventBasedEngine {
 				if (this.moverPressCounter > ClientConfig.longPressCounter) {
 					SkillContainer skill = this.playerpatch.getSkill(SkillSlots.MOVER);
 					skill.sendCastRequest(this.playerpatch, this);
-					
+
 					this.moverPressToggle = false;
 					this.moverPressCounter = 0;
 				} else {
@@ -531,19 +531,19 @@ public class ControlEngine implements IEventBasedEngine {
 				}
 			}
 		}
-		
+
 		if (!this.canPlayerMove(this.playerpatch.getEntityState())) {
             inputState = inputState.copyWith(0F, 0F, false, false, false, false, false, false);
             InputManager.setInputState(inputState);
 			this.player.sprintTriggerTime = -1;
 			this.player.setSprinting(false);
 		}
-		
+
 		return inputState;
 	}
 
     /**
-     * <b>DEPRECATED:</b> This method is retained for backward compatibility and will 
+     * <b>DEPRECATED:</b> This method is retained for backward compatibility and will
      * be removed in a future release. Do not use it for new code.
      * <p>Instead of using this method, use
      * {@link #reserveKey(SkillSlot, InputAction)}, which works directly
@@ -560,7 +560,7 @@ public class ControlEngine implements IEventBasedEngine {
     private void reserveKey(SkillSlot slot, InputAction action) {
         reserveKey(slot, action.keyMapping());
     }
-	
+
 	public void releaseAllServedKeys() {
 		this.holdingFinished = true;
 		this.currentHoldingKey = null;
@@ -568,7 +568,7 @@ public class ControlEngine implements IEventBasedEngine {
 		this.reserveCounter = -1;
 		this.reservedKey = null;
 	}
-	
+
 	public void setHoldingKey(SkillSlot chargingSkillSlot, KeyMapping keyMapping) {
 		this.holdingFinished = false;
 		this.currentHoldingKey = keyMapping;
@@ -576,17 +576,17 @@ public class ControlEngine implements IEventBasedEngine {
 		this.reserveCounter = -1;
 		this.reservedKey = null;
 	}
-	
+
 	public void lockHotkeys() {
 		this.hotbarLocked = true;
 		this.lastHotbarLockedTime = this.player.tickCount;
         disableHotbarSlotPresses();
 	}
-	
+
 	public void unlockHotkeys() {
 		this.hotbarLocked = false;
 	}
-	
+
 	public void addPacketToSend(CustomPacketPayload packet) {
 		this.packetsToSend.add(packet);
 	}
@@ -631,16 +631,16 @@ public class ControlEngine implements IEventBasedEngine {
     @Deprecated(forRemoval = true)
 	private static boolean isKeyPressed(KeyMapping key, boolean eventCheck) {
 		boolean consumes = key.consumeClick();
-		
+
 		if (consumes && eventCheck) {
 			int mouseButton = InputConstants.Type.MOUSE == key.getKey().getType() ? key.getKey().getValue() : -1;
 			InputEvent.InteractionKeyMappingTriggered inputEvent = ClientHooks.onClickInput(mouseButton, key, InteractionHand.MAIN_HAND);
-			
+
 	        if (inputEvent.isCanceled()) {
 	        	return false;
 	        }
 		}
-        
+
     	return consumes;
 	}
 
@@ -791,34 +791,33 @@ public class ControlEngine implements IEventBasedEngine {
         makeUnpressed(MinecraftInputAction.ATTACK_DESTROY.keyMapping());
     }
 
-    /**
-     * Previously used to temporarily disable the vanilla swap-offhand key while the player
-     * was performing an action or attacking, but this is now handled by
-     * {@link yesman.epicfight.mixin.client.MixinClientCommonPacketListenerImpl#onBeforeSendPacket}.
-     * <p>
-     * This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
-     * to prevent potential conflicts with other mods. It serves as a safety measure;
-     * removing it should no longer cause any issues.
-     * <p>
-     * This method does not rely on {@link InputManager} because it operates solely on
-     * the vanilla {@link KeyMapping} behavior.
-     * @see ControlEngine#shouldDisableSwapHandItems
-     */
+    /// Previously used to temporarily disable the vanilla swap-offhand key while the player
+    /// was performing an action or attacking, but this is now handled by
+    /// [yesman.epicfight.mixin.client.MixinClientCommonPacketListenerImpl#onBeforeSendPacket].
+    ///
+    /// This method now only decrements the internal counter of the vanilla [KeyMapping#clickCount]
+    /// to prevent potential conflicts with other mods.
+    ///
+    /// It serves as a safety measure; removing it should no longer cause any issues.
+    ///
+    /// This method does not rely on [InputManager] because it operates solely on
+    /// the vanilla [KeyMapping] behavior.
+    ///
+    /// @see ControlEngine#shouldDisableSwapHandItems
     @SuppressWarnings("JavadocReference")
     private static void consumeSwapOffhandKeyClicks() {
         makeUnpressed(MinecraftInputAction.SWAP_OFF_HAND.keyMapping());
     }
 
-    /**
-     * Disables hotbar slot key presses (keyboard only).
-     * <p>
-     * This feature is strictly for keyboards and will not support controllers,
-     * as controllers have limited buttons. Keyboard users can switch slots via
-     * number keys or the mouse wheel. Controller users can only switch using
-     * forward/backward buttons.
-     *
-     * @see ControlEngine#isHotbarCyclingDisabled
-     */
+    /// Disables hotbar slot key presses (keyboard only).
+    ///
+    /// This feature is strictly for keyboards and will not support controllers,
+    /// as controllers have limited buttons.
+    ///
+    /// Keyboard users can switch slots via number keys or the mouse wheel.
+    /// Controller users can only switch using forward/backward buttons.
+    ///
+    /// @see ControlEngine#isHotbarCyclingDisabled
     private static void disableHotbarSlotPresses() {
         final KeyMapping[] hotbarSlots = Minecraft.getInstance().options.keyHotbarSlots;
         for (int i = 0; i < 9; ++i) {
@@ -827,52 +826,50 @@ public class ControlEngine implements IEventBasedEngine {
         }
     }
 
-    /**
-     * Previously used to temporarily disable the vanilla item drop key while the player
-     * was performing an action or attacking, but this is now handled by
-     * {@link yesman.epicfight.mixin.client.MixinLocalPlayer#onDrop}.
-     * <p>
-     * This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
-     * to prevent potential conflicts with other mods. It serves as a safety measure;
-     * removing it should no longer cause any issues.
-     * <p>
-     */
+    /// Previously used to temporarily disable the vanilla item drop key while the player
+    /// was performing an action or attacking, but this is now handled by
+    /// [yesman.epicfight.mixin.client.MixinLocalPlayer#onDrop].
+    ///
+    /// This method now only decrements the internal counter of the vanilla {@link KeyMapping#clickCount}
+    /// to prevent potential conflicts with other mods.
+    ///
+    /// It serves as a safety measure; removing it should no longer cause any issues.
     @SuppressWarnings("JavadocReference")
     private static void consumeDropKeyClicks() {
         makeUnpressed(MinecraftInputAction.DROP.keyMapping());
     }
 
-    /**
-     * Maps a {@link KeyMapping} to its corresponding input action, if defined.
-     * <p>
-     * Each {@link EpicFightInputAction} enum constant has an associated {@link KeyMapping},
-     * but not every {@link KeyMapping} corresponds to an {@link EpicFightInputAction}, so this may return {@code null}.
-     * Using {@link KeyMapping} directly does not support controllers.
-     * <p>
-     * Ideally, this workaround should not exist. The code should depend on {@link EpicFightInputAction} directly
-     * instead of storing {@link KeyMapping} instances. However, since some classes and Epic Fight addons still rely on:
-     * <ul>
-     *   <li>{@link HoldableSkill#getKeyMapping}</li>
-     *   <li>{@link ControlEngine#currentHoldingKey}</li>
-     *   <li>{@link ControlEngine#reservedKey}</li>
-     * </ul>
-     * this method remains temporarily for backward compatibility. Future updates should refactor these dependencies
-     * to remove reliance on {@link KeyMapping}, allowing this method to be fully removed.
-     * <p>
-     * Sometimes, it makes sense to use this method, for example, if you're using an event such as {@link InputEvent.InteractionKeyMappingTriggered},
-     * which provides only a {@link KeyMapping}.
-     */
+    /// Maps a [KeyMapping] to its corresponding input action, if defined.
+    ///
+    /// Each [InputAction] enum constant has an associated [KeyMapping],
+    /// but not every [KeyMapping] corresponds to an [EpicFightInputAction],
+    /// so this may return `null`.
+    /// Using [KeyMapping] directly does not support controllers.
+    ///
+    /// Ideally, this workaround should not exist.
+    /// The code should depend on [EpicFightInputAction] directly
+    /// instead of storing [KeyMapping] instances.
+    ///
+    /// However, since some classes and Epic Fight addons still rely on:
+    ///
+    /// - [HoldableSkill#getKeyMapping]
+    /// - [ControlEngine#currentHoldingKey]
+    /// - [ControlEngine#reservedKey]
+    ///
+    /// this method remains temporarily for backward compatibility. Future updates should refactor these dependencies
+    /// to remove reliance on [KeyMapping], allowing this method to be fully removed.
+    ///
+    /// Sometimes, it makes sense to use this method, for example, if you're using an event such as [InputEvent.InteractionKeyMappingTriggered],
+    /// which provides only a [KeyMapping].
     private static @Nullable InputAction mapKeyMappingToAction(@NotNull KeyMapping keyMapping) {
         return InputAction.fromKeyMapping(keyMapping);
     }
 
-    /**
-     * Checks if the specified input action is currently being held.
-     *
-     * @param other the input action to check
-     * @return {@code true} if the given action is currently held; otherwise {@code false}
-     * @see ControlEngine#mapKeyMappingToAction
-     */
+    /// Checks if the specified input action is currently being held.
+    ///
+    /// @param other the input action to check
+    /// @return `true` if the given action is currently held; otherwise `false`
+    /// @see ControlEngine#mapKeyMappingToAction
     private boolean isCurrentHoldingAction(@NotNull InputAction other) {
         if (currentHoldingKey == null) {
             return false;
@@ -886,7 +883,7 @@ public class ControlEngine implements IEventBasedEngine {
         }
         return other == currentHoldingAction;
     }
-    
+
     private boolean isCurrentHoldingActionActive() {
         if (currentHoldingKey == null) {
             return false;
@@ -901,18 +898,19 @@ public class ControlEngine implements IEventBasedEngine {
         return InputManager.isActionActive(currentHoldingAction);
     }
 
-    /**
-     * Determines whether hotbar cycling should be disabled.
-     * <p>
-     * Used internally in {@link InputEvent.MouseScrollingEvent} and
-     * {@link yesman.epicfight.mixin.client.MixinInventory}. Cancelling the mouse
-     * scroll event disables cycling for vanilla mouse input, but other input
-     * systems (e.g., controllers) still call {@link Inventory#swapPaint}, so we
-     * cancel those calls as well. This ensures universal behavior while
-     * maximizing compatibility.
-     *
-     * @return {@code true} if hotbar item cycling should be disabled; {@code false} otherwise.
-     * */
+    /// Determines whether hotbar cycling should be disabled.
+    ///
+    /// Used internally in [InputEvent.MouseScrollingEvent] and
+    /// [yesman.epicfight.mixin.client.MixinInventory].
+    ///
+    /// Cancelling the mouse scroll event disables cycling for vanilla mouse input, but other input
+    /// systems (e.g., controllers) still call {@link Inventory#swapPaint}, so we
+    /// cancel those calls as well.
+    ///
+    /// This ensures universal behavior while
+    /// maximizing compatibility.
+    ///
+    /// @return `true` if hotbar item cycling should be disabled; `false` otherwise.
     @ApiStatus.Internal
     public static boolean isHotbarCyclingDisabled() {
         final Minecraft minecraft = Minecraft.getInstance();
@@ -920,11 +918,9 @@ public class ControlEngine implements IEventBasedEngine {
         return minecraft.player != null && localPlayerPatch != null && !localPlayerPatch.getEntityState().canSwitchHoldingItem() && minecraft.screen == null;
     }
 
-    /**
-     * Checks whether the player is blocked from switching or dropping the held item.
-     *
-     * @return true if switching or dropping is blocked, false otherwise
-     */
+     /// Checks whether the player is blocked from switching or dropping the held item.
+     ///
+     /// @return `true` if switching or dropping is blocked, `false` otherwise
     public boolean isSwitchOrDropBlocked() {
         return !this.playerpatch.getEntityState().canSwitchHoldingItem() || this.hotbarLocked;
     }
@@ -932,19 +928,19 @@ public class ControlEngine implements IEventBasedEngine {
     public boolean moverToggling() {
 		return this.moverPressToggle;
 	}
-	
+
 	public boolean sneakToggling() {
 		return this.sneakPressToggle;
 	}
-	
+
 	public boolean attackToggling() {
 		return this.attackLightPressToggle;
 	}
-	
+
 	public boolean weaponInnateToggling() {
 		return this.weaponInnatePressToggle;
 	}
-	
+
 	/******************
 	 * Event listeners
 	 ******************/
@@ -954,22 +950,22 @@ public class ControlEngine implements IEventBasedEngine {
             event.setCanceled(true);
         }
 	}
-	
+
 	private void epicfight$moveInputEvent(MovementInputUpdateEvent event) {
 		if (this.playerpatch == null) {
 			return;
 		}
-		
+
 		PlayerInputState playerinputstate = this.inputTick(event.getInput());
 		MappedMovementInputUpdateEvent wrappedEvent = new MappedMovementInputUpdateEvent(this.playerpatch, playerinputstate);
 		this.playerpatch.getPlayerSkills().fireSkillEvents(EpicFightMod.MODID, wrappedEvent);
 	}
-	
+
 	private void epicfight$clientTickEndEvent(ClientTickEvent.Post event) {
 		if (this.player == null) {
 			return;
 		}
-		
+
 		this.packetsToSend.forEach(EpicFightNetworkManager::sendToServer);
 		this.packetsToSend.clear();
 	}
@@ -993,13 +989,13 @@ public class ControlEngine implements IEventBasedEngine {
 		) {
 			BlockPos bp = ((BlockHitResult)this.minecraft.hitResult).getBlockPos();
 			BlockState bs = this.minecraft.level.getBlockState(bp);
-			
+
 			if (!this.player.getMainHandItem().getItem().canAttackBlock(bs, this.player.level(), bp, this.player) || this.player.getMainHandItem().getDestroySpeed(bs) <= 1.0F) {
 				event.setSwingHand(false);
 				event.setCanceled(true);
 			}
 		}
-		
+
 		if (
 			triggeredAction == MinecraftInputAction.USE &&
 			InputManager.isBoundToSamePhysicalInput(MinecraftInputAction.USE, EpicFightInputAction.GUARD) &&
@@ -1009,15 +1005,15 @@ public class ControlEngine implements IEventBasedEngine {
 			)
 		) {
 			MutableBoolean canGuard = new MutableBoolean();
-			
+
 			EpicFightCapabilities.getUnparameterizedEntityPatch(this.minecraft.player, LocalPlayerPatch.class).ifPresent(playerpatch -> {
 				SkillContainer skillcontainer = playerpatch.getSkill(SkillSlots.GUARD);
-				
+
 				if (skillcontainer.getSkill() != null && skillcontainer.getSkill().canExecute(skillcontainer)) {
 					canGuard.setValue(true);
 				}
 			});
-			
+
 			if (this.minecraft.hitResult.getType() == HitResult.Type.MISS) {
 				if (canGuard.booleanValue() && ClientConfig.keyConflictResolveScope.cancelItemUse()) {
 					event.setSwingHand(false);
@@ -1035,14 +1031,14 @@ public class ControlEngine implements IEventBasedEngine {
 							BlockState blockstate = this.minecraft.level.getBlockState(blockpos);
 							FakeLevel fakeLevelForSimulation = FakeLevel.getFakeLevel(this.minecraft.level);
 							FakeLevel.FakeClientPlayer fakePlayerForSimulation = FakeLevel.getFakePlayer(this.minecraft.player.getGameProfile());
-							
+
 							InteractionResult useItemInteractionResult = blockstate.useItemOn(this.player.getItemInHand(event.getHand()), fakeLevelForSimulation, fakePlayerForSimulation, event.getHand(), blockHitResult).result();
 							if (useItemInteractionResult != InteractionResult.PASS) yield useItemInteractionResult;
 							yield blockstate.useWithoutItem(fakeLevelForSimulation, fakePlayerForSimulation, blockHitResult);
 						}
 						default -> throw new IllegalArgumentException();
 					};
-					
+
 					if (interactionResult != InteractionResult.PASS && ClientConfig.keyConflictResolveScope.cancelInteraction()) {
 						event.setSwingHand(false);
 						event.setCanceled(true);
@@ -1054,13 +1050,13 @@ public class ControlEngine implements IEventBasedEngine {
 			}
 		}
 	}
-	
+
 	private void epicfight$livingJumpEvent(LivingJumpEvent event) {
 		if (event.getEntity() == this.player) {
 			this.tickSinceLastJump = 5;
 		}
 	}
-	
+
 	/**********************
 	 * Event listeners end
 	 **********************/
@@ -1072,7 +1068,7 @@ public class ControlEngine implements IEventBasedEngine {
 		gameEventBus.addListener(this::epicfight$interactionKeyMappingTriggered);
 		gameEventBus.addListener(this::epicfight$livingJumpEvent);
 	}
-	
+
 	@Override
 	public void modEventBus(IEventBus modEventBus) {
 	}

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
@@ -36,8 +36,8 @@ import yesman.epicfight.api.client.animation.AnimationSubFileReader.PovSettings.
 import yesman.epicfight.api.client.animation.Layer;
 import yesman.epicfight.api.client.animation.property.ClientAnimationProperties;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
-import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.InputManager;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.events.engine.RenderEngine;
@@ -180,7 +180,7 @@ public class LocalPlayerPatch extends AbstractClientPlayerPatch<LocalPlayer> {
 	
 	@Override
 	public boolean shouldBlockMoving() {
-		return InputManager.isActionActive(EpicFightInputAction.MOVE_BACKWARD) || InputManager.isActionActive(EpicFightInputAction.SNEAK);
+		return InputManager.isActionActive(MinecraftInputAction.MOVE_BACKWARD) || InputManager.isActionActive(MinecraftInputAction.SNEAK);
 	}
 	
 	@Override

--- a/src/main/java/yesman/epicfight/compat/controlify/ControlifyControllerBinding.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/ControlifyControllerBinding.java
@@ -44,4 +44,10 @@ public record ControlifyControllerBinding(@NotNull InputBinding inputBinding) im
     public void emulatePress() {
         inputBinding.fakePress();
     }
+
+    @Override
+    @NotNull
+    public Object physicalInputId() {
+        return inputBinding.boundInput().getRelevantInputs();
+    }
 }

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.PlayerInputState;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.input.controller.ControllerBinding;
 import yesman.epicfight.api.client.input.controller.IEpicFightControllerMod;
 
@@ -29,11 +30,11 @@ public class EpicFightControlifyControllerMod implements IEpicFightControllerMod
     }
 
     public static @NotNull ControllerBinding getBinding(@NotNull EpicFightInputAction action) {
-        return new ControlifyControllerBinding(getControlifyBinding(action));
+        return new ControlifyControllerBinding(EpicFightControlifyEntrypoint.getControlifyBinding(action));
     }
 
-    public static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
-        return EpicFightControlifyEntrypoint.getControlifyBinding(action);
+    public static @NotNull ControllerBinding getBinding(@NotNull MinecraftInputAction action) {
+        return new ControlifyControllerBinding(EpicFightControlifyEntrypoint.getControlifyBinding(action));
     }
 
     @Override

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyControllerMod.java
@@ -2,7 +2,6 @@ package yesman.epicfight.compat.controlify;
 
 import dev.isxander.controlify.api.bind.InputBinding;
 import dev.isxander.controlify.bindings.ControlifyBindings;
-import dev.isxander.controlify.bindings.input.Input;
 import dev.isxander.controlify.controller.ControllerEntity;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -57,12 +56,5 @@ public class EpicFightControlifyControllerMod implements IEpicFightControllerMod
                 leftBind.digitalNow(), rightBind.digitalNow(),
                 jumpBind.digitalNow(), sneakBind.digitalNow()
         );
-    }
-
-    @Override
-    public boolean isBoundToSamePhysicalInput(@NotNull EpicFightInputAction action, @NotNull EpicFightInputAction action2) {
-        final Input input1 = getControlifyBinding(action).boundInput();
-        final Input input2 = getControlifyBinding(action2).boundInput();
-        return input1.getRelevantInputs().equals(input2.getRelevantInputs());
     }
 }

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -31,6 +31,7 @@ import org.joml.Vector2f;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.InputMode;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.input.controller.EpicFightControllerModProvider;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.SkillBookScreen;
@@ -131,14 +132,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
                 case SWITCH_VANILLA_MODEL_DEBUGGING ->
                         new TranslationKeys(LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG, LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG_DESCRIPTION);
                 case MOBILITY -> new TranslationKeys(LangKeys.KEY_MOVER_SKILL, LangKeys.KEY_MOVER_SKILL_DESCRIPTION);
-
-                // Vanilla actions translations already handled by Controlify.
-                case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, DROP, TOGGLE_PERSPECTIVE, JUMP,
-                     MOVE_FORWARD, MOVE_BACKWARD, MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK ->
-                        throw new IllegalArgumentException(
-                                "TranslationKeys#fromAction() must only be called for non-vanilla actions. " +
-                                        "This action is vanilla and already registered by Controlify: " + action.name()
-                        );
             };
         }
 
@@ -180,7 +173,7 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     }
 
     private static void registerInputBindings(ControlifyBindApi registrar) {
-        for (EpicFightInputAction action : EpicFightInputAction.nonVanillaActions()) {
+        for (EpicFightInputAction action : EpicFightInputAction.values()) {
             registerInputBinding(registrar, action);
         }
     }
@@ -215,11 +208,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         // The returned value is a dummy and does nothing; its only purpose is to
         // satisfy the compiler and ensure all enum constants are handled.
         return switch (action) {
-            case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
-                 MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
-                    "EpicFightControlifyEntrypoint#registerInputBinding() must only be called for non-vanilla actions. " +
-                            "This action is vanilla and already registered by Controlify: " + action.name()
-            );
             case ATTACK -> attack = registrar.registerBinding(
                     builder -> applyCommonBindingProperties(action, builder)
                             .category(combatCategory)
@@ -329,11 +317,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
             case OPEN_SKILL_SCREEN -> "open_skill_editor_screen";
             case OPEN_CONFIG_SCREEN -> "open_config_screen";
             case SWITCH_VANILLA_MODEL_DEBUGGING -> "switch_vanilla_mode_debugging";
-            case VANILLA_ATTACK_DESTROY, USE, SWAP_OFF_HAND, TOGGLE_PERSPECTIVE, DROP, MOVE_FORWARD, MOVE_BACKWARD,
-                 MOVE_LEFT, MOVE_RIGHT, SPRINT, SNEAK, JUMP -> throw new IllegalArgumentException(
-                    "EpicFightControlifyEntrypoint#getInputBindingId() must only be called for non-vanilla actions. " +
-                            "This action is vanilla and already registered by Controlify: " + action.name()
-            );
         };
         return EpicFightMod.rl(path);
     }
@@ -381,20 +364,6 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
 
     public static @NotNull InputBinding getControlifyBinding(@NotNull EpicFightInputAction action) {
         final InputBindingSupplier bindingSupplier = switch (action) {
-            // Minecraft Vanilla actions
-            case VANILLA_ATTACK_DESTROY -> ControlifyBindings.ATTACK;
-            case MOVE_FORWARD -> ControlifyBindings.WALK_FORWARD;
-            case MOVE_BACKWARD -> ControlifyBindings.WALK_BACKWARD;
-            case MOVE_LEFT -> ControlifyBindings.WALK_LEFT;
-            case MOVE_RIGHT -> ControlifyBindings.WALK_RIGHT;
-            case SPRINT -> ControlifyBindings.SPRINT;
-            case SNEAK -> ControlifyBindings.SNEAK;
-            case USE -> ControlifyBindings.USE;
-            case SWAP_OFF_HAND -> ControlifyBindings.SWAP_HANDS;
-            case DROP -> ControlifyBindings.DROP_INGAME;
-            case TOGGLE_PERSPECTIVE -> ControlifyBindings.CHANGE_PERSPECTIVE;
-            case JUMP -> ControlifyBindings.JUMP;
-            // Epic Fight custom actions
             case ATTACK -> attack;
             case MOBILITY -> mobility;
             case GUARD -> guard;
@@ -409,6 +378,25 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
             case OPEN_SKILL_SCREEN -> openSkillEditorScreen;
             case OPEN_CONFIG_SCREEN -> openConfigScreen;
             case SWITCH_VANILLA_MODEL_DEBUGGING -> switchVanillaModeDebugging;
+        };
+        final @Nullable InputBinding binding = bindingSupplier.onOrNull(requireControllerEntity());
+        return Objects.requireNonNull(binding, "The binding for the action " + action.name() + " is not yet registered.");
+    }
+
+    public static @NotNull InputBinding getControlifyBinding(@NotNull MinecraftInputAction action) {
+        final InputBindingSupplier bindingSupplier = switch (action) {
+            case ATTACK_DESTROY -> ControlifyBindings.ATTACK;
+            case MOVE_FORWARD -> ControlifyBindings.WALK_FORWARD;
+            case MOVE_BACKWARD -> ControlifyBindings.WALK_BACKWARD;
+            case MOVE_LEFT -> ControlifyBindings.WALK_LEFT;
+            case MOVE_RIGHT -> ControlifyBindings.WALK_RIGHT;
+            case SPRINT -> ControlifyBindings.SPRINT;
+            case SNEAK -> ControlifyBindings.SNEAK;
+            case USE -> ControlifyBindings.USE;
+            case SWAP_OFF_HAND -> ControlifyBindings.SWAP_HANDS;
+            case DROP -> ControlifyBindings.DROP_INGAME;
+            case TOGGLE_PERSPECTIVE -> ControlifyBindings.CHANGE_PERSPECTIVE;
+            case JUMP -> ControlifyBindings.JUMP;
         };
         final @Nullable InputBinding binding = bindingSupplier.onOrNull(requireControllerEntity());
         return Objects.requireNonNull(binding, "The binding for the action " + action.name() + " is not yet registered.");

--- a/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
+++ b/src/main/java/yesman/epicfight/compat/shouldersurfing/ShoulderSurfingCompat.java
@@ -9,6 +9,7 @@ import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.InputManager;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.camera.EpicFightTpsCameraDisableState;
 import yesman.epicfight.client.camera.EpicFightTpsCameraDisabledReason;
@@ -56,7 +57,7 @@ public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
     private static class ForceCameraCouplingWhenAttackingCallback implements ICameraCouplingCallback {
         @Override
         public boolean isForcingCameraCoupling(Minecraft minecraft) {
-            return InputManager.isActionActive(EpicFightInputAction.ATTACK) || InputManager.isActionActive(EpicFightInputAction.VANILLA_ATTACK_DESTROY);
+            return InputManager.isActionActive(EpicFightInputAction.ATTACK) || InputManager.isActionActive(MinecraftInputAction.ATTACK_DESTROY);
         }
     }
 

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -39,6 +39,7 @@ import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.client.animation.property.JointMaskReloadListener;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.action.InputAction;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.model.ItemSkinsReloadListener;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.data.reloader.ItemCapabilityReloadListener;
@@ -170,6 +171,7 @@ public class EpicFightMod {
     	EntityPairingPacketType.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EntityPairingPacketTypes.class);
     	if (EpicFightSharedConstants.isPhysicalClient()) {
             InputAction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, EpicFightInputAction.class);
+            InputAction.ENUM_MANAGER.registerEnumCls(EpicFightMod.MODID, MinecraftInputAction.class);
         }
     	
     	EpicFightRegistries.DEFERRED_REGISTRIES.forEach(deferredRegistry -> deferredRegistry.register(modEventBus));

--- a/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
+++ b/src/main/java/yesman/epicfight/skill/mover/PhantomAscentSkill.java
@@ -13,8 +13,8 @@ import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.MovementDirection;
-import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.client.input.InputManager;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.PlayerPatchEvent;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
@@ -157,6 +157,6 @@ public class PhantomAscentSkill extends Skill {
 	}
 
     private static boolean isJumpActionPressed() {
-        return InputManager.isActionActive(EpicFightInputAction.JUMP);
+        return InputManager.isActionActive(MinecraftInputAction.JUMP);
     }
 }


### PR DESCRIPTION
Closes #2194 

- Allows third-party controller mods to compare or check whether different controller bindings refer to the same physical control without force, depending on Controlify APIs.
- Treats all input actions equally, without depending on `EpicFightInputAction` for better addon support.
- Separates all Minecraft vanilla standard input actions from Epic Fight-specific ones, with two different enums