### PR TITLE
[1.21.1] Fixed the animation looping error, caused by unprotected elapsed time variable between 0 ~ total time

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
@@ -1,14 +1,9 @@
 package yesman.epicfight.api.animation;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import net.minecraft.util.Mth;
 import org.apache.commons.lang3.mutable.MutableInt;
 
-import net.minecraft.util.Mth;
+import java.util.*;
 
 public class AnimationClip {
 	public static final AnimationClip EMPTY_CLIP = new AnimationClip();
@@ -73,7 +68,11 @@ public class AnimationClip {
 	
 	public final Pose getPoseInTime(float time) {
 		Pose pose = new Pose();
-		
+
+        if (time < 0.0F) {
+            time = this.clipTime + time;
+        }
+
 		if (this.bakedTimes != null && this.bakedTimes.length > 0) {
 			// Binary search
 			int begin = 0, end = this.bakedTimes.length - 1;


### PR DESCRIPTION
Initially reported by @squoshi, a regression driven by the binary search and baked keyframes feature in 20.12.8

https://github.com/Epic-Fight/epicfight/commit/9e2519390e3fb358155c058ca3290e1fa532c1e8