### PR TITLE
[1.20.1] Fixed the animation looping error, caused by unprotected elapsed time

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
@@ -74,6 +74,10 @@ public class AnimationClip {
 	public final Pose getPoseInTime(float time) {
 		Pose pose = new Pose();
 		
+		if (time < 0.0F) {
+			time = this.clipTime + time;
+		}
+		
 		if (this.bakedTimes != null && this.bakedTimes.length > 0) {
 			// Binary search
 			int begin = 0, end = this.bakedTimes.length - 1;


### PR DESCRIPTION
same goes with #2254, but 1.20.1.