### PR TITLE
[1.20.1] Fixed the dedicated server crash when initializing the server

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -901,8 +901,6 @@ public final class EpicFightCameraAPI {
 	@ApiStatus.Internal
 	public float getYRotForHead(Player player) {
 		if (!player.isLocalPlayer()) {
-			// Casting player to LocalPlayer led to a crash in dedicated server, so we delegated type checking to here
-			// See MixinLivingEntity
 			throw new IllegalArgumentException("Only LocalPlayer are allowed to this parameter");
 		}
 		

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -896,11 +896,17 @@ public final class EpicFightCameraAPI {
 	}
 	
 	/**
-	 * REturns a new basis for {@link LivingEntity#yRotHead} instead of coupling it to {@link Entity#getYRot}
+	 * Returns a new basis for {@link LivingEntity#yRotHead} instead of coupling it to {@link Entity#getYRot}
 	 */
 	@ApiStatus.Internal
-	public float getYRotForHead(LocalPlayer localPlayer) {
-		return (this.isTPSMode() && (Mth.abs(Mth.wrapDegrees(this.cameraYRot - localPlayer.yBodyRot)) <= 51.0F || this.predicateCouplingPlayer())) ? this.cameraYRot : localPlayer.getYRot();
+	public float getYRotForHead(Player player) {
+		if (!player.isLocalPlayer()) {
+			// Casting player to LocalPlayer led to a crash in dedicated server, so we delegated type checking to here
+			// See MixinLivingEntity
+			throw new IllegalArgumentException("Only LocalPlayer are allowed to this parameter");
+		}
+		
+		return (this.isTPSMode() && (Mth.abs(Mth.wrapDegrees(this.cameraYRot - player.yBodyRot)) <= 51.0F || this.predicateCouplingPlayer())) ? this.cameraYRot : player.getYRot();
 	}
 	
 	private boolean predicateFocusableEntity(Entity entity) {

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -895,9 +895,11 @@ public final class EpicFightCameraAPI {
 		EpicFightClientHooks.Camera.BUILD_TRANSFORM_POST.post(new BuildCameraTransform.Post(this, camera, partialTick));
 	}
 	
-	/**
-	 * Returns a new basis for {@link LivingEntity#yRotHead} instead of coupling it to {@link Entity#getYRot}
-	 */
+	/// Returns a new basis for [LivingEntity#yRotHead] instead of coupling it to [Entity#getYRot].
+    ///
+    /// This method takes a [Player] instead of [LocalPlayer] because casting
+    /// to the client-only [LocalPlayer] inside a mixin (e.g., in [LivingEntity])
+    /// would crash a dedicated server due to Forge's `@OnlyIn(Dist.CLIENT)`.
 	@ApiStatus.Internal
 	public float getYRotForHead(Player player) {
 		if (!player.isLocalPlayer()) {

--- a/src/main/java/yesman/epicfight/mixin/common/MixinLivingEntity.java
+++ b/src/main/java/yesman/epicfight/mixin/common/MixinLivingEntity.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.CombatRules;
@@ -159,7 +158,7 @@ public abstract class MixinLivingEntity {
     private float epicfight$tick(LivingEntity livingEntity) {
 		// returns the basis y rotation as camera in TPS mode
 		if (livingEntity instanceof Player player && player.isLocalPlayer()) {
-			return EpicFightCameraAPI.getInstance().getYRotForHead((LocalPlayer)player);
+			return EpicFightCameraAPI.getInstance().getYRotForHead(player);
 		}
 		
 		return livingEntity.getYRot();
@@ -175,7 +174,7 @@ public abstract class MixinLivingEntity {
 	protected float epicfight$tickHeadTurn(LivingEntity livingEntity) {
 		// returns the basis y rotation as camera in TPS mode
 		if (livingEntity instanceof Player player && player.isLocalPlayer()) {
-			return EpicFightCameraAPI.getInstance().getYRotForHead((LocalPlayer)player);
+			return EpicFightCameraAPI.getInstance().getYRotForHead(player);
 		}
 		
 		return livingEntity.getYRot();

--- a/src/main/java/yesman/epicfight/mixin/common/MixinPlayer.java
+++ b/src/main/java/yesman/epicfight/mixin/common/MixinPlayer.java
@@ -6,7 +6,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.damagesource.CombatTracker;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.player.Player;
@@ -53,7 +52,7 @@ public abstract class MixinPlayer {
     )
     private float epicfight$serverAiStep(Player player) {
 		if (player.isLocalPlayer()) {
-			return EpicFightCameraAPI.getInstance().getYRotForHead((LocalPlayer)player);
+			return EpicFightCameraAPI.getInstance().getYRotForHead(player);
 		}
 		
 		return player.getYRot();


### PR DESCRIPTION
Using `LocalPlayer` in mixin code causes a dedicated server crash, even tho it's guarded by type-checking.

```JAVA
private float epicfight$serverAiStep(Player player) {
		if (player.isLocalPlayer()) {
			return EpicFightCameraAPI.getInstance().getYRotForHead((LocalPlayer)player);
		}
		
		return player.getYRot();
    }
```

So moved the type-casting into EpicFightCameraAPI

```JAVA
@ApiStatus.Internal
	public float getYRotForHead(Player player) {
		if (!player.isLocalPlayer()) {
			// Casting player to LocalPlayer led to a crash in dedicated server, so we delegated type checking to here
			// See MixinLivingEntity
			throw new IllegalArgumentException("Only LocalPlayer are allowed to this parameter");
		}
		
		return (this.isTPSMode() && (Mth.abs(Mth.wrapDegrees(this.cameraYRot - player.yBodyRot)) <= 51.0F || this.predicateCouplingPlayer())) ? this.cameraYRot : player.getYRot();
	}
```