### PR TITLE
[1.21.1] Generate -api.jar with public APIs only

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,9 @@
     - Replace the mod-loader event system into Epic Fight API, as we're planning to support multi-loader developer environment
     - The feature is still WIP, supporting only events for EpicFightCameraAPI
     - We will eventually replace all Forge/NeoForge events owned by Epic Fight into Hooks
+- Added API JAR file, which includes classes under `yesman/epicfight/api/**` only, to allow consumers to compile against
+  Epic Fight public API only.
+    - **Note:** Keep in mind that Epic Fight public APIs are still being stabilized, and breaking changes may occur. 
 
 ## [21.13.5] - 2025-11-12
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -325,6 +325,30 @@ tasks.compileJava {
     dependsOn(generateLangKeys)
 }
 
+// The API JAR file includes only classes from the API package.
+
+val apiPackage = "yesman/epicfight/api/**"
+val apiJarClassifier = "api"
+
+val apiJar by tasks.registering(Jar::class) {
+    group = "build"
+    archiveClassifier.set(apiJarClassifier)
+
+    from(sourceSets.main.get().output) { include(apiPackage) }
+}
+
+val apiSourcesJar by tasks.registering(Jar::class) {
+    group = "build"
+    archiveClassifier.set("$apiJarClassifier-sources") // Important to use this suffix, to follow standards
+
+    from(sourceSets.main.get().allSource) { include(apiPackage) }
+}
+
+artifacts {
+    archives(apiJar)
+    archives(apiSourcesJar)
+}
+
 fun extractCurrentVersionChangelog(): String? {
     val changelogFile = project.file("RELEASE_NOTES.md")
     val fullChangelogText = changelogFile.readText()
@@ -366,7 +390,7 @@ publishMods {
     type.set(STABLE)
     displayName.set(getFullModVersion())
     file.set(tasks.jar.get().archiveFile)
-    additionalFiles.from(sourcesJar)
+    additionalFiles.from(sourcesJar, apiJar, apiSourcesJar)
 
     curseforge {
         accessToken.set(providers.environmentVariable("CURSEFORGE_TOKEN"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,10 +35,9 @@ repositories {
 
     // JEI
     strictMaven("https://maven.blamejared.com", "mezz.jei", "Jared")
-
     strictMaven("https://maven.architectury.dev", "dev.architectury", "Architectury")
-    strictMaven("https://maven.latvian.dev/releases", "dev.latvian.mods", "Architectury")
-
+    // KubeJS
+    strictMaven("https://maven.latvian.dev/releases", "dev.latvian.mods", "Latvian")
     // Controlify, YACL
     strictMaven("https://maven.isxander.dev/releases", "dev.isxander", "IsXander")
 }


### PR DESCRIPTION
Configures Gradle to generate API JAR file (with the sources JAR file) while following Java standards.

There is a way to ship the sources in one JAR file instead of 2, but this is non-standard and may not display the source in some IDEs.

<img width="541" height="515" alt="image" src="https://github.com/user-attachments/assets/1f95aed6-2de8-45de-9b5a-2ceb73534b45" />

<img width="2154" height="1354" alt="image" src="https://github.com/user-attachments/assets/87275907-927d-48c4-b42a-1c868a4590a5" />

<img width="1123" height="1021" alt="image" src="https://github.com/user-attachments/assets/fddfe08f-9def-4de4-9719-24f3280da983" />

While our public API is quite stable yet, we should make this step early to allow consumers to adapt to the API earlier.

When the API becomes more stable, we won't need any changes in Gradle scripts.
