### PR TITLE
[1.21.1] Setup GitHub workflow to update Gradle wrapper

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
This makes it so that a GitHub pull request will be automatically sent by a GitHub bot to update the Gradle wrapper (`gradle`, `./gradlew`, `./gradlew.bat`) and GitHub action dependencies.

We can still review the changes and reject them if needed.

This uses [Update Gradle Wrapper Action](https://github.com/marketplace/actions/update-gradle-wrapper-action) provided by Gradle Update.