### PR TITLE
[1.21.1] Restrict Some Internal Epic Fight APIs from Public Exposure

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -40,7 +40,7 @@ import yesman.epicfight.api.client.input.action.InputAction;
 import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.client.neoevent.MappedMovementInputUpdateEvent;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
-import yesman.epicfight.api.utils.FakeLevel;
+import yesman.epicfight.client.world.util.FakeLevel;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.gui.screen.config.IngameConfigurationScreen;

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/IngameConfigurationScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/IngameConfigurationScreen.java
@@ -10,7 +10,7 @@ import net.minecraft.network.chat.Component;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModContainer;
-import yesman.epicfight.api.client.online.EpicFightServerConnectionHelper;
+import yesman.epicfight.client.online.EpicFightServerConnectionHelper;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.datapack.screen.DatapackEditScreen;
 import yesman.epicfight.client.gui.datapack.screen.MessageScreen;

--- a/src/main/java/yesman/epicfight/client/online/EpicFightServerConnectionHelper.java
+++ b/src/main/java/yesman/epicfight/client/online/EpicFightServerConnectionHelper.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.api.client.online;
+package yesman.epicfight.client.online;
 
 import net.minecraft.Util;
 import net.neoforged.api.distmarker.Dist;

--- a/src/main/java/yesman/epicfight/client/online/EpicFightServerConnectionHelper.java
+++ b/src/main/java/yesman/epicfight/client/online/EpicFightServerConnectionHelper.java
@@ -1,8 +1,6 @@
 package yesman.epicfight.client.online;
 
 import net.minecraft.Util;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.main.EpicFightMod;
@@ -17,7 +15,6 @@ import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.function.BiConsumer;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightServerConnectionHelper {
 	public static HttpClient HTTP_CLIENT;
 	private static final String LIB_FILE = "ServerCommunicationHelper";

--- a/src/main/java/yesman/epicfight/client/online/EpicSkins.java
+++ b/src/main/java/yesman/epicfight/client/online/EpicSkins.java
@@ -13,8 +13,6 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.item.Items;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.model.SoftBodyTranslatable;
 import yesman.epicfight.api.client.physics.cloth.ClothColliderPresets;
@@ -33,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Supplier;
 
-@OnlyIn(Dist.CLIENT)
 public record EpicSkins(Supplier<ResourceLocation> capeTexture, float r, float g, float b) {
 	public static void initEpicSkins(AbstractClientPlayerPatch<?> playerpatch) {
 		if (EpicFightServerConnectionHelper.supported() && ClientConfig.enableCosmetics) {
@@ -137,8 +134,7 @@ public record EpicSkins(Supplier<ResourceLocation> capeTexture, float r, float g
 		
 		playerpatch.setEpicSkinsInformation(new EpicSkins(() -> playerpatch.getOriginal().getSkin().capeTexture(), 1.0F, 1.0F, 1.0F));
 	}
-	
-	@OnlyIn(Dist.CLIENT)
+
 	public record Cosmetic(int seq, Slot slot, int intParam1, boolean boolParam1, boolean useIntParam1, boolean useBoolParam1, String fileLocation, ResourceLocation textureLocation) {
 		/**
 		 * intParam1 is normally used to color
@@ -157,8 +153,7 @@ public record EpicSkins(Supplier<ResourceLocation> capeTexture, float r, float g
 			);
 		}
 	}
-	
-	@OnlyIn(Dist.CLIENT)
+
 	public enum Slot {
 		CAPE
 	}

--- a/src/main/java/yesman/epicfight/client/online/EpicSkins.java
+++ b/src/main/java/yesman/epicfight/client/online/EpicSkins.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.api.client.online;
+package yesman.epicfight.client.online;
 
 import com.google.common.collect.Maps;
 import com.google.gson.JsonArray;

--- a/src/main/java/yesman/epicfight/client/online/RemoteAssets.java
+++ b/src/main/java/yesman/epicfight/client/online/RemoteAssets.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.api.client.online;
+package yesman.epicfight.client.online;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
@@ -11,7 +11,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Mesh;
-import yesman.epicfight.api.client.online.texture.RemoteTexture;
+import yesman.epicfight.client.online.texture.RemoteTexture;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.main.EpicFightSharedConstants;
 

--- a/src/main/java/yesman/epicfight/client/online/RemoteAssets.java
+++ b/src/main/java/yesman/epicfight/client/online/RemoteAssets.java
@@ -7,8 +7,6 @@ import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.client.online.texture.RemoteTexture;
@@ -21,7 +19,6 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-@OnlyIn(Dist.CLIENT)
 public class RemoteAssets {
 	private static final RemoteAssets INSTANCE = new RemoteAssets();
 	private static final TextureManager TEXTURE_MANAGER = Minecraft.getInstance().getTextureManager();
@@ -61,7 +58,7 @@ public class RemoteAssets {
 				}
 			});
 		});
-		
+
 		return this.cachedMeshes.get(seq);
 	}
 	
@@ -76,9 +73,8 @@ public class RemoteAssets {
 		
 		return textureLocation;
 	}
-	
-	@OnlyIn(Dist.CLIENT)
-	private class RemoteMeshAccessor implements AssetAccessor<Mesh> {
+
+    private static class RemoteMeshAccessor implements AssetAccessor<Mesh> {
 		private Queue<Consumer<Mesh>> callback = Queues.newArrayDeque();
 		private Mesh mesh;
 		

--- a/src/main/java/yesman/epicfight/client/online/texture/RemoteTexture.java
+++ b/src/main/java/yesman/epicfight/client/online/texture/RemoteTexture.java
@@ -1,29 +1,23 @@
 package yesman.epicfight.client.online.texture;
 
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.platform.TextureUtil;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.logging.LogUtils;
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.SimpleTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
-import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-
-import com.mojang.blaze3d.platform.NativeImage;
-import com.mojang.blaze3d.platform.TextureUtil;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.logging.LogUtils;
-
-import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.texture.SimpleTexture;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
-
-@OnlyIn(Dist.CLIENT)
 public class RemoteTexture extends SimpleTexture {
 	private static final Logger LOGGER = LogUtils.getLogger();
 	@Nullable

--- a/src/main/java/yesman/epicfight/client/online/texture/RemoteTexture.java
+++ b/src/main/java/yesman/epicfight/client/online/texture/RemoteTexture.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.api.client.online.texture;
+package yesman.epicfight.client.online.texture;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedCapeLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedCapeLayer.java
@@ -25,7 +25,7 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh;
-import yesman.epicfight.api.client.online.EpicSkins;
+import yesman.epicfight.client.online.EpicSkins;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator.ClothObject;
 import yesman.epicfight.api.utils.math.MathUtils;

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/AbstractClientPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/AbstractClientPlayerPatch.java
@@ -27,7 +27,7 @@ import yesman.epicfight.api.client.animation.ClientAnimator;
 import yesman.epicfight.api.client.animation.Layer;
 import yesman.epicfight.api.client.neoevent.RenderEpicFightPlayerEvent;
 import yesman.epicfight.api.client.neoevent.UpdatePlayerMotionEvent;
-import yesman.epicfight.api.client.online.EpicSkins;
+import yesman.epicfight.client.online.EpicSkins;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulatable;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator;
 import yesman.epicfight.api.neoevent.playerpatch.PlayerPatchEvent;

--- a/src/main/java/yesman/epicfight/client/world/util/FakeLevel.java
+++ b/src/main/java/yesman/epicfight/client/world/util/FakeLevel.java
@@ -1,4 +1,4 @@
-package yesman.epicfight.api.utils;
+package yesman.epicfight.client.world.util;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/yesman/epicfight/client/world/util/FakeLevel.java
+++ b/src/main/java/yesman/epicfight/client/world/util/FakeLevel.java
@@ -30,8 +30,6 @@ import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.main.EpicFightMod;
@@ -42,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-@OnlyIn(Dist.CLIENT)
 public class FakeLevel extends ClientLevel {
 	private static FakeLevel instance;
 	private static final Map<GameProfile, FakeClientPlayer> FAKE_PLAYERS = new HashMap<> ();
@@ -196,14 +193,12 @@ public class FakeLevel extends ClientLevel {
 		return false;
 	}
 
-    @OnlyIn(Dist.CLIENT)
     public static class FakeClientPlayer extends AbstractClientPlayer {
         public FakeClientPlayer(FakeLevel fakeLevel, GameProfile gameProfile) {
             super(fakeLevel, gameProfile);
         }
     }
 
-	@OnlyIn(Dist.CLIENT)
 	private static class FakeClientPacketListener extends ClientPacketListener {
 		private static final Connection DUMMY_CONNECTION = new Connection(PacketFlow.CLIENTBOUND);
 		

--- a/src/main/java/yesman/epicfight/config/ClientConfig.java
+++ b/src/main/java/yesman/epicfight/config/ClientConfig.java
@@ -16,7 +16,7 @@ import net.neoforged.neoforge.common.ModConfigSpec.*;
 import org.apache.commons.compress.utils.Lists;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import org.jetbrains.annotations.NotNull;
-import yesman.epicfight.api.client.online.EpicFightServerConnectionHelper;
+import yesman.epicfight.client.online.EpicFightServerConnectionHelper;
 import yesman.epicfight.api.utils.CirculatableEnum;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.Vec2i;

--- a/src/main/java/yesman/epicfight/events/WorldEvents.java
+++ b/src/main/java/yesman/epicfight/events/WorldEvents.java
@@ -11,7 +11,7 @@ import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.data.reloader.ItemCapabilityReloadListener;
 import yesman.epicfight.api.data.reloader.MobPatchReloadListener;
 import yesman.epicfight.api.data.reloader.SkillReloadListener;
-import yesman.epicfight.api.utils.FakeLevel;
+import yesman.epicfight.client.world.util.FakeLevel;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.network.EpicFightNetworkManager;
 import yesman.epicfight.network.EpicFightNetworkManager.PayloadBundleBuilder;

--- a/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
+++ b/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
@@ -6,7 +6,7 @@ import net.neoforged.bus.api.IEventBus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import yesman.epicfight.api.utils.FakeLevel;
+import yesman.epicfight.client.world.util.FakeLevel;
 
 @Mixin(value = ClientLevel.class)
 public abstract class MixinClientLevel {


### PR DESCRIPTION
Part-fi_x #2211 (FYI: intentionally made a typo to prevent GitHub from automatically closing the issue).

This is a step closer to stabilizing the public API by moving internal APIs outside of `yesman.epicfight.api`.

This does not mean addons can't access them anymore, it means that these are not maintained for backward compatibility, and breaking changes will occur in future versions.

We should be cautious about which APIs to add to the `api` package. Typically, we want useful yet Epic Fight-specific APIs and features, such as animations, skills, patching entities, and combat.

We shouldn't maintain generic Minecraft APIs such as `FakeLevel` or `LevelUtils` for addons, as these are not unique Epic Fight APIs, and making them public APIs means we will have to maintain them for backward compatibility.

I have also moved `yesman.epicfight.api.client.online` -> `yesman.epicfight.client.online`, since addons never need to change Epic Fight Patreon cosmetics, and there are no supported APIs.

This makes the PR #2260 slightly more useful. We should continue with these changes.