### PR TITLE
[1.20.1] Fixed Lock-on stuck

### DIFF
--- a/src/main/java/yesman/epicfight/api/animation/TransformSheet.java
+++ b/src/main/java/yesman/epicfight/api/animation/TransformSheet.java
@@ -167,7 +167,7 @@ public class TransformSheet {
 		Keyframe startKeyframe = keyframes[0];
 		Keyframe endKeyframe = keyframes[keyframes.length - 1];
 		float pitchDeg = (float) Math.toDegrees(Mth.atan2(modifiedStartToEnd.y - startToEnd.y, modifiedStartToEnd.length()));
-		float yawDeg = (float) MathUtils.getAngleBetween(modifiedStartToEnd.copy().multiply(1.0F, 0.0F, 1.0F).normalize(), startToEnd.copy().multiply(1.0F, 0.0F, 1.0F).normalize());
+		float yawDeg = (float) MathUtils.getAngleBetween(modifiedStartToEnd.copy().multiply(1.0F, 0.0F, 1.0F), startToEnd.copy().multiply(1.0F, 0.0F, 1.0F));
 		
 		for (Keyframe kf : keyframes) {
 			float lerp = (kf.time() - startKeyframe.time()) / (endKeyframe.time() - startKeyframe.time());

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -326,11 +326,8 @@ public final class EpicFightCameraAPI {
 		Vec3 cameraLocation = this.minecraft.gameRenderer.getMainCamera().getPosition();
 		
 		// Create a compact projection matrix without view, hurt bob
-		PoseStack posestack = new PoseStack();
-		double fov = this.minecraft.gameRenderer.getFov(this.minecraft.gameRenderer.getMainCamera(), 1.0F, true);
+		Matrix4f compactProjection = this.getCompactProjectionMatrix();
 		double lockOnRange = this.getFocusingEntityPickRange();
-		posestack.mulPoseMatrix(this.minecraft.gameRenderer.getProjectionMatrix(fov));
-		Matrix4f compactProjection = posestack.last().pose();
 		
 		// Select the nearest target on the screen from the given direction
 		Optional<Pair<LivingEntity, Float>> next = entitiesInLevel.stream()
@@ -353,6 +350,17 @@ public final class EpicFightCameraAPI {
 		});
 		
 		return next.isPresent();
+	}
+	
+	/**
+	 * Creates a compact projection matrix without view, hurt bob
+	 * @return
+	 */
+	private Matrix4f getCompactProjectionMatrix() {
+		PoseStack posestack = new PoseStack();
+		double fov = this.minecraft.gameRenderer.getFov(this.minecraft.gameRenderer.getMainCamera(), 1.0F, true);
+		posestack.mulPoseMatrix(this.minecraft.gameRenderer.getProjectionMatrix(fov));
+		return posestack.last().pose();
 	}
 	
 	/**
@@ -574,8 +582,9 @@ public final class EpicFightCameraAPI {
 		
 		// Calculate camera based ray trace result
 		double pickRange = this.minecraft.options.renderDistance().get() * 16.0D;
-		Vec3 cameraPos = this.minecraft.gameRenderer.getMainCamera().getPosition();
-		Vec3 lookVec = new Vec3(this.minecraft.gameRenderer.getMainCamera().getLookVector());
+		Camera mainCamera = this.minecraft.gameRenderer.getMainCamera();
+		Vec3 cameraPos = mainCamera.getPosition();
+		Vec3 lookVec = new Vec3(mainCamera.getLookVector());
 		Vec3 rayEed = cameraPos.add(lookVec.x * pickRange, lookVec.y * pickRange, lookVec.z * pickRange);
 		LocalPlayer localPlayer = this.minecraft.player;
 		this.crosshairHitResult = localPlayer.level().clip(new ClipContext(cameraPos, rayEed, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, localPlayer));
@@ -614,7 +623,7 @@ public final class EpicFightCameraAPI {
 		boolean tpsMode = this.isTPSMode();
 		
 		if (tpsMode) {
-			Vec3 view = new Vec3(this.minecraft.gameRenderer.getMainCamera().getLookVector());
+			Vec3 view = new Vec3(mainCamera.getLookVector());
 			
 			// If the hit result is in front of the player based on to camera, set missed.
 			if (view.dot(this.crosshairHitResult.getLocation().subtract(localPlayer.getEyePosition()).normalize()) < -0.1D) {
@@ -659,8 +668,8 @@ public final class EpicFightCameraAPI {
 					!MathUtils.canBeSeen(this.focusingEntity, this.minecraft.player, maxLockOnDistance) ||
 					// Angle between look vec and to target too wide
 					!this.lockingOnTarget &&
-						this.focusingEntity.getBoundingBox().getCenter().subtract(this.minecraft.gameRenderer.getMainCamera().getPosition()).normalize()
-							.dot(new Vec3(this.minecraft.gameRenderer.getMainCamera().getLookVector())) < Mth.clampedLerp(0.0D, 0.99D, Mth.inverseLerp(Mth.clamp(distance, 1.0D, 3.5D), 1.0D, 3.5D))
+						this.focusingEntity.getBoundingBox().getCenter().subtract(mainCamera.getPosition()).normalize()
+							.dot(new Vec3(mainCamera.getLookVector())) < Mth.clampedLerp(0.0D, 0.99D, Mth.inverseLerp(Mth.clamp(distance, 1.0D, 3.5D), 1.0D, 3.5D))
 				) {
 					if (this.lockingOnTarget) {
 						this.setLockOn(false);
@@ -685,9 +694,7 @@ public final class EpicFightCameraAPI {
 			this.cameraXRot = this.minecraft.player.getXRot();
 			this.cameraYRot = this.minecraft.player.getYRot();
 		} else {
-			/**
-			 * We do assume playerpatch is never null, but check the null for the crash resistancy
-			 */
+			// We do assume playerpatch is never null, but check the null for the crash resistancy
 			@Nullable
 			LocalPlayerPatch playerpatch = EpicFightCapabilities.getEntityPatch(localPlayer, LocalPlayerPatch.class);
 			float clamp = 30.0F;
@@ -696,9 +703,21 @@ public final class EpicFightCameraAPI {
 			
 			// Handle camera lock-on
 			if (this.focusingEntity != null && this.lockingOnTarget && !this.isLerpingFpv() && !InputManager.isActionActive(EpicFightInputAction.LOCK_ON_SHIFT_FREELY)) {
-				Vec3 povPos = tpsMode ? cameraPos : localPlayer.getEyePosition();
-				Vec3 targetPos = tpsMode ? this.focusingEntity.getBoundingBox().getCenter() : this.focusingEntity.getEyePosition();
-				Vec3 toTarget = targetPos.subtract(povPos);
+				Vec3 lockEnd;
+				Vec3 lockStart;
+				
+				if (tpsMode) {
+					double toTargetDistanceSqr = localPlayer.position().distanceToSqr(this.focusingEntity.position());
+					
+					// Lerp the start and end location of the camera arm for lock-on based on the distance between the player and the focusing entity
+					lockStart = MathUtils.lerpVector(localPlayer.getEyePosition(), cameraPos, (float)Mth.clampedMap(toTargetDistanceSqr, 1.0F, 18.0F, 0.2F, 1.0F));
+					lockEnd = MathUtils.lerpVector(this.focusingEntity.getEyePosition(), this.focusingEntity.getBoundingBox().getCenter(), (float)Mth.clampedMap(toTargetDistanceSqr, 0.0F, 18.0F, 0.5F, 1.0F));
+				} else {
+					lockStart = localPlayer.getEyePosition();
+					lockEnd = this.focusingEntity.getEyePosition();
+				}
+				
+				Vec3 toTarget = lockEnd.subtract(lockStart);
 				float xRot = (float)MathUtils.getXRotOfVector(toTarget);
 				float yRot = (float)MathUtils.getYRotOfVector(toTarget);
 				
@@ -708,15 +727,8 @@ public final class EpicFightCameraAPI {
 				
 				float xLerp = Mth.clamp(Mth.wrapDegrees(xRot - this.cameraXRot) * 0.4F, -clamp, clamp);
 				float yLerp = Mth.clamp(Mth.wrapDegrees(yRot - this.cameraYRot) * 0.4F, -clamp, clamp);
-				Vec3 playerToTarget = targetPos.subtract(localPlayer.getEyePosition());
-				
-				// Limit angle difference in tps mode
-				if (tpsMode) {
-					double angle = MathUtils.getAngleBetween(playerToTarget, toTarget);
-					if (angle < 30.0D) this.setCameraRotations(this.cameraXRot + xLerp, this.cameraYRot + yLerp, false);
-				} else {
-					this.setCameraRotations(this.cameraXRot + xLerp, this.cameraYRot + yLerp, false);
-				}
+				Vec3 playerToTarget = lockEnd.subtract(localPlayer.getEyePosition());
+				this.setCameraRotations(this.cameraXRot + xLerp, this.cameraYRot + yLerp, false);
 				
 				desiredXRot = (float)MathUtils.getXRotOfVector(playerToTarget);
 				desiredYRot = (float)MathUtils.getYRotOfVector(playerToTarget);

--- a/src/main/java/yesman/epicfight/api/utils/math/MathUtils.java
+++ b/src/main/java/yesman/epicfight/api/utils/math/MathUtils.java
@@ -310,12 +310,18 @@ public class MathUtils {
 	}
 	
 	public static double getAngleBetween(Vec3f a, Vec3f b) {
-		double cos = (a.x * b.x + a.y * b.y + a.z * b.z);
+		Vec3f normA = Vec3f.normalize(a, null);
+		Vec3f normB = Vec3f.normalize(b, null);
+		
+		double cos = (normA.x * normB.x + normA.y * normB.y + normA.z * normB.z);
 		return Math.toDegrees(Math.acos(cos));
 	}
 	
 	public static double getAngleBetween(Vec3 a, Vec3 b) {
-		double cos = (a.x * b.x + a.y * b.y + a.z * b.z);
+		Vec3 normA = a.normalize();
+		Vec3 normB = b.normalize();
+		
+		double cos = (normA.x * normB.x + normA.y * normB.y + normA.z * normB.z);
 		return Math.toDegrees(Math.safeAcos(cos));
 	}
 	


### PR DESCRIPTION
While testing PvP with camera features on a dedicated server, I and @EchoEllet found a lock-on malfunction when a focusing entity is too close.

**Note the player is trying to move left**

https://github.com/user-attachments/assets/67a5c364-b04d-410c-8619-1a7261b4eba5

This is because I tried to prevent the infinite turning issue when the crosshair is never reachable to the focusing target.

**Infinite Looping issue**

https://github.com/user-attachments/assets/e4b83737-231e-4260-9339-aa4bcc34756a

So we had to find an alternative way, we searched how Better Lock On + Shoulder Surfing Reloaded work together and found the basis location of lock-on is the player's eye position, not a camera position.

**BUT** I thought this solution is a bit out of the innate of Lock-on functionality, so I decided to mix these cases.

In **EpicFightCameraAPI**, line 711
```java
double toTargetDistanceSqr = localPlayer.position().distanceToSqr(this.focusingEntity.position());
					
// Lerp the start and end location of the camera arm for lock-on based on the distance between the player and the focusing entity
lockStart = MathUtils.lerpVector(localPlayer.getEyePosition(), cameraPos, (float)Mth.clampedMap(toTargetDistanceSqr, 1.0F, 18.0F, 0.2F, 1.0F));
lockEnd = MathUtils.lerpVector(this.focusingEntity.getEyePosition(), this.focusingEntity.getBoundingBox().getCenter(), (float)Mth.clampedMap(toTargetDistanceSqr, 0.0F, 18.0F, 0.5F, 1.0F));
```

This code **interpolates** the beginning position of lock-on from the player's eye to the camera. In other words, the lock-on will be based on the camera location when it's far enough to locate the focusing entity in the center of the screen, while it will be based on player's eye location when the distance is too close to prevent the **infinite turning** I mentioned above.


https://github.com/user-attachments/assets/53bc89b6-7d78-40ef-99e7-ad414083048e

In this video, you can see the player is moving on the left side circling around the focusing entity unlike the first video.