### PR TITLE
[1.20.1] Use Minecraft Safe resources Gradle plugin to generate LangKeys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import dev.echoellet.minecraft_safe_resources.GenerateJsonKeysTask
+import dev.echoellet.minecraft_safe_resources.OutputLanguage
+
 plugins {
     id 'eclipse'
     id 'idea'
@@ -6,6 +9,7 @@ plugins {
 	id 'org.spongepowered.mixin' version '0.7.+'
 	id 'org.parchmentmc.librarian.forgegradle' version '1.+'
 	id "me.modmuss50.mod-publish-plugin" version "1.1.0"
+    id("dev.echoellet.minecraft-safe-resources") version("0.0.1")
 }
 
 version = mod_version
@@ -297,3 +301,24 @@ publishMods {
 	    }
     }
 }
+
+def modAssetsDirPath = "src/main/resources/assets/$mod_id"
+
+def generateLangKeys = tasks.register('generateLangKeys', GenerateJsonKeysTask) {
+    def enUsResourcePath = "$modAssetsDirPath/lang/en_us.json"
+
+    inputResourceFile.set(project.file(enUsResourcePath))
+    outputClassName.set("LangKeys")
+    outputLanguage.set(OutputLanguage.JAVA)
+    outputClassDescription.set("""
+    A generated object that represents the keys in `${enUsResourcePath}` resource file,
+    to avoid hardcoding the keys across the codebase, which is error-prone, inefficient, and less type-safe.
+
+    **Note:** Breaking changes may occur. This approach is preferred over hardcoding keys, which can lead to runtime errors or crashes.
+""".stripIndent().trim())
+    outputPackage.set("${mod_group_id}.generated")
+    keyNamespaceToStrip.set(mod_id)
+}
+
+java.sourceSets.main.java.srcDir(generateLangKeys.map { it.outputs.files.singleFile })
+tasks.compileJava.dependsOn(generateLangKeys)

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,9 @@ pluginManagement {
             name = 'MinecraftForge'
             url = 'https://maven.minecraftforge.net/'
         }
+        // Temporary: required because this plugin is not yet published on the Gradle Plugin Portal
+        //  https://github.com/EchoEllet/minecraft-safe-resources-gradle/issues/1
+        maven { url = uri("https://echoellet.github.io/maven-repo/") }
     }
 }
 

--- a/src/main/java/yesman/epicfight/client/input/EpicFightInputCategories.java
+++ b/src/main/java/yesman/epicfight/client/input/EpicFightInputCategories.java
@@ -1,15 +1,15 @@
 package yesman.epicfight.client.input;
 
 import org.jetbrains.annotations.ApiStatus;
-import yesman.epicfight.main.EpicFightMod;
+import yesman.epicfight.generated.LangKeys;
 
 @ApiStatus.Internal
 public final class EpicFightInputCategories {
     private EpicFightInputCategories() {
     }
 
-    public static final String COMBAT = EpicFightMod.format("key.%s.combat");
-    public static final String GUI = EpicFightMod.format("key.%s.gui");
-    public static final String SYSTEM = EpicFightMod.format("key.%s.system");
-    public static final String CAMERA = EpicFightMod.format("key.%s.camera");
+    public static final String COMBAT = LangKeys.KEY_COMBAT;
+    public static final String GUI = LangKeys.KEY_GUI;
+    public static final String SYSTEM = LangKeys.KEY_SYSTEM;
+    public static final String CAMERA = LangKeys.KEY_CAMERA;
 }

--- a/src/main/java/yesman/epicfight/client/input/EpicFightKeyMappings.java
+++ b/src/main/java/yesman/epicfight/client/input/EpicFightKeyMappings.java
@@ -7,6 +7,7 @@ import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import yesman.epicfight.generated.LangKeys;
 import yesman.epicfight.main.EpicFightMod;
 
 @Mod.EventBusSubscriber(modid = EpicFightMod.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -15,7 +16,7 @@ public class EpicFightKeyMappings {
     // GUI key-mappings
     public static final KeyMapping WEAPON_INNATE_SKILL_TOOLTIP =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.show_tooltip"),
+                    LangKeys.KEY_SHOW_TOOLTIP,
                     KeyConflictContext.GUI,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_LSHIFT,
@@ -24,7 +25,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping SKILL_EDIT =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.skill_gui"),
+                    LangKeys.KEY_SKILL_GUI,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_K,
@@ -33,7 +34,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping OPEN_CONFIG_SCREEN =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.config"),
+                    LangKeys.KEY_CONFIG,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     -1,
@@ -43,14 +44,14 @@ public class EpicFightKeyMappings {
     // In-game keymappings
     public static final KeyMapping DODGE =
             new CombatKeyMapping(
-                    EpicFightMod.format("key.%s.dodge"),
+                    LangKeys.KEY_DODGE,
                     InputConstants.KEY_LALT,
                     EpicFightInputCategories.COMBAT
             );
 
     public static final KeyMapping GUARD =
             new CombatKeyMapping(
-                    EpicFightMod.format("key.%s.guard"),
+                    LangKeys.KEY_GUARD,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_RIGHT,
                     EpicFightInputCategories.COMBAT
@@ -58,7 +59,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping ATTACK =
             new CombatKeyMapping(
-                    EpicFightMod.format("key.%s.attack"),
+                    LangKeys.KEY_ATTACK,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_LEFT,
                     EpicFightInputCategories.COMBAT
@@ -66,7 +67,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping WEAPON_INNATE_SKILL =
             new CombatKeyMapping(
-                    EpicFightMod.format("key.%s.weapon_innate_skill"),
+                    LangKeys.KEY_WEAPON_INNATE_SKILL,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_LEFT,
                     EpicFightInputCategories.COMBAT
@@ -74,14 +75,14 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping MOVER_SKILL =
             new CombatKeyMapping(
-                    EpicFightMod.format("key.%s.mover_skill"),
+                    LangKeys.KEY_MOVER_SKILL,
                     InputConstants.KEY_SPACE,
                     EpicFightInputCategories.COMBAT
             );
 
     public static final KeyMapping SWITCH_MODE =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.switch_mode"),
+                    LangKeys.KEY_SWITCH_MODE,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_R,
@@ -90,7 +91,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping LOCK_ON =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.lock_on"),
+                    LangKeys.KEY_LOCK_ON,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_G,
@@ -99,7 +100,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping LOCK_ON_SHIFT_LEFT =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.lock_on_shift_left"),
+                    LangKeys.KEY_LOCK_ON_SHIFT_LEFT,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_LEFT,
@@ -108,7 +109,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping LOCK_ON_SHIFT_RIGHT =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.lock_on_shift_right"),
+                    LangKeys.KEY_LOCK_ON_SHIFT_RIGHT,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_RIGHT,
@@ -117,7 +118,7 @@ public class EpicFightKeyMappings {
 
     public static final KeyMapping LOCK_ON_SHIFT_FREELY =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.lock_on_shift_freely"),
+                    LangKeys.KEY_LOCK_ON_SHIFT_FREELY,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_RIGHT,
@@ -127,7 +128,7 @@ public class EpicFightKeyMappings {
     // Systemical key mappings especially for debugging
     public static final KeyMapping SWITCH_VANILLA_MODEL_DEBUGGING =
             new KeyMapping(
-                    EpicFightMod.format("key.%s.switch_vanilla_model_debug"),
+                    LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     -1,

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -32,6 +32,7 @@ import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.client.input.EpicFightInputCategories;
 import yesman.epicfight.compat.controlify.screenop.SkillBookScreenProcessor;
 import yesman.epicfight.compat.controlify.screenop.SkillEditScreenProcessor;
+import yesman.epicfight.generated.LangKeys;
 import yesman.epicfight.main.EpicFightMod;
 
 import java.util.Objects;
@@ -96,30 +97,27 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
         /// @return a [TranslationKeys] instance containing the translation keys for the name and description
         private static @NotNull TranslationKeys fromAction(@NotNull EpicFightInputAction action) {
             return switch (action) {
-                case ATTACK -> new TranslationKeys("key.epicfight.attack", "key.epicfight.attack.description");
-                case DODGE -> new TranslationKeys("key.epicfight.dodge", "key.epicfight.dodge.description");
-                case GUARD -> new TranslationKeys("key.epicfight.guard", "key.epicfight.guard.description");
-                case LOCK_ON -> new TranslationKeys("key.epicfight.lock_on", "key.epicfight.lock_on.description");
+                case ATTACK -> new TranslationKeys(LangKeys.KEY_ATTACK, LangKeys.KEY_ATTACK_DESCRIPTION);
+                case DODGE -> new TranslationKeys(LangKeys.KEY_DODGE, LangKeys.KEY_DODGE_DESCRIPTION);
+                case GUARD -> new TranslationKeys(LangKeys.KEY_GUARD, LangKeys.KEY_GUARD_DESCRIPTION);
+                case LOCK_ON -> new TranslationKeys(LangKeys.KEY_LOCK_ON, LangKeys.KEY_LOCK_ON_DESCRIPTION);
                 case LOCK_ON_SHIFT_LEFT ->
-                        new TranslationKeys("key.epicfight.lock_on_shift_left", "key.epicfight.lock_on_shift_left.description");
+                        new TranslationKeys(LangKeys.KEY_LOCK_ON_SHIFT_LEFT, LangKeys.KEY_LOCK_ON_SHIFT_LEFT_DESCRIPTION);
                 case LOCK_ON_SHIFT_RIGHT ->
-                        new TranslationKeys("key.epicfight.lock_on_shift_right", "key.epicfight.lock_on_shift_right.description");
+                        new TranslationKeys(LangKeys.KEY_LOCK_ON_SHIFT_RIGHT, LangKeys.KEY_LOCK_ON_SHIFT_RIGHT_DESCRIPTION);
                 case LOCK_ON_SHIFT_FREELY ->
-                        new TranslationKeys("key.epicfight.lock_on_shift_freely", "key.epicfight.lock_on_shift_freely.description");
-                case SWITCH_MODE ->
-                        new TranslationKeys("key.epicfight.switch_mode", "key.epicfight.switch_mode.description");
+                        new TranslationKeys(LangKeys.KEY_LOCK_ON_SHIFT_FREELY, LangKeys.KEY_LOCK_ON_SHIFT_FREELY_DESCRIPTION);
+                case SWITCH_MODE -> new TranslationKeys(LangKeys.KEY_SWITCH_MODE, LangKeys.KEY_SWITCH_MODE_DESCRIPTION);
                 case WEAPON_INNATE_SKILL ->
-                        new TranslationKeys("key.epicfight.weapon_innate_skill", "key.epicfight.weapon_innate_skill.description");
+                        new TranslationKeys(LangKeys.KEY_WEAPON_INNATE_SKILL, LangKeys.KEY_WEAPON_INNATE_SKILL_DESCRIPTION);
                 case WEAPON_INNATE_SKILL_TOOLTIP ->
-                        new TranslationKeys("key.epicfight.show_tooltip", "key.epicfight.show_tooltip.description");
+                        new TranslationKeys(LangKeys.KEY_SHOW_TOOLTIP, LangKeys.KEY_SHOW_TOOLTIP_DESCRIPTION);
                 case OPEN_SKILL_SCREEN ->
-                        new TranslationKeys("key.epicfight.skill_gui", "key.epicfight.skill_gui.description");
-                case OPEN_CONFIG_SCREEN ->
-                        new TranslationKeys("key.epicfight.config", "key.epicfight.config.description");
+                        new TranslationKeys(LangKeys.KEY_SKILL_GUI, LangKeys.KEY_SKILL_GUI_DESCRIPTION);
+                case OPEN_CONFIG_SCREEN -> new TranslationKeys(LangKeys.KEY_CONFIG, LangKeys.KEY_CONFIG_DESCRIPTION);
                 case SWITCH_VANILLA_MODEL_DEBUGGING ->
-                        new TranslationKeys("key.epicfight.switch_vanilla_model_debug", "key.epicfight.switch_vanilla_model_debug.description");
-                case MOBILITY ->
-                        new TranslationKeys("key.epicfight.mover_skill", "key.epicfight.mover_skill.description");
+                        new TranslationKeys(LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG, LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG_DESCRIPTION);
+                case MOBILITY -> new TranslationKeys(LangKeys.KEY_MOVER_SKILL, LangKeys.KEY_MOVER_SKILL_DESCRIPTION);
             };
         }
     }


### PR DESCRIPTION
Backports #2270 and #2235 (not cherry-pick, fully manual) to remove some of the gaps between `1.21.1` and `1.20.1`, for consistency reasons, so addons can use `LangKeys` in both versions, and there will be fewer future git conflicts when backporting.

