### PR TITLE
Improve compatibility with Shoulder Surfing Reloaded

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.api.client.camera;
 
+import com.github.exopandora.shouldersurfing.api.client.IShoulderSurfing;
+import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.Camera;
@@ -20,7 +22,11 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.*;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.ViewportEvent;
 import net.neoforged.neoforge.entity.PartEntity;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -862,8 +868,21 @@ public final class EpicFightCameraAPI {
             return true;
         } else if (this.lockingOnTarget && this.focusingEntity != null) {
             if (this.minecraft.options.getCameraType() == CameraType.THIRD_PERSON_BACK) {
+				Vec3 playerPosition = this.minecraft.player.position();
+				Vec3 targetPosition = this.focusingEntity.position();
+				Vec3 toTarget = targetPosition.subtract(playerPosition);
+				this.cameraYRot = (float) MathUtils.getYRotOfVector(toTarget);
                 float xRot = Mth.rotLerp(partialTick, this.cameraXRotO, this.cameraXRot);
                 float yRot = Mth.rotLerp(partialTick, this.cameraYRotO, this.cameraYRot);
+				camera.getEntity().setXRot(xRot);
+				camera.getEntity().setYRot(yRot);
+
+				IShoulderSurfing instance = ShoulderSurfing.getInstance();
+				if (instance.isShoulderSurfing()) {
+					instance.getCamera().setXRot(xRot);
+					instance.getCamera().setYRot(yRot);
+					return false;
+				}
 
                 camera.setRotation(yRot, xRot);
                 camera.setPosition(

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -288,8 +288,15 @@ public final class EpicFightCameraAPI {
                 if (!flag) {
                     this.minecraft.player.setXRot(this.cameraXRot);
                 } else {
-                    this.setCameraRotations(this.minecraft.player.getXRot(), this.minecraft.player.getYRot(), true);
-                }
+					float xRot = this.minecraft.player.getXRot();
+					float yRot = this.minecraft.player.getYRot();
+					IShoulderSurfing instance = ShoulderSurfing.getInstance();
+					if (instance.isShoulderSurfing()) {
+						xRot = instance.getCamera().getXRot();
+						yRot = instance.getCamera().getYRot();
+					}
+					this.setCameraRotations(xRot, yRot, true);
+				}
             }
         }
     }


### PR DESCRIPTION
This PR aims to improve compatibility with Shoulder Surfing Reloaded (SSR) and serves more of a demo purpose. The first two commits demonstrate what is necessary to get lock-on working again (although the crosshair alignment could be better).

What still needs to be done:
1. The code should be moved to a different location if possible, and proper runtime checks should be added, whether SSR is actually installed.
2. The lock-on raytrace should be adjusted to use the object picker provided by the SSR API.

Related to #2258
