### PR TITLE
[1.21.1] Fixed duplicated registration of skill data keys

### DIFF
--- a/src/main/java/yesman/epicfight/server/commands/PlayerSkillCommand.java
+++ b/src/main/java/yesman/epicfight/server/commands/PlayerSkillCommand.java
@@ -1,16 +1,11 @@
 package yesman.epicfight.server.commands;
 
-import java.util.Collection;
-import java.util.Locale;
-import java.util.function.Supplier;
-
 import com.google.common.collect.ImmutableList;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -18,6 +13,8 @@ import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.network.EpicFightNetworkManager;
 import yesman.epicfight.network.server.SPClearSkills;
 import yesman.epicfight.network.server.SPRemoveSkillAndLearn;
@@ -27,6 +24,10 @@ import yesman.epicfight.skill.SkillContainer;
 import yesman.epicfight.skill.SkillSlot;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.function.Supplier;
 
 public class PlayerSkillCommand {
 	private static final SimpleCommandExceptionType ERROR_ADD_FAILED = new SimpleCommandExceptionType(Component.translatable("commands.epicfight.skill.add.failed"));
@@ -43,7 +44,7 @@ public class PlayerSkillCommand {
 					.then(Commands.literal(skillSlot.toString().toLowerCase(Locale.ROOT))
 					.then(Commands.argument("skill", SkillArgument.skill())
 					.executes((commandContext) -> {
-						return addSkill(commandContext.getSource(), EntityArgument.getPlayers(commandContext, "targets"), skillSlot, SkillArgument.getSkill(commandContext, "skill"));
+						return addSkill(commandContext.getSource(), EntityArgument.getPlayers(commandContext, "targets"), skillSlot, commandContext.getArgument("skill", Holder.class));
 					})));
 				
 				removeCommandBuilder
@@ -53,7 +54,7 @@ public class PlayerSkillCommand {
 					})
 					.then(Commands.argument("skill", SkillArgument.skill())
 					.executes((commandContext) -> {
-						return removeSkill(commandContext.getSource(), EntityArgument.getPlayers(commandContext, "targets"), skillSlot, SkillArgument.getSkill(commandContext, "skill"));
+						return removeSkill(commandContext.getSource(), EntityArgument.getPlayers(commandContext, "targets"), skillSlot, commandContext.getArgument("skill", Holder.class));
 					})));
 			}
 		}
@@ -101,7 +102,7 @@ public class PlayerSkillCommand {
 		return i;
 	}
 	
-	public static int addSkill(CommandSourceStack commandSourceStack, Collection<? extends ServerPlayer> targets, SkillSlot slot, Holder<Skill> skill) throws CommandSyntaxException {
+	public static int addSkill(CommandSourceStack commandSourceStack, Collection<? extends ServerPlayer> targets, SkillSlot slot, @NotNull Holder<Skill> skill) throws CommandSyntaxException {
 		int i = 0;
 		
 		for (ServerPlayer player : targets) {
@@ -132,40 +133,42 @@ public class PlayerSkillCommand {
 		return i;
 	}
 	
-	public static int removeSkill(CommandSourceStack commandSourceStack, Collection<? extends ServerPlayer> targets, SkillSlot slot, Holder<Skill> skill) throws CommandSyntaxException {
+	public static int removeSkill(CommandSourceStack commandSourceStack, Collection<? extends ServerPlayer> targets, SkillSlot slot, @Nullable Holder<Skill> skill) throws CommandSyntaxException {
 		int i = 0;
-		
+        Holder<Skill> removedSkill = null;
+
 		for (ServerPlayer player : targets) {
 			ServerPlayerPatch playerpatch = EpicFightCapabilities.getEntityPatch(player, ServerPlayerPatch.class);
 			
 			if (playerpatch != null) {
 				if (skill == null) {
 					SkillContainer skillContainer = playerpatch.getSkill(slot);
-					
+
 					if (skillContainer.getSkill() != null) {
+                        removedSkill = skillContainer.getSkill().holder();
 						skillContainer.setSkill(null);
-						EpicFightNetworkManager.sendToPlayer(new SPRemoveSkillAndLearn(skill, slot), player);
+						EpicFightNetworkManager.sendToPlayer(new SPRemoveSkillAndLearn(removedSkill, slot), player);
 						EpicFightNetworkManager.sendToAllPlayerTrackingThisEntity(skillContainer.createSyncPacketToRemotePlayer(), player);
 						i++;
 					}
 				} else {
-					if (playerpatch.getPlayerSkills().removeLearnedSkill(skill.value())) {
-						SkillContainer skillContainer = playerpatch.getSkill(slot);
-						
-						if (skillContainer.getSkill() == skill) {
-							skillContainer.setSkill(null);
-							EpicFightNetworkManager.sendToPlayer(new SPRemoveSkillAndLearn(skill, slot), player);
-							EpicFightNetworkManager.sendToAllPlayerTrackingThisEntity(skillContainer.createSyncPacketToRemotePlayer(), player);
-							i++;
-						}
-					}
+                    SkillContainer skillContainer = playerpatch.getSkill(slot);
+
+                    if (skillContainer.getSkill().equals(skill.value())) {
+                        playerpatch.getPlayerSkills().removeLearnedSkill(skill.value());
+                        removedSkill = skill;
+                        skillContainer.setSkill(null);
+                        EpicFightNetworkManager.sendToPlayer(new SPRemoveSkillAndLearn(skill, slot), player);
+                        EpicFightNetworkManager.sendToAllPlayerTrackingThisEntity(skillContainer.createSyncPacketToRemotePlayer(), player);
+                        i++;
+                    }
 				}
 			}
 		}
 		
 		if (i > 0) {
 			if (i == 1) {
-				commandSourceStack.sendSuccess(wrap(Component.translatable("commands.epicfight.skill.remove.success.single", skill.getRegisteredName(), targets.iterator().next().getDisplayName())), true);
+				commandSourceStack.sendSuccess(wrap(Component.translatable("commands.epicfight.skill.remove.success.single", removedSkill.value().getTranslationKey(), targets.iterator().next().getDisplayName())), true);
 			} else {
 				commandSourceStack.sendSuccess(wrap(Component.translatable("commands.epicfight.skill.remove.success.multiple", skill.getRegisteredName(), i)), true);
 			}

--- a/src/main/java/yesman/epicfight/server/commands/arguments/SkillArgument.java
+++ b/src/main/java/yesman/epicfight/server/commands/arguments/SkillArgument.java
@@ -1,10 +1,5 @@
 package yesman.epicfight.server.commands.arguments;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;
@@ -13,8 +8,6 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-
-import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
@@ -23,6 +16,11 @@ import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.skill.SkillCategory;
 import yesman.epicfight.skill.SkillSlot;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public class SkillArgument implements ArgumentType<Holder<Skill>> {
 	private static final Collection<String> EXAMPLES = Arrays.asList("epicfight:dodge");
@@ -37,11 +35,7 @@ public class SkillArgument implements ArgumentType<Holder<Skill>> {
 	public static SkillArgument skill() {
 		return new SkillArgument();
 	}
-	
-	public static Holder<Skill> getSkill(CommandContext<CommandSourceStack> commandContext, String name) {
-		return commandContext.getSource().getServer().registryAccess().registryOrThrow(EpicFightRegistries.Keys.SKILL).getHolder(ResourceLocation.parse(name)).get();
-	}
-	
+
 	public Holder<Skill> parse(StringReader p_98428_) throws CommandSyntaxException {
 		ResourceLocation resourcelocation = ResourceLocation.read(p_98428_);
 		Optional<Holder.Reference<Skill>> skill = EpicFightRegistries.SKILL.getHolder(resourcelocation);

--- a/src/main/java/yesman/epicfight/skill/SkillContainer.java
+++ b/src/main/java/yesman/epicfight/skill/SkillContainer.java
@@ -66,9 +66,7 @@ public class SkillContainer {
 	}
 	
 	public boolean setSkill(@Nullable Skill skill, boolean initialize) {
-		/**
-		 * For remote players, call setSkillRemote instead
-		 */
+        // For remote players, call setSkillRemote instead
 		if (this.executor.isLogicalClient() && !this.executor.getOriginal().isLocalPlayer()) {
 			return false;
 		}
@@ -127,9 +125,7 @@ public class SkillContainer {
 	
 	@OnlyIn(Dist.CLIENT)
 	public void setSkillRemote(@Nullable Skill skill) {
-		/**
-		 * For server players or a local player, call setSkill instead
-		 */
+        // For server players or a local player, call setSkill instead
 		if (!this.executor.isLogicalClient() || this.executor.getOriginal().isLocalPlayer()) {
 			return;
 		}
@@ -146,7 +142,7 @@ public class SkillContainer {
 			this.skill.onRemoveClient(this);
 			this.executor.getPlayerSkills().removeSkillFromContainer(this.skill);
 		}
-		
+
 		this.skill = skill;
 		this.resetValues();
 		
@@ -154,6 +150,12 @@ public class SkillContainer {
 		this.skillDataManager.clearData();
 		
 		if (skill != null) {
+            Set<Holder<SkillDataKey<?>>> datakeys = SkillDataKeyCallbacks.getSkillDataKeyMap().get(skill.getClass());
+
+            if (datakeys != null && !datakeys.isEmpty()) {
+                datakeys.stream().filter(holder -> holder.value().syncronizeToRemotePlayers()).forEach(this.skillDataManager::registerData);
+            }
+
 			skill.onInitiateClient(this);
 			this.executor.getPlayerSkills().setSkillToContainer(skill, this);
 			

--- a/src/main/java/yesman/epicfight/skill/SkillContainer.java
+++ b/src/main/java/yesman/epicfight/skill/SkillContainer.java
@@ -22,7 +22,7 @@ import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Set;
 import java.util.function.Consumer;
 

--- a/src/main/java/yesman/epicfight/skill/SkillContainer.java
+++ b/src/main/java/yesman/epicfight/skill/SkillContainer.java
@@ -1,10 +1,5 @@
 package yesman.epicfight.skill;
 
-import java.util.Set;
-import java.util.function.Consumer;
-
-import javax.annotation.Nullable;
-
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -26,6 +21,10 @@ import yesman.epicfight.skill.modules.HoldableSkill;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.Consumer;
 
 public class SkillContainer {
 	protected Skill skill;
@@ -155,12 +154,6 @@ public class SkillContainer {
 		this.skillDataManager.clearData();
 		
 		if (skill != null) {
-			Set<Holder<SkillDataKey<?>>> datakeys = SkillDataKeyCallbacks.getSkillDataKeyMap().get(skill.getClass());
-			
-			if (datakeys != null && !datakeys.isEmpty()) {
-				datakeys.stream().filter(holder -> holder.value().syncronizeToRemotePlayers()).forEach(this.skillDataManager::registerData);
-			}
-			
 			skill.onInitiateClient(this);
 			this.executor.getPlayerSkills().setSkillToContainer(skill, this);
 			

--- a/src/main/java/yesman/epicfight/skill/SkillDataManager.java
+++ b/src/main/java/yesman/epicfight/skill/SkillDataManager.java
@@ -1,22 +1,21 @@
 package yesman.epicfight.skill;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-
-import org.jetbrains.annotations.ApiStatus;
-
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.registries.DeferredHolder;
+import org.jetbrains.annotations.ApiStatus;
 import yesman.epicfight.network.EpicFightNetworkManager;
 import yesman.epicfight.network.client.CPHandleSkillData;
 import yesman.epicfight.network.server.SPHandleSkillData;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 
 public class SkillDataManager {
 	private final Map<Holder<SkillDataKey<?>>, Object> data = new HashMap<> ();

--- a/src/main/java/yesman/epicfight/skill/SkillDataManager.java
+++ b/src/main/java/yesman/epicfight/skill/SkillDataManager.java
@@ -106,7 +106,7 @@ public class SkillDataManager {
 	public void onTracked(EpicFightNetworkManager.PayloadBundleBuilder bundleBuilder) {
 		this.data.forEach((key, val) -> {
 			if (key.value().syncronizeToRemotePlayers()) {
-				SPHandleSkillData msg = new SPHandleSkillData(SPHandleSkillData.WorkType.REGISTER, this.container.getSlot(), this.container.executor.getOriginal().getId(), key);
+				SPHandleSkillData msg = new SPHandleSkillData(SPHandleSkillData.WorkType.MODIFY, this.container.getSlot(), this.container.executor.getOriginal().getId(), key);
 				((SkillDataKey<Object>)key.value()).encode(msg.buffer(), val);
 				
 				bundleBuilder.and(msg);

--- a/src/main/java/yesman/epicfight/world/capabilities/skill/PlayerSkills.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/skill/PlayerSkills.java
@@ -1,31 +1,20 @@
 package yesman.epicfight.world.capabilities.skill;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
-
 import com.google.common.collect.HashMultimap;
 import com.mojang.datafixers.util.Pair;
-
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.registry.EpicFightRegistries;
-import yesman.epicfight.skill.Skill;
+import yesman.epicfight.skill.*;
 import yesman.epicfight.skill.Skill.SkillEventSubscriber;
-import yesman.epicfight.skill.SkillCategory;
-import yesman.epicfight.skill.SkillContainer;
-import yesman.epicfight.skill.SkillEvent;
-import yesman.epicfight.skill.SkillSlot;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+
+import java.util.*;
+import java.util.stream.Stream;
 
 public class PlayerSkills {
 	public static final PlayerSkills EMPTY = new PlayerSkills(null);
@@ -138,8 +127,13 @@ public class PlayerSkills {
 	public void clearContainersAndLearnedSkills(boolean isLocalOrServerPlayer) {
 		for (SkillContainer container : this.skillContainers) {
 			if (container.getSlot().category().learnable()) {
-				if (isLocalOrServerPlayer) { container.setSkill(null); container.setReplaceCooldown(0); }
-				else { container.setSkillRemote(null); container.setReplaceCooldown(0); }
+				if (isLocalOrServerPlayer) {
+                    container.setSkill(null);
+                } else {
+                    container.setSkillRemote(null);
+                }
+
+                container.setReplaceCooldown(0);
 			}
 		}
 		


### PR DESCRIPTION
Skill data keys with `syncronizeToRemotePlayers = true` will cause the duplicated data key registration crash. This is because of the new feature introduced in `20.12,x`, the skill update, where the skills are synchronized to remote clients to express some VFX effects like Adaptive Skin overlay and Berserker's particle generation

The point is, when the skill is equipped in remote clients, it registers data keys specified in their initial registration.

`SkillContainer.java:`
```java
public void setSkillRemote(@Nullable Skill skill) {

...

    Set<Holder<SkillDataKey<?>>> datakeys = SkillDataKeyCallbacks.getSkillDataKeyMap().get(skill.getClass());
			
    if (datakeys != null && !datakeys.isEmpty()) {
	    datakeys.stream().filter(holder -> holder.value().syncronizeToRemotePlayers()).forEach(this.skillDataManager::registerData);
    }
```
But the initial registration was also conducted at `SkillDataManager.java`

```java
public void onTracked(EpicFightNetworkManager.PayloadBundleBuilder bundleBuilder) {
	this.data.forEach((key, val) -> {
		if (key.value().syncronizeToRemotePlayers()) {
			SPHandleSkillData msg = new SPHandleSkillData(SPHandleSkillData.WorkType.REGISTER, this.container.getSlot(), this.container.executor.getOriginal().getId(), key);
			((SkillDataKey<Object>)key.value()).encode(msg.buffer(), val);
			
			bundleBuilder.and(msg);
		}
	});
}
```

This is the reason why other players get instantly crashed when begin to track a player with AdaptiveSkin skill, where has the only data key set `syncronizeToRemotePlayers = true`.

```java
	public static final DeferredHolder<SkillDataKey<?>, SkillDataKey<TagKey<DamageType>>> RESISTING_DAMAGE_TYPE = REGISTRY.register("resisting_damage_type", () ->
		SkillDataKey.createSkillDataKey(ByteBufCodecsExtends.tagKey(Registries.DAMAGE_TYPE), EpicFightDamageTypeTags.NONE, true, AdaptiveSkinSkill.class) // note that true third parameter is true
	)
```

The solutions are two, removing synchronization either in `onTracked` method or `setSkillRemote` method. Since `onTracked` provides the initial value of the skill too, I decided to remove the skill data key registration code from `setSkillRemote`. [See](https://github.com/Epic-Fight/epicfight/pull/2284/files#diff-90bcbcd73373c6862be2878bd4715d334dcf2783468063ea627b2023349aaabdL158).

I expect no regression because that skill data key was the only one set `syncronizeToRemotePlayers = true`.

Demonstration:
<img width="483" height="325" alt="image" src="https://github.com/user-attachments/assets/4042d002-34a8-468c-890b-9e24345dda12" />

Now you can track the player with Adaptive Skin skill applied.