### PR TITLE
[1.21.1] Fixed players not looking at the crosshair when mining

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -33,6 +33,7 @@ import yesman.epicfight.api.client.event.EpicFightClientHooks;
 import yesman.epicfight.api.client.event.types.*;
 import yesman.epicfight.api.client.input.InputManager;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.client.input.action.MinecraftInputAction;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
@@ -966,7 +967,7 @@ public final class EpicFightCameraAPI {
         CoupleTPSCamera coupleTPSCameraEvent = new CoupleTPSCamera(
             this,
             InputManager.getInputState(this.minecraft.player.input).getMoveVector().lengthSquared() > 0.0F,                             // When moving
-            this.minecraft.options.keyAttack.isDown(),                                                                                  // When pressing left button
+            InputManager.isActionActive(MinecraftInputAction.ATTACK_DESTROY),                                                           // When pressing left button
             this.minecraft.player.isUsingItem() && tpsItemAnimations.contains(this.minecraft.player.getUseItem().getUseAnimation()),    // When using an item with pre-defined use animations
             this.isZooming(),                                                                                                           // When zooming
             (playerpatch == null || playerpatch.isHoldingAny()),                                                                        // When holding a skill

--- a/src/main/java/yesman/epicfight/api/client/event/types/CoupleTPSCamera.java
+++ b/src/main/java/yesman/epicfight/api/client/event/types/CoupleTPSCamera.java
@@ -50,7 +50,7 @@ public class CoupleTPSCamera extends CameraAPIEvent {
     }
 
     public boolean shouldCoupleCamera() {
-        return this.modified ? this.shouldCouple : this.isMoving || this.isUsingCouplingItem || this.isZooming || this.isHoldingSkill || this.manualCoupling;
+        return this.modified ? this.shouldCouple : this.isMoving || this.isPressingVanillaAttackKeybind || this.isUsingCouplingItem || this.isZooming || this.isHoldingSkill || this.manualCoupling;
     }
 
     public boolean isModified() {


### PR DESCRIPTION
Fixed an issue where the player doesn't look at the crosshair when mining, caused by a missed coupling judgment variable.
```java
public boolean shouldCoupleCamera() {
//    return this.modified ? this.shouldCouple : this.isMoving || this.isUsingCouplingItem || this.isZooming || this.isHoldingSkill || this.manualCoupling;
      return this.modified ? this.shouldCouple : this.isMoving || this.isPressingVanillaAttackKeybind || this.isUsingCouplingItem || this.isZooming || this.isHoldingSkill || this.manualCoupling;
}
```
_original issue video tested by @EchoEllet_

https://github.com/user-attachments/assets/10d83e88-90dd-4e6c-82c2-aa6218b19315

_demonstration for fix_

https://github.com/user-attachments/assets/3017c2ee-1984-4f15-8515-71d251468f07

There is also a slight change; instead of using the Minecraft input system, we now depend on our input API.

```diff
-    //this.minecraft.options.keyAttack.isDown(),
+    InputManager.isActionActive(MinecraftInputAction.ATTACK_DESTROY),
```

By the way, there is also a similar issue in [1.20.1](https://github.com/Epic-Fight/epicfight/commit/2d6f8cac8be66df622c839b1c01f8f3bc455cc01), but I didn't create a PR since it doesn't have a noticeable fix.