### PR TITLE
[1.21.1] Remove OnlyIn Forge annotations for client packages

### DIFF
--- a/src/main/java/yesman/epicfight/api/client/animation/AnimationSubFileReader.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/AnimationSubFileReader.java
@@ -23,8 +23,6 @@ import com.mojang.datafixers.util.Pair;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.util.GsonHelper;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.TransformSheet;
@@ -44,7 +42,6 @@ import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class AnimationSubFileReader {
 	public static final SubFileType<ClientProperty> SUBFILE_CLIENT_PROPERTY = new ClientPropertyType();
 	public static final SubFileType<PovSettings> SUBFILE_POV_ANIMATION = new PovAnimationType();
@@ -68,7 +65,6 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static abstract class SubFileType<T> {
 		private final String directory;
 		private final AnimationSubFileDeserializer<T> deserializer;
@@ -100,11 +96,9 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private record ClientProperty(LayerInfo layerInfo, LayerInfo multilayerInfo, List<TrailInfo> trailInfo) {
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class ClientPropertyType extends SubFileType<ClientProperty> {
 		private ClientPropertyType() {
 			super("data", new AnimationSubFileReader.ClientAnimationPropertyDeserializer());
@@ -153,7 +147,6 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class ClientAnimationPropertyDeserializer implements AnimationSubFileDeserializer<ClientProperty> {
 		private static LayerInfo deserializeLayerInfo(JsonObject jsonObject) {
 			return deserializeLayerInfo(jsonObject, null);
@@ -216,7 +209,6 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static record PovSettings(
 		@Nullable TransformSheet cameraTransform,
 		Map<String, Boolean> visibilities,
@@ -226,17 +218,14 @@ public class AnimationSubFileReader {
 		boolean hasUniqueAnimation,
 		boolean syncFrame
 	) {
-		@OnlyIn(Dist.CLIENT)
 		public enum RootTransformation {
 			CAMERA, WORLD
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		public record ViewLimit(float xRotMin, float xRotMax, float yRotMin, float yRotMax) {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class PovAnimationType extends SubFileType<PovSettings> {
 		private PovAnimationType() {
 			super("pov", new AnimationSubFileReader.PovAnimationDeserializer());
@@ -267,7 +256,6 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class PovAnimationDeserializer implements AnimationSubFileDeserializer<PovSettings> {
 		@Override
 		public PovSettings deserialize(StaticAnimation animation, JsonElement json) throws AssetLoadingException, JsonParseException {
@@ -321,7 +309,6 @@ public class AnimationSubFileReader {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public interface AnimationSubFileDeserializer<T> {
 		public T deserialize(StaticAnimation animation, JsonElement json) throws JsonParseException;
 	}

--- a/src/main/java/yesman/epicfight/api/client/animation/ClientAnimator.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/ClientAnimator.java
@@ -6,8 +6,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.ApiStatus;
 import yesman.epicfight.api.animation.*;
 import yesman.epicfight.api.animation.property.AnimationProperty.ActionAnimationProperty;
@@ -32,7 +30,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-@OnlyIn(Dist.CLIENT)
 public class ClientAnimator extends Animator {
 	public static Animator getAnimator(LivingEntityPatch<?> entitypatch) {
 		return entitypatch.isLogicalClient() ? new ClientAnimator(entitypatch) : ServerAnimator.getAnimator(entitypatch);

--- a/src/main/java/yesman/epicfight/api/client/animation/Layer.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/Layer.java
@@ -6,8 +6,6 @@ import java.util.function.Supplier;
 
 import com.google.common.collect.Maps;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationPlayer;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.Pose;
@@ -20,7 +18,6 @@ import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.gameasset.Animations;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class Layer {
 	protected AssetAccessor<? extends StaticAnimation> nextAnimation;
 	protected final LinkAnimation linkAnimation;
@@ -230,7 +227,6 @@ public class Layer {
 		return sb.toString();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class BaseLayer extends Layer {
 		protected Map<Layer.Priority, Layer> compositeLayers = Maps.newLinkedHashMap();
 		protected Layer.Priority baseLayerPriority;
@@ -318,12 +314,10 @@ public class Layer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public enum LayerType {
 		BASE_LAYER, COMPOSITE_LAYER
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public enum Priority {
 		/**
 		 * The common usage of each layer

--- a/src/main/java/yesman/epicfight/api/client/animation/property/ClientAnimationProperties.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/ClientAnimationProperties.java
@@ -2,14 +2,11 @@ package yesman.epicfight.api.client.animation.property;
 
 import java.util.List;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.property.AnimationProperty.StaticAnimationProperty;
 import yesman.epicfight.api.animation.types.DirectStaticAnimation;
 import yesman.epicfight.api.client.animation.AnimationSubFileReader;
 import yesman.epicfight.api.client.animation.Layer;
 
-@OnlyIn(Dist.CLIENT)
 public class ClientAnimationProperties {
 	/**
 	 * Layer type. (BASE: Living, attack animations, COMPOSITE: Aiming, weapon holding, digging animation)

--- a/src/main/java/yesman/epicfight/api/client/animation/property/JointMask.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/JointMask.java
@@ -6,8 +6,6 @@ import java.util.Set;
 import com.google.common.collect.Maps;
 import com.mojang.datafixers.util.Pair;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -19,9 +17,7 @@ import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class JointMask {
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	public interface BindModifier {
 		public void modify(LivingEntityPatch<?> entitypatch, Pose baseLayerPose, Pose resultPose, LivingMotion livingMotion, JointMaskEntry wholeEntry, Layer.Priority priority, Joint joint, Map<Layer.Priority, Pair<AssetAccessor<? extends DynamicAnimation>, Pose>> poses);
@@ -68,7 +64,6 @@ public class JointMask {
 		this.bindModifier = bindModifier;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class JointMaskSet {
 		final Map<String, BindModifier> masks = Maps.newHashMap();
 		

--- a/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskEntry.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskEntry.java
@@ -9,12 +9,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.client.animation.property.JointMask.JointMaskSet;
 
-@OnlyIn(Dist.CLIENT)
 public class JointMaskEntry {
 	public static final JointMaskSet BIPED_UPPER_JOINTS_WITH_ROOT = JointMaskSet.of(
 		JointMask.of("Root", JointMask.KEEP_CHILD_LOCROT), JointMask.of("Torso"),
@@ -78,7 +75,6 @@ public class JointMaskEntry {
 		return builder.toString();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Builder {
 		private final List<Pair<LivingMotion, JointMaskSet>> masks = Lists.newArrayList();
 		private JointMaskSet defaultMask = null;

--- a/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskReloadListener.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskReloadListener.java
@@ -16,13 +16,10 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.animation.property.JointMask.BindModifier;
 import yesman.epicfight.api.client.animation.property.JointMask.JointMaskSet;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class JointMaskReloadListener extends SimpleJsonResourceReloadListener {
 	private static final BiMap<ResourceLocation, JointMaskSet> JOINT_MASKS = HashBiMap.create();
 	private static final Map<String, JointMask.BindModifier> BIND_MODIFIERS = Maps.newHashMap();

--- a/src/main/java/yesman/epicfight/api/client/animation/property/LayerInfo.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/LayerInfo.java
@@ -1,10 +1,7 @@
 package yesman.epicfight.api.client.animation.property;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.animation.Layer;
 
-@OnlyIn(Dist.CLIENT)
 public class LayerInfo {
 	public final JointMaskEntry jointMaskEntry;
 	public final Layer.Priority priority;

--- a/src/main/java/yesman/epicfight/api/client/animation/property/TrailInfo.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/TrailInfo.java
@@ -16,14 +16,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.registry.entries.EpicFightParticles;
 
-@OnlyIn(Dist.CLIENT)
 public record TrailInfo(
 	  Vec3 start
 	, Vec3 end
@@ -315,7 +312,6 @@ public record TrailInfo(
 		return trailBuilder.create();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Builder {
 		private Vec3 start;
 		private Vec3 end;

--- a/src/main/java/yesman/epicfight/api/client/model/ClassicMesh.java
+++ b/src/main/java/yesman/epicfight/api/client/model/ClassicMesh.java
@@ -15,14 +15,11 @@ import com.google.common.collect.Maps;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.ClassicMesh.ClassicMeshPart;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class ClassicMesh extends StaticMesh<ClassicMeshPart> {
 	public ClassicMesh(Map<String, Number[]> arrayMap, Map<MeshPartDefinition, List<VertexBuilder>> partBuilders, ClassicMesh parent, RenderProperties properties) {
 		super(arrayMap, partBuilders, parent, properties);
@@ -61,7 +58,6 @@ public class ClassicMesh extends StaticMesh<ClassicMeshPart> {
 		this.draw(poseStack, vertexConsumer, drawingFunction, packedLight, r, g, b, a, overlay);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class ClassicMeshPart extends MeshPart {
 		public ClassicMeshPart(List<VertexBuilder> verticies, @Nullable Mesh.RenderProperties renderProperties, @Nullable Supplier<OpenMatrix4f> vanillaPartTracer) {
 			super(verticies, renderProperties, vanillaPartTracer);

--- a/src/main/java/yesman/epicfight/api/client/model/CompositeMesh.java
+++ b/src/main/java/yesman/epicfight/api/client/model/CompositeMesh.java
@@ -7,15 +7,12 @@ import javax.annotation.Nullable;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulatable;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator.ClothObject;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator.ClothObjectBuilder;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 
-@OnlyIn(Dist.CLIENT)
 public class CompositeMesh implements Mesh, SoftBodyTranslatable {
 	private final StaticMesh<?> staticMesh;
 	private final SoftBodyTranslatable softBodyMesh;

--- a/src/main/java/yesman/epicfight/api/client/model/ItemSkinsReloadListener.java
+++ b/src/main/java/yesman/epicfight/api/client/model/ItemSkinsReloadListener.java
@@ -9,11 +9,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.events.engine.RenderEngine;
 
-@OnlyIn(Dist.CLIENT)
 public class ItemSkinsReloadListener extends SimpleJsonResourceReloadListener {
 	public static final ItemSkinsReloadListener INSTANCE = new ItemSkinsReloadListener();
 	

--- a/src/main/java/yesman/epicfight/api/client/model/Mesh.java
+++ b/src/main/java/yesman/epicfight/api/client/model/Mesh.java
@@ -20,15 +20,12 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.model.IQuadTransformer;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 
-@OnlyIn(Dist.CLIENT)
 public interface Mesh {
 	
 	void initialize();
@@ -44,7 +41,6 @@ public interface Mesh {
 		this.drawPosed(poseStack, bufferSources.getBuffer(EpicFightRenderTypes.getTriangulated(renderType)), drawingFunction, packedLight, r, g, b, a, overlay, armature, poses);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static record RenderProperties(ResourceLocation customTexturePath, Vec3f customColor, boolean isTransparent) {
 		public static class Builder {
 			protected String customTexturePath;
@@ -78,7 +74,6 @@ public interface Mesh {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	public interface DrawingFunction {
 		public static final DrawingFunction NEW_ENTITY = (builder, posX, posY, posZ, normX, normY, normZ, packedLight, r, g, b, a, u, v, overlay) -> {

--- a/src/main/java/yesman/epicfight/api/client/model/MeshPart.java
+++ b/src/main/java/yesman/epicfight/api/client/model/MeshPart.java
@@ -12,12 +12,9 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class MeshPart {
 	protected final List<VertexBuilder> verticies;
 	protected final Mesh.RenderProperties renderProperties;

--- a/src/main/java/yesman/epicfight/api/client/model/MeshPartDefinition.java
+++ b/src/main/java/yesman/epicfight/api/client/model/MeshPartDefinition.java
@@ -2,11 +2,8 @@ package yesman.epicfight.api.client.model;
 
 import java.util.function.Supplier;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 
-@OnlyIn(Dist.CLIENT)
 public interface MeshPartDefinition {
 	String partName();
 	Mesh.RenderProperties renderProperties();

--- a/src/main/java/yesman/epicfight/api/client/model/Meshes.java
+++ b/src/main/java/yesman/epicfight/api/client/model/Meshes.java
@@ -15,8 +15,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.asset.JsonAssetLoader;
 import yesman.epicfight.api.client.model.Mesh.RenderProperties;
@@ -37,7 +35,6 @@ import yesman.epicfight.client.mesh.VillagerMesh;
 import yesman.epicfight.client.mesh.WitherMesh;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class Meshes implements PreparableReloadListener {
 	private static final Map<ResourceLocation, MeshAccessor<? extends Mesh>> ACCESSORS = new HashMap<> ();
 	private static final Map<MeshAccessor<? extends Mesh>, Mesh> MESHES = new HashMap<> ();
@@ -124,12 +121,10 @@ public class Meshes implements PreparableReloadListener {
 	}
 	
 	@FunctionalInterface
-	@OnlyIn(Dist.CLIENT)
 	public interface MeshContructor<P extends MeshPart, V extends VertexBuilder, M extends StaticMesh<P>> {
 		M invoke(Map<String, Number[]> arrayMap, Map<MeshPartDefinition, List<V>> parts, M parent, RenderProperties properties);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static record MeshAccessor<M extends Mesh> (ResourceLocation registryName, Function<JsonAssetLoader, M> jsonLoader, boolean inRegistry) implements AssetAccessor<M>, SoftBodyTranslatable {
 		public static <M extends Mesh> MeshAccessor<M> create(String namespaceId, String path, Function<JsonAssetLoader, M> jsonLoader) {
 			return create(ResourceLocation.fromNamespaceAndPath(namespaceId, path), jsonLoader, true);

--- a/src/main/java/yesman/epicfight/api/client/model/SingleGroupVertexBuilder.java
+++ b/src/main/java/yesman/epicfight/api/client/model/SingleGroupVertexBuilder.java
@@ -9,12 +9,9 @@ import it.unimi.dsi.fastutil.floats.FloatArrayList;
 import it.unimi.dsi.fastutil.floats.FloatList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
 
-@OnlyIn(Dist.CLIENT)
 public class SingleGroupVertexBuilder {
 	private Vec3f position;
 	private Vec3f normal;

--- a/src/main/java/yesman/epicfight/api/client/model/SkinnedMesh.java
+++ b/src/main/java/yesman/epicfight/api/client/model/SkinnedMesh.java
@@ -21,8 +21,6 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.JsonAssetLoader;
 import yesman.epicfight.api.client.model.SkinnedMesh.SkinnedMeshPart;
 import yesman.epicfight.api.model.Armature;
@@ -36,7 +34,6 @@ import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.main.EpicFightSharedConstants;
 
-@OnlyIn(Dist.CLIENT)
 public class SkinnedMesh extends StaticMesh<SkinnedMeshPart> {
 	protected final float[] weights;
 	protected final int[] affectingJointCounts;
@@ -271,7 +268,6 @@ public class SkinnedMesh extends StaticMesh<SkinnedMeshPart> {
 		return this.affectingJointIndices;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class SkinnedMeshPart extends MeshPart {
 		private ComputeShaderSetup.MeshPartBuffer partVBO;
 

--- a/src/main/java/yesman/epicfight/api/client/model/SoftBodyTranslatable.java
+++ b/src/main/java/yesman/epicfight/api/client/model/SoftBodyTranslatable.java
@@ -5,15 +5,12 @@ import java.util.Map;
 
 import com.google.common.collect.Lists;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes.MeshAccessor;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulatable;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator.ClothObject.ClothPart.ConstraintType;
 import yesman.epicfight.api.physics.SimulationProvider;
 
-@OnlyIn(Dist.CLIENT)
 public interface SoftBodyTranslatable extends SimulationProvider<ClothSimulatable, ClothSimulator.ClothObject, ClothSimulator.ClothObjectBuilder, SoftBodyTranslatable> {
 	public static final List<ClothSimulatable> TRACKING_SIMULATION_SUBJECTS = Lists.newArrayList();
 	
@@ -33,7 +30,6 @@ public interface SoftBodyTranslatable extends SimulationProvider<ClothSimulatabl
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static record ClothSimulationInfo(float particleMass, float selfCollision, List<int[]> constraints, ConstraintType[] constraintTypes, float[] compliances, int[] particles, float[] weights, float[] rootDistance, int[] normalOffsetMapping) {
 	}
 }

--- a/src/main/java/yesman/epicfight/api/client/model/StaticMesh.java
+++ b/src/main/java/yesman/epicfight/api/client/model/StaticMesh.java
@@ -13,15 +13,12 @@ import org.joml.Vector4f;
 import com.google.common.collect.ImmutableList;
 
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulatable;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator.ClothObject;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class StaticMesh<P extends MeshPart> implements Mesh, SoftBodyTranslatable {
 	protected final float[] positions;
 	protected final float[] normals;

--- a/src/main/java/yesman/epicfight/api/client/model/VertexBuilder.java
+++ b/src/main/java/yesman/epicfight/api/client/model/VertexBuilder.java
@@ -4,12 +4,9 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
 
 // Vertex Indices
-@OnlyIn(Dist.CLIENT)
 public class VertexBuilder {
 	public static List<VertexBuilder> create(int[] drawingIndices) {
 		List<VertexBuilder> vertexIndicators = Lists.newArrayList();

--- a/src/main/java/yesman/epicfight/api/client/model/transformer/HumanoidModelBaker.java
+++ b/src/main/java/yesman/epicfight/api/client/model/transformer/HumanoidModelBaker.java
@@ -27,13 +27,10 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class HumanoidModelBaker {
 	static final Map<ResourceLocation, SkinnedMesh> BAKED_MODELS = new HashMap<> ();
 	static final List<HumanoidModelTransformer> MODEL_TRANSFORMERS = new ArrayList<> ();
@@ -43,7 +40,6 @@ public class HumanoidModelBaker {
 	
 	public static final HumanoidModelTransformer VANILLA_TRANSFORMER = new VanillaModelTransformer();
 	
-	@OnlyIn(Dist.CLIENT)
 	public interface ModelProvider {
 		public Model get(LivingEntity entityLiving, ItemStack itemStack, EquipmentSlot slot, HumanoidModel<?> _default);
 	}

--- a/src/main/java/yesman/epicfight/api/client/model/transformer/HumanoidModelTransformer.java
+++ b/src/main/java/yesman/epicfight/api/client/model/transformer/HumanoidModelTransformer.java
@@ -8,18 +8,14 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.client.model.HumanoidModel;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.ApiStatus;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SingleGroupVertexBuilder;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class HumanoidModelTransformer {
 	public abstract SkinnedMesh transformArmorModel(HumanoidModel<?> humanoidModel);
 	
-	@OnlyIn(Dist.CLIENT)
 	public static abstract class PartTransformer<T> {
 		public abstract void bakeCube(PoseStack poseStack, MeshPartDefinition partDefinition, T cube, List<SingleGroupVertexBuilder> vertices, Map<MeshPartDefinition, IntList> indices, IndexCounter indexCounter);
 
@@ -55,7 +51,6 @@ public abstract class HumanoidModelTransformer {
 			indexCounter.count();
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		public static class IndexCounter {
 			private int indexCounter = 0;
 			

--- a/src/main/java/yesman/epicfight/api/client/model/transformer/VanillaModelTransformer.java
+++ b/src/main/java/yesman/epicfight/api/client/model/transformer/VanillaModelTransformer.java
@@ -22,8 +22,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh.RenderProperties;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SingleGroupVertexBuilder;
@@ -34,7 +32,6 @@ import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.mixin.client.MixinAgeableListModel;
 
-@OnlyIn(Dist.CLIENT)
 public class VanillaModelTransformer extends HumanoidModelTransformer {
 	public static final SimpleTransformer HEAD = new SimpleTransformer(AABB.ofSize(new Vec3(0.0D, -4.0D, 0.0D), 8.0D, 8.0D, 8.0D), 9);
 	public static final SimpleTransformer LEFT_FEET = new SimpleTransformer(AABB.ofSize(new Vec3(0.0D, -4.0D, 0.0D), 8.0D, 8.0D, 8.0D), 5);
@@ -67,7 +64,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		return CHEST;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static record VanillaModelPartition(PartTransformer<ModelPart.Cube> partTransformer, ModelPart modelPart, String partName) {
 	}
 	
@@ -205,7 +201,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		poseStack.popPose();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class SimpleTransformer extends PartTransformer<ModelPart.Cube> {
 		final int jointId;
 		final AABB coverArea;
@@ -238,7 +233,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ChestPartTransformer extends PartTransformer<ModelPart.Cube> {
 		static final float X_PLANE = 0.0F;
 		static final VertexWeight[] WEIGHT_ALONG_Y = { new VertexWeight(13.6666F, 0.230F, 0.770F), new VertexWeight(15.8333F, 0.254F, 0.746F), new VertexWeight(18.0F, 0.5F, 0.5F), new VertexWeight(20.1666F, 0.744F, 0.256F), new VertexWeight(22.3333F, 0.770F, 0.230F)};
@@ -431,7 +425,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class LimbPartTransformer extends PartTransformer<ModelPart.Cube> {
 		final int upperJoint;
 		final int lowerJoint;
@@ -626,7 +619,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		return new ModelPart.Vertex(translatedPosition.x(), translatedPosition.y(), translatedPosition.z(), original.u, original.v);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedVertex extends ModelPart.Vertex {
 		final Vec3i jointId;
 		final Vec3f weight;
@@ -650,7 +642,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedPolygon {
 		public final AnimatedVertex[] animatedVertexPositions;
 		public final Vector3f normal;
@@ -670,7 +661,6 @@ public class VanillaModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public record VanillaMeshPartDefinition(String partName, RenderProperties renderProperties, List<String> path, OpenMatrix4f invertedParentTransform, ModelPart root) implements MeshPartDefinition {
 		public static MeshPartDefinition of(String partName, RenderProperties renderProperties) {
 			return new VanillaMeshPartDefinition(partName, renderProperties, null, null, null);

--- a/src/main/java/yesman/epicfight/api/client/neoevent/AnimatedArmorTextureEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/AnimatedArmorTextureEvent.java
@@ -5,12 +5,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class AnimatedArmorTextureEvent extends Event {
 	private final LivingEntity livingentity;
     private final ItemStack itemstack;

--- a/src/main/java/yesman/epicfight/api/client/neoevent/AttributeIconRegisterEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/AttributeIconRegisterEvent.java
@@ -4,13 +4,10 @@ import java.util.Map;
 
 import net.minecraft.core.Holder;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
 import yesman.epicfight.client.gui.screen.SkillBookScreen.TextureInfo;
 
-@OnlyIn(Dist.CLIENT)
 public class AttributeIconRegisterEvent extends Event implements IModBusEvent {
 	final Map<Holder<Attribute>, TextureInfo> registry;
 	

--- a/src/main/java/yesman/epicfight/api/client/neoevent/PatchedRenderersEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/PatchedRenderersEvent.java
@@ -8,17 +8,13 @@ import com.google.gson.JsonElement;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
 import yesman.epicfight.client.renderer.patched.entity.PatchedEntityRenderer;
 import yesman.epicfight.client.renderer.patched.item.RenderItemBase;
 
-@OnlyIn(Dist.CLIENT)
 @SuppressWarnings("rawtypes")
 public abstract class PatchedRenderersEvent extends Event implements IModBusEvent {
-	@OnlyIn(Dist.CLIENT)
 	public static class RegisterItemRenderer extends PatchedRenderersEvent {
 		private final Map<ResourceLocation, Function<JsonElement, RenderItemBase>> itemRenderers;
 		
@@ -35,7 +31,6 @@ public abstract class PatchedRenderersEvent extends Event implements IModBusEven
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Add extends PatchedRenderersEvent {
 		private final Map<EntityType<?>, Function<EntityType<?>, PatchedEntityRenderer>> entityRendererProvider;
 		private final EntityRendererProvider.Context context;
@@ -54,7 +49,6 @@ public abstract class PatchedRenderersEvent extends Event implements IModBusEven
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Modify extends PatchedRenderersEvent {
 		private final Map<EntityType<?>, PatchedEntityRenderer> renderers;
 		

--- a/src/main/java/yesman/epicfight/api/client/neoevent/PrepareModelEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/PrepareModelEvent.java
@@ -3,15 +3,12 @@ package yesman.epicfight.api.client.neoevent;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.client.renderer.patched.entity.PatchedEntityRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PrepareModelEvent extends Event implements ICancellableEvent {
 	private final SkinnedMesh mesh;
 	private final LivingEntityPatch<?> entitypatch;

--- a/src/main/java/yesman/epicfight/api/client/neoevent/ProcessEntityPairingPacketEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/ProcessEntityPairingPacketEvent.java
@@ -1,13 +1,10 @@
 package yesman.epicfight.api.client.neoevent;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import yesman.epicfight.network.server.SPEntityPairingPacket;
 import yesman.epicfight.world.capabilities.entitypatch.EntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class ProcessEntityPairingPacketEvent extends Event implements ICancellableEvent {
 	private final EntityPatch<?> entitypatch;
 	private final SPEntityPairingPacket packet;

--- a/src/main/java/yesman/epicfight/api/client/neoevent/RegisterResourceLayersEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/RegisterResourceLayersEvent.java
@@ -6,14 +6,11 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.client.renderer.patched.layer.LayerUtil;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RegisterResourceLayersEvent<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends LivingEntityRenderer<E, M>, AM extends SkinnedMesh> extends Event {
 	private final Map<ResourceLocation, LayerUtil.LayerProvider<E, T, M, R, AM>> layersbyid;
 	

--- a/src/main/java/yesman/epicfight/api/client/neoevent/RenderEnderDragonEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/RenderEnderDragonEvent.java
@@ -5,12 +5,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EnderDragonRenderer;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderEnderDragonEvent extends Event implements ICancellableEvent {
 	private final EnderDragon entity;
     private final EnderDragonRenderer renderer;

--- a/src/main/java/yesman/epicfight/api/client/neoevent/RenderEpicFightPlayerEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/RenderEpicFightPlayerEvent.java
@@ -1,11 +1,8 @@
 package yesman.epicfight.api.client.neoevent;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderEpicFightPlayerEvent extends Event {
 	private final PlayerPatch<?> playerpatch;
 	private final boolean shouldRenderOriginal;

--- a/src/main/java/yesman/epicfight/api/client/neoevent/UpdatePlayerMotionEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/UpdatePlayerMotionEvent.java
@@ -1,12 +1,9 @@
 package yesman.epicfight.api.client.neoevent;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.neoevent.playerpatch.PlayerPatchEvent;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClientPlayerPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class UpdatePlayerMotionEvent extends PlayerPatchEvent<AbstractClientPlayerPatch<?>> {
 	private LivingMotion motion;
 	
@@ -23,7 +20,6 @@ public abstract class UpdatePlayerMotionEvent extends PlayerPatchEvent<AbstractC
 		return this.motion;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class BaseLayer extends UpdatePlayerMotionEvent {
 		private final boolean inaction;
 		
@@ -38,7 +34,6 @@ public abstract class UpdatePlayerMotionEvent extends PlayerPatchEvent<AbstractC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class CompositeLayer extends UpdatePlayerMotionEvent {
 		public CompositeLayer(AbstractClientPlayerPatch<?> playerpatch, LivingMotion motion) {
 			super(playerpatch, motion);

--- a/src/main/java/yesman/epicfight/api/client/neoevent/WeaponCategoryIconRegisterEvent.java
+++ b/src/main/java/yesman/epicfight/api/client/neoevent/WeaponCategoryIconRegisterEvent.java
@@ -4,13 +4,10 @@ import java.util.Map;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
 import yesman.epicfight.world.capabilities.item.WeaponCategory;
 
-@OnlyIn(Dist.CLIENT)
 public class WeaponCategoryIconRegisterEvent extends Event implements IModBusEvent {
 	final Map<WeaponCategory, ItemStack> registry;
 	

--- a/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothColliderPresets.java
+++ b/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothColliderPresets.java
@@ -6,8 +6,6 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 
 /**
@@ -33,7 +31,6 @@ import yesman.epicfight.api.utils.math.OpenMatrix4f;
  * 19: "Elbow_L"
 **/
 
-@OnlyIn(Dist.CLIENT)
 public class ClothColliderPresets {
 	public static final List<Pair<Function<ClothSimulatable, OpenMatrix4f>, ClothSimulator.ClothOBBCollider>> BIPED_SLIM = ImmutableList.<Pair<Function<ClothSimulatable, OpenMatrix4f>, ClothSimulator.ClothOBBCollider>>builder()
 			.add(Pair.of((simObject) -> simObject.getArmature().getPoseMatrices()[1], new ClothSimulator.ClothOBBCollider(0.125D, 0.24D, 0.125D, 0.0D, 0.22D, 0.0D)))

--- a/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulatable.java
+++ b/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulatable.java
@@ -3,13 +3,10 @@ package yesman.epicfight.api.client.physics.cloth;
 import javax.annotation.Nullable;
 
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Animator;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.api.physics.SimulatableObject;
 
-@OnlyIn(Dist.CLIENT)
 public interface ClothSimulatable extends SimulatableObject {
 	@Nullable
 	Armature getArmature();

--- a/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulator.java
+++ b/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulator.java
@@ -34,8 +34,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.client.model.CompositeMesh;
 import yesman.epicfight.api.client.model.Mesh;
@@ -60,13 +58,11 @@ import yesman.epicfight.main.EpicFightSharedConstants;
  * 
  * https://www.youtube.com/@TenMinutePhysics
  **/
-@OnlyIn(Dist.CLIENT)
 public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObjectBuilder, SoftBodyTranslatable, ClothSimulatable, ClothSimulator.ClothObject> {
 	public static final ResourceLocation PLAYER_CLOAK = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "ingame_cloak");
 	public static final ResourceLocation MODELPREVIEWER_CLOAK = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "previewer_cloak");
 	private static final float SPATIAL_HASH_SPACING = 0.05F;
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ClothObjectBuilder extends SimulationObject.SimulationObjectBuilder {
 		List<Pair<Function<ClothSimulatable, OpenMatrix4f>, ClothSimulator.ClothOBBCollider>> clothColliders = Lists.newArrayList();
 		Joint joint;
@@ -120,7 +116,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 		DRAW_OUTLINES = flag;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ClothObject implements SimulationObject<ClothObjectBuilder, SoftBodyTranslatable, ClothSimulatable>, Mesh {
 		private final SoftBodyTranslatable provider;
 		private final Map<String, ClothPart> parts;
@@ -594,7 +589,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 		public void initialize() {
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class Particle {
 			final Vec3f position;
 			final Vec3f modelPosition;
@@ -619,7 +613,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 			}
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		public class ClothPart {
 			final List<Particle> particleList;
 			final List<ConstraintList> constraints;
@@ -961,23 +954,19 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 				return Math.abs(hash) % this.hashTableSize;
 			}
 			
-			@OnlyIn(Dist.CLIENT)
 			public enum ConstraintType {
 				STRETCHING, SHAPING, BENDING, VOLUME
 			}
 			
-			@OnlyIn(Dist.CLIENT)
 			public static record ConstraintList(float compliance, ConstraintType constraintType, List<? extends Constraint> constraints) {
 			}
 			
-			@OnlyIn(Dist.CLIENT)
 			public static record OffsetParticle(int offsetVertexId, float length, Particle rootParticle, Vec3f position, List<Integer> positionNormalMembers, List<Integer> inverseNormal) {
 				public OffsetParticle copy() {
 					return new OffsetParticle(this.offsetVertexId, this.length, this.rootParticle, this.position.copy(), this.positionNormalMembers, this.inverseNormal);
 				}
 			}
 			
-			@OnlyIn(Dist.CLIENT)
 			abstract class Constraint {
 				abstract void solve(float alpha, int stepcount);
 			}
@@ -985,7 +974,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 			/**
 			 * A constraint that restricts stretching of two particles
 			 */
-			@OnlyIn(Dist.CLIENT)
 			class StretchingConstraint extends Constraint {
 				final Particle p1;
 				final Particle p2;
@@ -1035,7 +1023,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 			 * 
 			 * Be used to prevent streching too much in gravity direction in low fps
 			 */
-			@OnlyIn(Dist.CLIENT)
 			class ShapingConstraint extends Constraint {
 				final Particle p1;
 				final Particle p2;
@@ -1083,7 +1070,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 			/**
 			 * A constraint that restricts bending of member particles. p2, p3 are adjacent edge particles, and p1, p4 are opponent each other
 			 */
-			@OnlyIn(Dist.CLIENT)
 			class BendingConstraint extends Constraint {
 				final Particle p1;
 				final Particle p2;
@@ -1198,7 +1184,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 			 * 
 			 * Note: This constraint is expensive. Consider using NormalMappedParticle instead.
 			 */
-			@OnlyIn(Dist.CLIENT)
 			class VolumeConstraint extends Constraint {
 				final Particle[] particles;
 				final float restVolume;
@@ -1264,7 +1249,6 @@ public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObj
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ClothOBBCollider extends OBBCollider {
 		public ClothOBBCollider(double vertexX, double vertexY, double vertexZ, double centerX, double centerY, double centerZ) {
 			super(vertexX, vertexY, vertexZ, centerX, centerY, centerZ);

--- a/src/main/java/yesman/epicfight/client/ClientEngine.java
+++ b/src/main/java/yesman/epicfight/client/ClientEngine.java
@@ -4,8 +4,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.client.resources.sounds.SoundInstance;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import yesman.epicfight.client.particle.EpicFightParticleRenderTypes;
@@ -18,7 +16,6 @@ import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 
-@OnlyIn(Dist.CLIENT)
 public class ClientEngine {
 	private static ClientEngine instance = new ClientEngine();
 	

--- a/src/main/java/yesman/epicfight/client/events/ClientEvents.java
+++ b/src/main/java/yesman/epicfight/client/events/ClientEvents.java
@@ -9,7 +9,6 @@ import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.UseAnim;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -30,7 +29,6 @@ import yesman.epicfight.world.gamerule.EpicFightGameRules;
 import yesman.epicfight.world.gamerule.EpicFightGameRules.ConfigurableGameRule;
 import yesman.epicfight.world.level.block.FractureBlockState;
 
-@OnlyIn(Dist.CLIENT)
 @EventBusSubscriber(modid = EpicFightMod.MODID, value = Dist.CLIENT)
 public final class ClientEvents {
 	private ClientEvents() {}

--- a/src/main/java/yesman/epicfight/client/events/ClientModBusEvent.java
+++ b/src/main/java/yesman/epicfight/client/events/ClientModBusEvent.java
@@ -7,7 +7,6 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -33,7 +32,6 @@ import yesman.epicfight.skill.SkillCategory;
 import java.util.ArrayList;
 import java.util.List;
 
-@OnlyIn(Dist.CLIENT)
 @EventBusSubscriber(modid = EpicFightMod.MODID, value = Dist.CLIENT)
 public final class ClientModBusEvent {
 	private ClientModBusEvent() {}

--- a/src/main/java/yesman/epicfight/client/events/engine/IEventBasedEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/IEventBasedEngine.java
@@ -1,10 +1,7 @@
 package yesman.epicfight.client.events.engine;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.IEventBus;
 
-@OnlyIn(Dist.CLIENT)
 public interface IEventBasedEngine {
 	public void gameEventBus(IEventBus gameEventBus);
 	

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -38,8 +38,6 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.ModLoader;
@@ -94,7 +92,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("rawtypes")
-@OnlyIn(Dist.CLIENT)
 public class RenderEngine implements IEventBasedEngine {
 	private static final RenderEngine INSTANCE = new RenderEngine();
 	

--- a/src/main/java/yesman/epicfight/client/gui/BattleModeGui.java
+++ b/src/main/java/yesman/epicfight/client/gui/BattleModeGui.java
@@ -16,8 +16,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.ScreenCalculations.AlignDirection;
@@ -31,7 +29,6 @@ import yesman.epicfight.skill.SkillSlot;
 import yesman.epicfight.skill.SkillSlots;
 import yesman.epicfight.skill.modules.ChargeableSkill;
 
-@OnlyIn(Dist.CLIENT)
 public class BattleModeGui {
 	private final List<SkillContainer> skillIcons = new ArrayList<> ();
 	private Minecraft minecraft;

--- a/src/main/java/yesman/epicfight/client/gui/EntityUI.java
+++ b/src/main/java/yesman/epicfight/client/gui/EntityUI.java
@@ -7,8 +7,6 @@ import com.mojang.math.Axis;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
@@ -18,7 +16,6 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import javax.annotation.Nullable;
 import java.util.List;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class EntityUI {
 	public static final List<EntityUI> ENTITY_UI_LIST = Lists.newArrayList();
 	public static final TargetIndicator TARGET_INDICATOR = new TargetIndicator();

--- a/src/main/java/yesman/epicfight/client/gui/HealthBar.java
+++ b/src/main/java/yesman/epicfight/client/gui/HealthBar.java
@@ -19,8 +19,6 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.Tags.EntityTypes;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.config.ClientConfig;
@@ -30,7 +28,6 @@ import yesman.epicfight.world.capabilities.entitypatch.Faction;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.effect.VisibleMobEffect;
 
-@OnlyIn(Dist.CLIENT)
 public class HealthBar extends EntityUI {
 	public static final ResourceLocation HEALTHBARS1 = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png");
 	public static final ResourceLocation HEALTHBARS2 = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars2.png");
@@ -209,7 +206,6 @@ public class HealthBar extends EntityUI {
 		this.trackingEntities.values().forEach(EntityAttributeTracker::tick);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class EntityAttributeTracker {
 		private final LivingEntity entity;
 		private final AttributeState healthState;

--- a/src/main/java/yesman/epicfight/client/gui/ScreenCalculations.java
+++ b/src/main/java/yesman/epicfight/client/gui/ScreenCalculations.java
@@ -2,11 +2,8 @@ package yesman.epicfight.client.gui;
 
 import java.util.function.BiFunction;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.Vec2i;
 
-@OnlyIn(Dist.CLIENT)
 public class ScreenCalculations {
 	private static final BiFunction<Integer, Integer, Integer> ORIGIN = ((screenLength, value) -> value);
 	private static final BiFunction<Integer, Integer, Integer> SCREEN_EDGE = ((screenLength, value) -> screenLength - value);

--- a/src/main/java/yesman/epicfight/client/gui/TargetIndicator.java
+++ b/src/main/java/yesman/epicfight/client/gui/TargetIndicator.java
@@ -8,15 +8,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.neoevent.playerpatch.PlayerPatchEvent;
 import yesman.epicfight.api.neoevent.playerpatch.TargetIndicatorCheckEvent;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class TargetIndicator extends EntityUI {
 	@Override
 	public boolean shouldDraw(LivingEntity entity, @Nullable LivingEntityPatch<?> entitypatch, LocalPlayerPatch playerpatch, float partialTicks) {

--- a/src/main/java/yesman/epicfight/client/gui/VersionNotifier.java
+++ b/src/main/java/yesman/epicfight/client/gui/VersionNotifier.java
@@ -5,12 +5,9 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModList;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class VersionNotifier {
 	private final Minecraft minecraft;
 	private final boolean visible;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/AttackAnimationPropertyScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/AttackAnimationPropertyScreen.java
@@ -17,8 +17,6 @@ import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.animation.types.datapack.EditorAnimation;
 import yesman.epicfight.api.client.animation.property.TrailInfo;
@@ -33,7 +31,6 @@ import yesman.epicfight.client.gui.datapack.widgets.ResizableComponent.VerticalS
 import yesman.epicfight.client.gui.datapack.widgets.ResizableEditBox;
 import yesman.epicfight.client.gui.datapack.widgets.Static;
 
-@OnlyIn(Dist.CLIENT)
 public class AttackAnimationPropertyScreen extends Screen {
 	private final Screen parentScreen;
 	private final EditorAnimation animation;
@@ -331,7 +328,6 @@ public class AttackAnimationPropertyScreen extends Screen {
 		super.render(guiGraphics, mouseX, mouseY, partialTicks);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public enum LayerOptions {
 		BASE_LAYER, COMPOSITE_LAYER, MULTILAYER
 	}

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/CombatBehaviorScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/CombatBehaviorScreen.java
@@ -17,8 +17,6 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.types.AttackAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -43,7 +41,6 @@ import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.registry.entries.EpicFightConditions;
 
-@OnlyIn(Dist.CLIENT)
 public class CombatBehaviorScreen extends Screen {
 	private InputComponentList<CompoundTag> inputComponentsList;
 	private final List<CompoundTag> movesetList = Lists.newLinkedList();

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/DatapackEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/DatapackEditScreen.java
@@ -75,8 +75,6 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.validation.DirectoryValidator;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
@@ -131,7 +129,6 @@ import yesman.epicfight.world.capabilities.item.WeaponCategory;
 import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 import yesman.epicfight.world.damagesource.StunType;
 
-@OnlyIn(Dist.CLIENT)
 public class DatapackEditScreen extends Screen {
 	public static final Component GUI_EXPORT = Component.translatable("gui.epicfight.export");
 	private static DatapackEditScreen workingPackScreen;
@@ -728,7 +725,6 @@ public class DatapackEditScreen extends Screen {
 		return this.userAnimations;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	abstract class DatapackTab<T> extends GridLayoutTab implements TickableComponent {
 		protected Grid packListGrid;
 		protected InputComponentList<CompoundTag> inputComponentsList;
@@ -822,7 +818,6 @@ public class DatapackEditScreen extends Screen {
 		public abstract void exportEntries(ZipOutputStream out) throws Exception;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class WeaponTypeTab extends DatapackTab<ResourceLocation> {
 		private final ModelPreviewer modelPreviewer;
 		
@@ -1245,7 +1240,6 @@ public class DatapackEditScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class ItemCapabilityTab extends DatapackTab<Item> {
 		private ModelPreviewer modelPreviewer;
 		private ComboBox<ItemType> itemTypeCombo;
@@ -2176,7 +2170,6 @@ public class DatapackEditScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class MobCapabilityTab extends DatapackTab<EntityType<?>> {
 		private final ModelPreviewer modelPreviewer;
 		private final ComboBox<EntityType<?>> presetCombo = new ComboBox<>(DatapackEditScreen.this, DatapackEditScreen.this.font, 0, 124, 100, 15, HorizontalSizing.LEFT_WIDTH, null, 8,

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/HumanoidCombatBehaviorScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/HumanoidCombatBehaviorScreen.java
@@ -18,8 +18,6 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.model.Armature;
@@ -36,7 +34,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem.WeaponCategories;
 import yesman.epicfight.world.capabilities.item.Style;
 import yesman.epicfight.world.capabilities.item.WeaponCategory;
 
-@OnlyIn(Dist.CLIENT)
 public class HumanoidCombatBehaviorScreen extends Screen {
 	private final Screen parentScreen;
 	private final InputComponentList<CompoundTag> inputComponentsList;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/HumanoidWeaponMotionScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/HumanoidWeaponMotionScreen.java
@@ -19,8 +19,6 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.MainFrameAnimation;
@@ -40,7 +38,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.Style;
 import yesman.epicfight.world.capabilities.item.WeaponCategory;
 
-@OnlyIn(Dist.CLIENT)
 public class HumanoidWeaponMotionScreen extends Screen {
 	private Grid motionSetGrid;
 	private InputComponentList<CompoundTag> inputComponentsList;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/ImportAnimationsScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/ImportAnimationsScreen.java
@@ -28,8 +28,6 @@ import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.animation.types.datapack.DatapackAnimation;
@@ -57,7 +55,6 @@ import yesman.epicfight.client.gui.datapack.widgets.Static;
 import yesman.epicfight.client.gui.datapack.widgets.SubScreenOpenButton;
 import yesman.epicfight.gameasset.ColliderPreset;
 
-@OnlyIn(Dist.CLIENT)
 public class ImportAnimationsScreen extends Screen {
 	private final SelectAnimationScreen parentScreen;
 	private final Grid animationGrid;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/ImportModelScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/ImportModelScreen.java
@@ -17,8 +17,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.asset.JsonAssetLoader;
 import yesman.epicfight.api.asset.SelfAccessor;
@@ -32,7 +30,6 @@ import yesman.epicfight.client.gui.datapack.widgets.ResizableComponent.VerticalS
 import yesman.epicfight.client.gui.datapack.widgets.ResizableEditBox;
 import yesman.epicfight.client.gui.datapack.widgets.Static;
 
-@OnlyIn(Dist.CLIENT)
 public class ImportModelScreen extends Screen {
 	private final SelectModelScreen parentScreen;
 	private final Grid meshGrid;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/LivingAnimationsScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/LivingAnimationsScreen.java
@@ -18,8 +18,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.MainFrameAnimation;
@@ -40,7 +38,6 @@ import yesman.epicfight.gameasset.Armatures;
 import yesman.epicfight.world.capabilities.item.CapabilityItem.Styles;
 import yesman.epicfight.world.capabilities.item.Style;
 
-@OnlyIn(Dist.CLIENT)
 public class LivingAnimationsScreen extends Screen {
 	private final Screen parentScreen;
 	private final Grid stylesGrid;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/MessageScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/MessageScreen.java
@@ -14,11 +14,8 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.gui.datapack.widgets.DataBindingComponent;
 
-@OnlyIn(Dist.CLIENT)
 public class MessageScreen<T> extends Screen {
 	protected final Button.OnPress onOkPress;
 	protected final Button.OnPress onCancelPress;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/OffhandValidatorScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/OffhandValidatorScreen.java
@@ -17,8 +17,6 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.gui.datapack.widgets.Grid;
 import yesman.epicfight.client.gui.datapack.widgets.Grid.GridBuilder.RowEditButton;
@@ -31,7 +29,6 @@ import yesman.epicfight.data.conditions.Condition.ParameterEditor;
 import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.registry.entries.EpicFightConditions;
 
-@OnlyIn(Dist.CLIENT)
 public class OffhandValidatorScreen extends Screen {
 	private final Screen parentScreen;
 	private final List<CompoundTag> conditionList = Lists.newLinkedList();

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/PackEntry.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/PackEntry.java
@@ -3,10 +3,7 @@ package yesman.epicfight.client.gui.datapack.screen;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class PackEntry<K, T> implements Map.Entry<K, T> {
 	public static <K, T> PackEntry<K, T> of(K packKey, Supplier<T> valueGetter) {
 		return new PackEntry<>(packKey, valueGetter.get());

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectAnimationScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectAnimationScreen.java
@@ -14,8 +14,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.StringUtil;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -23,7 +21,6 @@ import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.client.gui.datapack.widgets.ModelPreviewer;
 
-@OnlyIn(Dist.CLIENT)
 public class SelectAnimationScreen extends Screen {
 	private final Screen parentScreen;
 	private final AnimationList animationList;
@@ -124,7 +121,6 @@ public class SelectAnimationScreen extends Screen {
 		super.render(guiGraphics, mouseX, mouseY, partialTicks);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class AnimationList extends ObjectSelectionList<AnimationList.AnimationEntry> {
 		public AnimationList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
 			super(minecraft, width, height, y, itemHeight);
@@ -174,7 +170,6 @@ public class SelectAnimationScreen extends Screen {
 				.forEach(this::addEntry);
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class AnimationEntry extends ObjectSelectionList.Entry<AnimationList.AnimationEntry> {
 			private final AssetAccessor<? extends StaticAnimation> animation;
 			

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectFromRegistryScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectFromRegistryScreen.java
@@ -26,12 +26,9 @@ import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringUtil;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class SelectFromRegistryScreen<T> extends Screen {
 	private final RegistryList registryList;
 	private final Screen parentScreen;
@@ -127,7 +124,6 @@ public class SelectFromRegistryScreen<T> extends Screen {
 		this.minecraft.setScreen(this.parentScreen);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class RegistryList extends ObjectSelectionList<RegistryList.RegistryEntry> {
 		private final Map<ResourceLocation, T> registry;
 		
@@ -165,7 +161,6 @@ public class SelectFromRegistryScreen<T> extends Screen {
 				.forEach(this::addEntry);
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class RegistryEntry extends ObjectSelectionList.Entry<RegistryList.RegistryEntry> {
 			private final T item;
 			private final String name;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectModelScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/SelectModelScreen.java
@@ -16,14 +16,11 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.StringUtil;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.client.gui.datapack.widgets.ModelPreviewer;
 
-@OnlyIn(Dist.CLIENT)
 public class SelectModelScreen extends Screen {
 	private final Screen parentScreen;
 	private final ModelList modelList;
@@ -122,7 +119,6 @@ public class SelectModelScreen extends Screen {
 		super.render(guiGraphics, mouseX, mouseY, partialTicks);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class ModelList extends ObjectSelectionList<ModelList.ModelEntry> {
 		public ModelList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
 			super(minecraft, width, height, y, itemHeight);
@@ -165,7 +161,6 @@ public class SelectModelScreen extends Screen {
 														.sorted((entry$1, entry$2) -> entry$1.registryName.compareTo(entry$2.registryName)).forEach(this::addEntry);
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class ModelEntry extends ObjectSelectionList.Entry<ModelList.ModelEntry> {
 			private final String registryName;
 			private final AssetAccessor<SkinnedMesh> mesh;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/StaticAnimationPropertyScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/StaticAnimationPropertyScreen.java
@@ -16,8 +16,6 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.GsonHelper;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.datapack.EditorAnimation;
@@ -33,7 +31,6 @@ import yesman.epicfight.client.gui.datapack.widgets.PopupBox;
 import yesman.epicfight.client.gui.datapack.widgets.ResizableComponent.HorizontalSizing;
 import yesman.epicfight.client.gui.datapack.widgets.Static;
 
-@OnlyIn(Dist.CLIENT)
 public class StaticAnimationPropertyScreen extends Screen {
 	private final InputComponentList<JsonObject> inputComponentsList;
 	private final ComboBox<LayerOptions> layerTypeCombo;
@@ -471,7 +468,6 @@ public class StaticAnimationPropertyScreen extends Screen {
 		super.render(guiGraphics, mouseX, mouseY, partialTicks);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public enum LayerOptions {
 		BASE_LAYER, COMPOSITE_LAYER, MULTILAYER
 	}

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/StylesScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/StylesScreen.java
@@ -23,8 +23,6 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.gui.datapack.widgets.ComboBox;
 import yesman.epicfight.client.gui.datapack.widgets.Grid;
@@ -42,7 +40,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.CapabilityItem.Styles;
 import yesman.epicfight.world.capabilities.item.Style;
 
-@OnlyIn(Dist.CLIENT)
 public class StylesScreen extends Screen {
 	private final Screen parentScreen;
 	private final Grid stylesGrid;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/WeaponAttributeScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/WeaponAttributeScreen.java
@@ -21,8 +21,6 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.gui.datapack.screen.DatapackEditScreen.ItemCapabilityTab.ItemType;
 import yesman.epicfight.client.gui.datapack.widgets.Grid;
@@ -35,7 +33,6 @@ import yesman.epicfight.data.conditions.Condition.ParameterEditor;
 import yesman.epicfight.world.capabilities.item.CapabilityItem.Styles;
 import yesman.epicfight.world.capabilities.item.Style;
 
-@OnlyIn(Dist.CLIENT)
 public class WeaponAttributeScreen extends Screen {
 	private final Map<String, ParameterEditor> weaponAttributeEditors = Maps.newLinkedHashMap();
 	private final Map<String, ParameterEditor> armorAttributeEditors = Maps.newLinkedHashMap();

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/WeaponComboScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/WeaponComboScreen.java
@@ -18,8 +18,6 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.types.AttackAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -39,7 +37,6 @@ import yesman.epicfight.gameasset.ColliderPreset;
 import yesman.epicfight.world.capabilities.item.CapabilityItem.Styles;
 import yesman.epicfight.world.capabilities.item.Style;
 
-@OnlyIn(Dist.CLIENT)
 public class WeaponComboScreen extends Screen {
 	private final Screen parentScreen;
 	private Grid stylesGrid;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/CheckBox.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/CheckBox.java
@@ -8,10 +8,7 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarratedElementType;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class CheckBox extends AbstractWidget implements DataBindingComponent<Boolean, Boolean> {
 	private final Font font;
 	private final boolean defaultVal;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ColorPreviewWidget.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ColorPreviewWidget.java
@@ -4,10 +4,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ColorPreviewWidget extends AbstractWidget implements ResizableComponent {
 	private int packedColor;
 	

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ComboBox.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ComboBox.java
@@ -17,10 +17,7 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ComboBox<T> extends AbstractWidget implements DataBindingComponent<T, T> {
 	private final ComboItemList comboItemList;
 	private final Font font;
@@ -213,7 +210,6 @@ public class ComboBox<T> extends AbstractWidget implements DataBindingComponent<
 		}
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	class ComboItemList extends ObjectSelectionList<ComboItemList.ComboItemEntry> {
 		private final Map<T, ComboItemEntry> entryMap = Maps.newHashMap();
 		
@@ -268,7 +264,6 @@ public class ComboBox<T> extends AbstractWidget implements DataBindingComponent<
 			return this.getY() + 2 - (int) this.getScrollAmount() + row * this.itemHeight;
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class ComboItemEntry extends ObjectSelectionList.Entry<ComboItemList.ComboItemEntry> {
 			private final T item;
 			private final String displayName;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/DataBindingComponent.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/DataBindingComponent.java
@@ -4,10 +4,7 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public interface DataBindingComponent<T, R> extends ResizableComponent {
 	public void reset();
 	public T _getValue();

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/Grid.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/Grid.java
@@ -30,13 +30,10 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.gui.datapack.widgets.PopupBox.PopupBoxProvider;
 import yesman.epicfight.client.gui.datapack.widgets.PopupBox.RegistryPopupBox;
 
-@OnlyIn(Dist.CLIENT)
 public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingComponent<Object, Object> {
 	private final Screen owner;
 	private final Map<String, Column<?, ?>> columns = Maps.newLinkedHashMap();
@@ -570,7 +567,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		return this.getRight() - 6;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class Row extends ObjectSelectionList.Entry<Grid.Row> {
 		private Map<String, Object> values = Maps.newLinkedHashMap();
 		
@@ -719,7 +715,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		return new WildcardColumnBuilder<>(string);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class GridBuilder {
 		private final Minecraft minecraft;
 		private final Screen owner;
@@ -824,7 +819,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static abstract class Column<T, W extends AbstractWidget> {
 		final Function<T, String> toDisplayText;
 		final Consumer<ValueChangeEvent<T>> onValueChanged;
@@ -851,7 +845,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		public abstract ResizableComponent createEditWidget(Screen owner, Font font, int x, int y, int height, int rowposition, Row row, String colName, T value);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class EditBoxColumn extends Column<String, EditBox> {
 		private EditBoxColumn(Function<String, String> toDisplayText, Consumer<ValueChangeEvent<String>> onValueChanged, Consumer<EditBox> onEditWidgetCreate, String defaultVal, boolean editable, int size) {
 			super(toDisplayText, onValueChanged, onEditWidgetCreate, defaultVal, editable, size);
@@ -873,7 +866,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class ComboColumn<T> extends Column<T, ComboBox<T>> {
 		final Collection<T> comboItemCollection;
 		
@@ -896,7 +888,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class RegistryPopupColumn<T> extends Column<T, PopupBox.RegistryPopupBox<T>> {
 		final Registry<T> registry;
 		final Predicate<T> filter;
@@ -923,7 +914,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class PopupColumn<T, P extends PopupBox<T>> extends Column<T, P> {
 		final PopupBoxProvider<T, P> popupBoxProvider;
 		final Predicate<T> filter;
@@ -951,7 +941,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 	}
 	
 	@SuppressWarnings("rawtypes")
-	@OnlyIn(Dist.CLIENT)
 	private static class WildcardColumn<T, W extends AbstractWidget & DataBindingComponent> extends Column<T, W> {
 		Function<Row, AbstractWidget> editWidgetProvider;
 		
@@ -988,7 +977,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public abstract static class ColumnBuilder<T, C extends Column<T, W>, W extends AbstractWidget> {
 		protected final String name;
 		protected Function<T, String> toDisplayText = ParseUtil::nullParam;
@@ -1035,7 +1023,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		protected abstract C create();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class EditBoxColumnBuilder extends ColumnBuilder<String, EditBoxColumn, EditBox> {
 		protected EditBoxColumnBuilder(String name) {
 			super(name);
@@ -1047,7 +1034,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ComboBoxColumnBuilder<T> extends ColumnBuilder<T, ComboColumn<T>, ComboBox<T>> {
 		private final Collection<T> enums;
 		
@@ -1064,7 +1050,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class RegistryPopupColumnBuilder<T> extends ColumnBuilder<T, RegistryPopupColumn<T>, RegistryPopupBox<T>> {
 		final Registry<T> registry;
 		Predicate<T> filter = (item) -> true;
@@ -1086,7 +1071,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class PopupColumnBuilder<T, P extends PopupBox<T>> extends ColumnBuilder<T, PopupColumn<T, P>, P> {
 		final PopupBoxProvider<T, P> popupProvider;
 		Predicate<T> filter = (item) -> true;
@@ -1110,7 +1094,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 	}
 	
 	@SuppressWarnings("rawtypes")
-	@OnlyIn(Dist.CLIENT)
 	public static class WildcardColumnBuilder<T, W extends AbstractWidget & DataBindingComponent> extends ColumnBuilder<T, WildcardColumn<T, W>, W> {
 		Function<Row, AbstractWidget> editWidgetProvider;
 		
@@ -1129,7 +1112,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class PackImporter {
 		List<Map<String, Object>> rows = Lists.newArrayList();
 		
@@ -1144,7 +1126,6 @@ public class Grid extends ObjectSelectionList<Grid.Row> implements DataBindingCo
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ValueChangeEvent<T> {
 		public final Grid grid;
 		public final int rowposition;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/InputComponentList.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/InputComponentList.java
@@ -10,10 +10,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.ContainerObjectSelectionList;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class InputComponentList<T> extends ContainerObjectSelectionList<InputComponentList<T>.InputComponentEntry> {
 	private final Screen owner;
 	private final List<DataBindingComponent<?, ?>> dataBindingComponent = Lists.newArrayList();
@@ -242,7 +239,6 @@ public abstract class InputComponentList<T> extends ContainerObjectSelectionList
 		return super.mouseDragged(mouseX, mouseY, button, dx, dy);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class InputComponentEntry extends ContainerObjectSelectionList.Entry<InputComponentList<T>.InputComponentEntry> {
 		final List<ResizableComponent> children = Lists.newArrayList();
 		

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ModelPreviewer.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ModelPreviewer.java
@@ -52,8 +52,6 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationPlayer;
 import yesman.epicfight.api.animation.Animator;
 import yesman.epicfight.api.animation.Joint;
@@ -96,7 +94,6 @@ import yesman.epicfight.world.capabilities.entitypatch.Faction;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.damagesource.StunType;
 
-@OnlyIn(Dist.CLIENT)
 public class ModelPreviewer extends AbstractWidget implements ResizableComponent, TickableComponent {
 	private final ModelRenderTarget modelRenderTarget;
 	private final List<AssetAccessor<? extends StaticAnimation>> animationsToPlay = Lists.newArrayList();
@@ -685,7 +682,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 		this.modelRenderTarget.destroyBuffers();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class FakeEntityPatch extends LivingEntityPatch<LivingEntity> implements SimulatableObject, ClothSimulatable {
 		public FakeEntityPatch(Armature armature) {
 			super(null);
@@ -814,7 +810,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class NoEntityAnimator extends ClientAnimator {
 		public NoEntityAnimator(LivingEntityPatch<?> entitypatch) {
 			super(entitypatch, NoEntityBaseLayer::new);
@@ -860,7 +855,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 			return this.entitypatch;
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		static class NoEntityAnimationPlayer extends AnimationPlayer {
 			@Override
 			public void tick(LivingEntityPatch<?> entitypatch) {
@@ -898,7 +892,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 			}
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		static class NoEntityLayer extends Layer {
 			public NoEntityLayer(Priority priority) {
 				super(priority, NoEntityAnimationPlayer::new);
@@ -992,7 +985,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 			}
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		static class NoEntityBaseLayer extends Layer.BaseLayer {
 			public NoEntityBaseLayer() {
 				super(NoEntityAnimationPlayer::new);
@@ -1129,7 +1121,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class ModelRenderTarget extends RenderTarget {
 		public ModelRenderTarget() {
 			super(true);
@@ -1167,7 +1158,6 @@ public class ModelPreviewer extends AbstractWidget implements ResizableComponent
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class CustomTrailParticle extends AnimationTrailParticle {
 		@SuppressWarnings("deprecation")
 		protected CustomTrailParticle(Joint joint, AssetAccessor<? extends StaticAnimation> animation, TrailInfo trailInfo) {

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/PopupBox.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/PopupBox.java
@@ -21,8 +21,6 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.StringUtil;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.animation.property.JointMask.JointMaskSet;
@@ -49,7 +47,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class PopupBox<T> extends AbstractWidget implements DataBindingComponent<T, Pair<String, T>> {
 	public static final ResourceLocation POPUP_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/widget/popup_icon.png");
 	
@@ -149,7 +146,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		narrationElementInput.add(NarratedElementType.TITLE, this.createNarrationMessage());
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class RegistryPopupBox<T> extends PopupBox<T> {
 		protected final Registry<T> registry;
 		protected final Consumer<T> onPressRow;
@@ -173,7 +169,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class SoundPopupBox extends RegistryPopupBox<SoundEvent> {
 		public SoundPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, SoundEvent>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, BuiltInRegistries.SOUND_EVENT, (soundevent) -> {
@@ -182,7 +177,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class AnimationPopupBox extends PopupBox<AssetAccessor<? extends StaticAnimation>> {
 		private AssetAccessor<? extends Armature> armature;
 		private AssetAccessor<? extends SkinnedMesh> mesh;
@@ -208,7 +202,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ColliderPopupBox extends PopupBox<Collider> {
 		public ColliderPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, Collider>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (collider) -> ParseUtil.nullOrToString(collider, (c) -> ParseUtil.nullParam(ColliderPreset.getKey(c))), responder);
@@ -222,7 +215,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class WeaponTypePopupBox extends PopupBox<Function<Item, CapabilityItem.Builder<?>>> {
 		public WeaponTypePopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, Function<Item, CapabilityItem.Builder<?>>>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (builder) -> {
@@ -283,7 +275,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class JointMaskPopupBox extends PopupBox<JointMaskSet> {
 		public JointMaskPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, JointMaskSet>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (jointMask) -> ParseUtil.nullParam(JointMaskReloadListener.getKey(jointMask)), responder);
@@ -297,7 +288,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class BuiltinMobpatchPopupBox extends PopupBox<EntityType<?>> {
 		public BuiltinMobpatchPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, EntityType<?>>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (entityType) -> ParseUtil.nullParam(EntityType.getKey(entityType)), responder);
@@ -313,7 +303,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class MeshPopupBox extends PopupBox<AssetAccessor<? extends SkinnedMesh>> {
 		public MeshPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, AssetAccessor<? extends SkinnedMesh>>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (mesh) -> ParseUtil.nullOrToString(mesh, (accessor) -> ParseUtil.nullOrToString(accessor, accessor$2 -> accessor$2.registryName().toString())), responder);
@@ -333,7 +322,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ArmaturePopupBox extends PopupBox<AssetAccessor<Armature>> {
 		public ArmaturePopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, AssetAccessor<Armature>>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (accessor) -> ParseUtil.nullOrToString(accessor, accessor$2 -> accessor$2.registryName().toString()), responder);
@@ -357,7 +345,6 @@ public abstract class PopupBox<T> extends AbstractWidget implements DataBindingC
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class RendererPopupBox extends PopupBox<ResourceLocation> {
 		public RendererPopupBox(Screen owner, Font font, int x1, int x2, int y1, int y2, HorizontalSizing horizontal, VerticalSizing vertical, Component title, Consumer<Pair<String, ResourceLocation>> responder) {
 			super(owner, font, x1, x2, y1, y2, horizontal, vertical, title, (entityType) -> ParseUtil.nullOrToString(entityType, (rl) -> rl.toString()), responder);

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableButton.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableButton.java
@@ -3,10 +3,7 @@ package yesman.epicfight.client.gui.datapack.widgets;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ResizableButton extends Button implements ResizableComponent {
 	public ResizableButton(ResizableButton.Builder builder) {
 		super(builder);
@@ -138,7 +135,6 @@ public class ResizableButton extends Button implements ResizableComponent {
 		return this.getMessage();
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class Builder extends Button.Builder {
 		private int x1;
 		private int x2;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableComponent.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableComponent.java
@@ -6,10 +6,7 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public interface ResizableComponent extends GuiEventListener, NarratableEntry {
 	default void resize(ScreenRectangle screenRectangle) {
 		if (this.getHorizontalSizingOption() != null) {
@@ -56,7 +53,6 @@ public interface ResizableComponent extends GuiEventListener, NarratableEntry {
 	HorizontalSizing getHorizontalSizingOption();
 	VerticalSizing getVerticalSizingOption();
 	
-	@OnlyIn(Dist.CLIENT)
 	public static enum HorizontalSizing {
 		LEFT_WIDTH((component, screenRectangle, v1, v2) -> {
 			component._setX(screenRectangle.left() + v1);
@@ -80,7 +76,6 @@ public interface ResizableComponent extends GuiEventListener, NarratableEntry {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static enum VerticalSizing {
 		TOP_HEIGHT((component, screenRectangle, v1, v2) -> {
 			component._setY(v1);
@@ -104,7 +99,6 @@ public interface ResizableComponent extends GuiEventListener, NarratableEntry {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	interface ResizeFunction {
 		public void resize(ResizableComponent component, ScreenRectangle screenRectangle, int v1, int v2);

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableEditBox.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/ResizableEditBox.java
@@ -6,10 +6,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ResizableEditBox extends EditBox implements DataBindingComponent<String, String> {
 	public ResizableEditBox(Font font, int x1, int x2, int y1, int y2, Component title, HorizontalSizing horizontalSizingOption, VerticalSizing verticalSizingOption) {
 		super(font, x1, y1, x2, y2, title);

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/RowSpliter.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/RowSpliter.java
@@ -5,10 +5,7 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class RowSpliter implements ResizableComponent {
 	private int x;
 	private int y;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/Static.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/Static.java
@@ -9,10 +9,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class Static extends AbstractWidget implements ResizableComponent {
 	private final Screen owner;
 	private final Font font;

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/SubScreenOpenButton.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/SubScreenOpenButton.java
@@ -5,10 +5,7 @@ import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class SubScreenOpenButton extends ResizableButton {
 	protected final Supplier<Screen> subScreenProvider;
 	
@@ -27,7 +24,6 @@ public class SubScreenOpenButton extends ResizableButton {
 		return new SubScreenOpenButton.Builder();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Builder extends ResizableButton.Builder {
 		Supplier<Screen> subScreenProvider;
 		

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
@@ -38,8 +38,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.client.ClientHooks;
 import yesman.epicfight.api.client.neoevent.AttributeIconRegisterEvent;
@@ -59,7 +57,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem.WeaponCategories;
 import yesman.epicfight.world.capabilities.item.WeaponCategory;
 import yesman.epicfight.world.item.SkillBookItem;
 
-@OnlyIn(Dist.CLIENT)
 public class SkillBookScreen extends Screen {
 	private static final Map<WeaponCategory, ItemStack> WEAPON_CATEGORY_ICONS = new HashMap<> ();
 	private static final Map<Holder<Attribute>, TextureInfo> ATTRIBUTE_ICONS = new HashMap<> ();
@@ -402,7 +399,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private class SkillTooltipList extends ObjectSelectionList<SkillTooltipList.TooltipLine> {
 		public SkillTooltipList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
 			super(minecraft, width, height, y, itemHeight);
@@ -427,7 +423,6 @@ public class SkillBookScreen extends Screen {
 			return this.getRight() - 6;
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		private class TooltipLine extends ObjectSelectionList.Entry<SkillTooltipList.TooltipLine> {
 			private final FormattedCharSequence tooltip;
 			
@@ -447,7 +442,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private class AvailableItemsList extends AbstractWidget {
 		private static final float ICON_LENGTH = 21.25F;
 		private final List<WeaponCategory> availableCategories = Lists.newArrayList();
@@ -533,7 +527,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class AttributeIconList extends ContainerObjectSelectionList<AttributeIconList.ProvidingAttributeEntry> {
 		public AttributeIconList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
 			super(minecraft, width, height, y, itemHeight);
@@ -567,7 +560,6 @@ public class SkillBookScreen extends Screen {
 			return this.getX() + 2;
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		private class ProvidingAttributeEntry extends ContainerObjectSelectionList.Entry<AttributeIconList.ProvidingAttributeEntry> {
 			private List<AbstractWidget> icons = Lists.newArrayList();
 			
@@ -627,7 +619,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private static class AttributeIcon extends AbstractWidget {
 		private final TextureInfo textureInfo;
 		
@@ -659,7 +650,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class TextureInfo {
 		final ResourceLocation resourceLocation;
 		final int u;
@@ -676,7 +666,6 @@ public class SkillBookScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private class LearnButton extends Button {
 		protected static final WidgetSprites SPRITES = new WidgetSprites(
 	        ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "widget/skillbook_button"),

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -22,8 +22,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.data.reloader.SkillReloadListener;
 import yesman.epicfight.main.EpicFightMod;
@@ -35,7 +33,6 @@ import yesman.epicfight.skill.SkillSlot;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 import yesman.epicfight.world.capabilities.skill.PlayerSkills;
 
-@OnlyIn(Dist.CLIENT)
 public class SkillEditScreen extends Screen {
 	public static final ResourceLocation EMPTY_SKILL_SLOT_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/empty.png");
 	public static final ResourceLocation SCROLL_ARROW_UP = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/scroll_arrow_up.png");
@@ -293,7 +290,6 @@ public class SkillEditScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class SlotButton extends Button {
         private static final int SIZE = 18;
 		private final SkillContainer skillContainer;
@@ -364,7 +360,6 @@ public class SkillEditScreen extends Screen {
         }
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class ScrollArrow extends Button {
 		final boolean up;
 		
@@ -385,7 +380,6 @@ public class SkillEditScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public class EquipSkillButton extends Button {
         private static final int SPACING = 26;
 

--- a/src/main/java/yesman/epicfight/client/gui/screen/SlotSelectScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SlotSelectScreen.java
@@ -16,12 +16,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.skill.SkillContainer;
 
-@OnlyIn(Dist.CLIENT)
 public class SlotSelectScreen extends Screen {
 	private static final int MAX_ROWS = 2;
 	private static final int MAX_COLUMNS = 3;
@@ -184,7 +181,6 @@ public class SlotSelectScreen extends Screen {
         }
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class ScrollArrow extends Button {
 		final boolean up;
 		
@@ -206,7 +202,6 @@ public class SlotSelectScreen extends Screen {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	class SlotButton extends Button {
 		final ResourceLocation texture;
 		

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightControlOptionScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightControlOptionScreen.java
@@ -6,8 +6,6 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.client.events.engine.RenderEngine;
 import yesman.epicfight.client.gui.widgets.EpicFightOptionList;
@@ -15,7 +13,6 @@ import yesman.epicfight.client.gui.widgets.RewindableButton;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightControlOptionScreen extends EpicFightOptionSubScreen {
 	private EpicFightOptionList optionsList;
 	

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
@@ -7,8 +7,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.transformer.HumanoidModelBaker;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.camera.EpicFightTpsCameraDisableState;
@@ -24,7 +22,6 @@ import yesman.epicfight.main.EpicFightMod;
 import java.io.File;
 import java.io.IOException;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightGraphicOptionScreen extends EpicFightOptionSubScreen {
 	private EpicFightOptionList optionsList;
 	

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightOptionSubScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightOptionSubScreen.java
@@ -5,12 +5,9 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.gui.widgets.EpicFightOptionList;
 import yesman.epicfight.config.ClientConfig;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightOptionSubScreen extends Screen {
 	protected final Screen lastScreen;
 

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/IngameConfigurationScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/IngameConfigurationScreen.java
@@ -7,8 +7,6 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModContainer;
 import yesman.epicfight.client.online.EpicFightServerConnectionHelper;
 import yesman.epicfight.client.ClientEngine;
@@ -18,7 +16,6 @@ import yesman.epicfight.main.AuthenticationHelper;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.main.EpicFightSharedConstants;
 
-@OnlyIn(Dist.CLIENT)
 public class IngameConfigurationScreen extends Screen {
 	protected final Screen parentScreen;
 	

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/ItemsPreferenceScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/ItemsPreferenceScreen.java
@@ -27,8 +27,6 @@ import net.minecraft.world.item.PickaxeItem;
 import net.minecraft.world.item.ShovelItem;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.TridentItem;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen.ItemList.ItemEntry;
 import yesman.epicfight.config.ClientConfig;
@@ -38,7 +36,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.WeaponCapability;
 import yesman.epicfight.world.item.WeaponItem;
 
-@OnlyIn(Dist.CLIENT)
 public class ItemsPreferenceScreen extends Screen {
 	private static final Set<Class<? extends Item>> WEAPON_CATEGORIZED_ITEM_CLASSES = new HashSet<> ();
 	private static final Set<Class<? extends Item>> TOOL_CATEGORIZED_ITEM_CLASSES = new HashSet<> ();
@@ -300,7 +297,6 @@ public class ItemsPreferenceScreen extends Screen {
 		this.minecraft.setScreen(this.parentScreen);
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	class ItemList extends ObjectSelectionList<ItemsPreferenceScreen.ItemList.ItemEntry> {
 		private final Component title;
 		private final Component tooltip;
@@ -384,7 +380,6 @@ public class ItemsPreferenceScreen extends Screen {
 			}).sorted(ItemEntry::compare).forEach(this::addEntry);
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		class ItemEntry extends ObjectSelectionList.Entry<ItemsPreferenceScreen.ItemList.ItemEntry> {
 			private static final Set<Item> UNRENDERABLE_ITEMS = Sets.newHashSet();
 			

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/TPSSettingScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/TPSSettingScreen.java
@@ -12,12 +12,9 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class TPSSettingScreen extends Screen {
     private static final ResourceLocation BUTTON_TEXTURE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/widget/camera_settings.png");
     protected final Screen parentScreen;
@@ -113,7 +110,6 @@ public class TPSSettingScreen extends Screen {
         return true;
     }
 
-    @OnlyIn(Dist.CLIENT)
     private class CameraMoveButton extends Button {
         private final Direction direction;
 
@@ -150,13 +146,11 @@ public class TPSSettingScreen extends Screen {
             guiGraphics.pose().popPose();
         }
 
-        @OnlyIn(Dist.CLIENT)
         public enum Direction {
             UP, DOWN, LEFT, RIGHT
         }
     }
 
-    @OnlyIn(Dist.CLIENT)
     private class ZoomScroll extends AbstractWidget {
         private double scrollPosition;
 

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/UISetupScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/UISetupScreen.java
@@ -6,8 +6,6 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.gui.ScreenCalculations.AlignDirection;
 import yesman.epicfight.client.gui.ScreenCalculations.HorizontalBasis;
 import yesman.epicfight.client.gui.ScreenCalculations.VerticalBasis;
@@ -17,7 +15,6 @@ import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.config.OptionHandler;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class UISetupScreen extends Screen {
 	protected final Screen parentScreen;
 	private UIComponent draggingButton;

--- a/src/main/java/yesman/epicfight/client/gui/screen/overlay/BlendingTextureOverlay.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/overlay/BlendingTextureOverlay.java
@@ -12,10 +12,7 @@ import com.mojang.blaze3d.vertex.VertexFormat;
 
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class BlendingTextureOverlay extends OverlayManager.Overlay {
 	public ResourceLocation texture;
 	private boolean isAlive = true;

--- a/src/main/java/yesman/epicfight/client/gui/screen/overlay/FlickeringOverlay.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/overlay/FlickeringOverlay.java
@@ -2,11 +2,8 @@ package yesman.epicfight.client.gui.screen.overlay;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.events.engine.RenderEngine;
 
-@OnlyIn(Dist.CLIENT)
 public class FlickeringOverlay extends OverlayManager.Overlay {
 	private float time = (float)-Math.PI;
 	private final float deltaTime;

--- a/src/main/java/yesman/epicfight/client/gui/screen/overlay/OverlayManager.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/overlay/OverlayManager.java
@@ -6,10 +6,7 @@ import com.google.common.collect.Maps;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class OverlayManager {
 	private Map<String, OverlayManager.Overlay> overlays = Maps.newHashMap();
 	private double modifiedGamma;

--- a/src/main/java/yesman/epicfight/client/gui/widgets/ColorSlider.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/ColorSlider.java
@@ -13,13 +13,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FastColor;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.ColorUtil;
 import yesman.epicfight.client.gui.datapack.widgets.ResizableComponent;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 
-@OnlyIn(Dist.CLIENT)
 public class ColorSlider extends AbstractSliderButton implements ResizableComponent {
 	public static final int[] RGB_COMBINATIONS = { 0xFFFF0000, 0xFFFFFF00, 0xFF00FF00, 0xFF00FFFF, 0xFF0000FF, 0xFFFF00FF, 0xFFFF0000 };
 	
@@ -153,25 +150,21 @@ public class ColorSlider extends AbstractSliderButton implements ResizableCompon
 		guiGraphics.flush();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	interface Selector {
 		public void render(ColorSlider widget, GuiGraphics guiGraphics);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	interface Background {
 		public void render(ColorSlider widget, GuiGraphics guiGraphics);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	@FunctionalInterface
 	interface Title {
 		public void render(ColorSlider widget, GuiGraphics guiGraphics, Font font);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public enum Style {
 		CLASSIC(
 			(ColorSlider widget, GuiGraphics guiGraphics) -> {

--- a/src/main/java/yesman/epicfight/client/gui/widgets/EpicFightOptionList.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/EpicFightOptionList.java
@@ -12,10 +12,7 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.ContainerObjectSelectionList;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightOptionList extends ContainerObjectSelectionList<EpicFightOptionList.OptionEntry> {
 	public EpicFightOptionList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
         super(minecraft, width, height, y, itemHeight);
@@ -40,7 +37,6 @@ public class EpicFightOptionList extends ContainerObjectSelectionList<EpicFightO
 		return super.getScrollbarPosition() + 46;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	protected static class OptionEntry extends ContainerObjectSelectionList.Entry<EpicFightOptionList.OptionEntry> {
 		final List<AbstractWidget> children;
 		

--- a/src/main/java/yesman/epicfight/client/gui/widgets/RewindableButton.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/RewindableButton.java
@@ -3,10 +3,7 @@ package yesman.epicfight.client.gui.widgets;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class RewindableButton extends Button {
 	protected final Button.OnPress onRewindPress;
 	

--- a/src/main/java/yesman/epicfight/client/gui/widgets/UIComponent.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/UIComponent.java
@@ -14,8 +14,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.gui.ScreenCalculations.AlignDirection;
 import yesman.epicfight.client.gui.ScreenCalculations.HorizontalBasis;
@@ -24,7 +22,6 @@ import yesman.epicfight.client.gui.screen.config.UISetupScreen;
 import yesman.epicfight.client.gui.widgets.UIComponentPop.PassivesUIComponentPop;
 import yesman.epicfight.config.OptionHandler;
 
-@OnlyIn(Dist.CLIENT)
 public class UIComponent extends Button {
 	protected final UISetupScreen parentScreen;
 	protected final ResourceLocation texture;
@@ -213,7 +210,6 @@ public class UIComponent extends Button {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class PassiveUIComponent extends UIComponent {
 		public final OptionHandler<AlignDirection> alignDirection;
 		protected final ResourceLocation texture2;

--- a/src/main/java/yesman/epicfight/client/gui/widgets/UIComponentPop.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/UIComponentPop.java
@@ -18,8 +18,6 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.phys.Vec2;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.gui.ScreenCalculations.AlignDirection;
 import yesman.epicfight.client.gui.ScreenCalculations.HorizontalBasis;
 import yesman.epicfight.client.gui.ScreenCalculations.VerticalBasis;
@@ -27,7 +25,6 @@ import yesman.epicfight.client.gui.widgets.UIComponent.PassiveUIComponent;
 import yesman.epicfight.config.OptionHandler;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class UIComponentPop<T extends UIComponent> extends Screen implements ContainerEventHandler {
 	protected final T parentWidget;
 	protected int width;
@@ -158,7 +155,6 @@ public class UIComponentPop<T extends UIComponent> extends Screen implements Con
 		guiGraphics.fillGradient(j2 - 3, k2 + j + 2, j2 + i + 3, k2 + j + 3, 0, boarderEnd, boarderEnd);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class PassivesUIComponentPop extends UIComponentPop<PassiveUIComponent> {
 		public PassivesUIComponentPop(int width, int height, PassiveUIComponent parentWidget) {
 			super(width, height, parentWidget);

--- a/src/main/java/yesman/epicfight/client/input/CombatKeyMapping.java
+++ b/src/main/java/yesman/epicfight/client/input/CombatKeyMapping.java
@@ -3,8 +3,6 @@ package yesman.epicfight.client.input;
 import com.mojang.blaze3d.platform.InputConstants;
 
 import net.minecraft.client.KeyMapping;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.settings.KeyConflictContext;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.client.ClientEngine;
@@ -35,7 +33,6 @@ import yesman.epicfight.client.ClientEngine;
 ///
 /// Future maintainers should consider refactoring or removing this class
 /// if it becomes problematic or a maintenance burden.
-@OnlyIn(Dist.CLIENT)
 public class CombatKeyMapping extends KeyMapping {
     public CombatKeyMapping(String description, int code, String category) {
         this(description, InputConstants.Type.KEYSYM, code, category);

--- a/src/main/java/yesman/epicfight/client/mesh/CreeperMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/CreeperMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class CreeperMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart torso;

--- a/src/main/java/yesman/epicfight/client/mesh/DragonMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/DragonMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class DragonMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart neck;

--- a/src/main/java/yesman/epicfight/client/mesh/EndermanMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/EndermanMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class EndermanMesh extends SkinnedMesh {
 	public final SkinnedMeshPart headTop;
 	public final SkinnedMeshPart headBottom;

--- a/src/main/java/yesman/epicfight/client/mesh/HoglinMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/HoglinMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class HoglinMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart body;

--- a/src/main/java/yesman/epicfight/client/mesh/HumanoidMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/HumanoidMesh.java
@@ -4,15 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.world.entity.EquipmentSlot;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class HumanoidMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart torso;

--- a/src/main/java/yesman/epicfight/client/mesh/IronGolemMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/IronGolemMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class IronGolemMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart chest;

--- a/src/main/java/yesman/epicfight/client/mesh/PiglinMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/PiglinMesh.java
@@ -4,15 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.world.entity.EquipmentSlot;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class PiglinMesh extends HumanoidMesh {
 	public PiglinMesh(Map<String, Number[]> arrayMap, Map<MeshPartDefinition, List<VertexBuilder>> parts, SkinnedMesh parent, RenderProperties properties) {
 		super(arrayMap, parts, parent, properties);

--- a/src/main/java/yesman/epicfight/client/mesh/RavagerMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/RavagerMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class RavagerMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart body;

--- a/src/main/java/yesman/epicfight/client/mesh/SpiderMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/SpiderMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class SpiderMesh extends SkinnedMesh {
 	public final SkinnedMeshPart head;
 	public final SkinnedMeshPart middleStomach;

--- a/src/main/java/yesman/epicfight/client/mesh/VexMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/VexMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class VexMesh extends SkinnedMesh {
 	public final SkinnedMeshPart torso;
 	public final SkinnedMeshPart head;

--- a/src/main/java/yesman/epicfight/client/mesh/VillagerMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/VillagerMesh.java
@@ -4,15 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.world.entity.EquipmentSlot;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class VillagerMesh extends HumanoidMesh {
 	public VillagerMesh(Map<String, Number[]> arrayMap, Map<MeshPartDefinition, List<VertexBuilder>> parts, SkinnedMesh parent, RenderProperties properties) {
 		super(arrayMap, parts, parent, properties);

--- a/src/main/java/yesman/epicfight/client/mesh/WitherMesh.java
+++ b/src/main/java/yesman/epicfight/client/mesh/WitherMesh.java
@@ -3,13 +3,10 @@ package yesman.epicfight.client.mesh;
 import java.util.List;
 import java.util.Map;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 
-@OnlyIn(Dist.CLIENT)
 public class WitherMesh extends SkinnedMesh {
 	public final SkinnedMeshPart centerHead;
 	public final SkinnedMeshPart leftHead;

--- a/src/main/java/yesman/epicfight/client/particle/AbstractTrailParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/AbstractTrailParticle.java
@@ -21,12 +21,9 @@ import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.animation.property.TrailInfo;
 import yesman.epicfight.world.capabilities.entitypatch.EntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class AbstractTrailParticle<T extends EntityPatch<?>> extends TextureSheetParticle {
 	protected final TrailInfo trailInfo;
 	protected final T owner;
@@ -217,7 +214,6 @@ public abstract class AbstractTrailParticle<T extends EntityPatch<?>> extends Te
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class TrailEdge {
 		public final Vec3 start;
 		public final Vec3 end;

--- a/src/main/java/yesman/epicfight/client/particle/AirBurstParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/AirBurstParticle.java
@@ -6,14 +6,11 @@ import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.ClassicMesh;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class AirBurstParticle extends TexturedCustomModelParticle {
 	public static final ResourceLocation AIR_BURST_PARTICLE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/air_burst.png");
 	
@@ -40,7 +37,6 @@ public class AirBurstParticle extends TexturedCustomModelParticle {
 		this.scale += 0.5F;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/AnimationTrailParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/AnimationTrailParticle.java
@@ -19,8 +19,6 @@ import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.AnimationPlayer;
@@ -42,7 +40,6 @@ import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 
-@OnlyIn(Dist.CLIENT)
 public class AnimationTrailParticle extends AbstractTrailParticle<LivingEntityPatch<?>> {
 	protected final Joint joint;
 	protected final AssetAccessor<? extends StaticAnimation> animation;
@@ -267,7 +264,6 @@ public class AnimationTrailParticle extends AbstractTrailParticle<LivingEntityPa
 		this.makeTrailEdges(finalStartPositions, finalEndPositions, visibleTrail ? this.trailEdges : this.invisibleTrailEdges);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/AshDirectionalParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/AshDirectionalParticle.java
@@ -6,16 +6,12 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class AshDirectionalParticle extends BaseAshSmokeParticle {
 	protected AshDirectionalParticle(ClientLevel pLevel, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed, float pQuadSizeMultiplier, SpriteSet pSprites) {
 		super(pLevel, pX, pY, pZ, 0.1F, -0.1F, 0.1F, pXSpeed, pYSpeed, pZSpeed, pQuadSizeMultiplier, pSprites, 0.5F, 5, 0.0F, false);
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet sprites;
 

--- a/src/main/java/yesman/epicfight/client/particle/BladeRushParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/BladeRushParticle.java
@@ -5,10 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class BladeRushParticle extends HitParticle {
 	public BladeRushParticle(ClientLevel world, double x, double y, double z, SpriteSet animatedSprite) {
 		super(world, x, y, z, animatedSprite);
@@ -19,7 +16,6 @@ public class BladeRushParticle extends HitParticle {
 		this.quadSize = 2.0F;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 

--- a/src/main/java/yesman/epicfight/client/particle/BlastParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/BlastParticle.java
@@ -8,10 +8,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class BlastParticle extends HitParticle {
 	public BlastParticle(ClientLevel world, double x, double y, double z, SpriteSet animatedSprite) {
 		super(world, x, y, z, animatedSprite);
@@ -40,7 +37,6 @@ public class BlastParticle extends HitParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 

--- a/src/main/java/yesman/epicfight/client/particle/BloodParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/BloodParticle.java
@@ -10,11 +10,8 @@ import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.config.ClientConfig;
 
-@OnlyIn(Dist.CLIENT)
 public class BloodParticle extends TextureSheetParticle {
 	protected BloodParticle(ClientLevel world, double x, double y, double z, double motionX, double motionY, double motionZ) {
 		super(world, x, y, z, motionX, motionY, motionZ);
@@ -31,7 +28,6 @@ public class BloodParticle extends TextureSheetParticle {
 		return ParticleRenderType.PARTICLE_SHEET_OPAQUE;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 		

--- a/src/main/java/yesman/epicfight/client/particle/CatharsisParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/CatharsisParticle.java
@@ -7,10 +7,7 @@ import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class CatharsisParticle extends TextureSheetParticle {
 	private final SpriteSet sprites;
 	
@@ -35,7 +32,6 @@ public class CatharsisParticle extends TextureSheetParticle {
 		return ParticleRenderType.PARTICLE_SHEET_TRANSLUCENT;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet sprites;
 

--- a/src/main/java/yesman/epicfight/client/particle/CustomModelParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/CustomModelParticle.java
@@ -11,13 +11,10 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.utils.math.QuaternionUtils;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class CustomModelParticle<M extends Mesh> extends Particle {
 	protected final AssetAccessor<M> particleMeshProvider;
 	protected float pitch;

--- a/src/main/java/yesman/epicfight/client/particle/CutParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/CutParticle.java
@@ -7,11 +7,8 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.config.ClientConfig;
 
-@OnlyIn(Dist.CLIENT)
 public class CutParticle extends HitParticle {
 	public CutParticle(ClientLevel world, double x, double y, double z, SpriteSet animatedSprite) {
 		super(world, x, y, z, animatedSprite);
@@ -27,7 +24,6 @@ public class CutParticle extends HitParticle {
 		this.roll = angle;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 

--- a/src/main/java/yesman/epicfight/client/particle/DustParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/DustParticle.java
@@ -9,11 +9,8 @@ import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.registry.entries.EpicFightParticles;
 
-@OnlyIn(Dist.CLIENT)
 public class DustParticle extends TextureSheetParticle {
 	private final DustParticle.PhysicsType physicsType;
 	
@@ -59,7 +56,6 @@ public class DustParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ExpansiveMetaParticle extends NoRenderParticle {
 		public ExpansiveMetaParticle(ClientLevel level, double x, double y, double z, double radius, int density) {
 			super(level, x, y, z);
@@ -74,7 +70,6 @@ public class DustParticle extends TextureSheetParticle {
 			}
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		public static class Provider implements ParticleProvider<SimpleParticleType> {
 			@Override
 			public Particle createParticle(SimpleParticleType typeIn, ClientLevel worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
@@ -84,7 +79,6 @@ public class DustParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ContractiveMetaParticle extends NoRenderParticle {
 		private final double radius;
 		private final int density;
@@ -112,7 +106,6 @@ public class DustParticle extends TextureSheetParticle {
 			}
 		}
 		
-		@OnlyIn(Dist.CLIENT)
 		public static class Provider implements ParticleProvider<SimpleParticleType> {
 			@Override
 			public Particle createParticle(SimpleParticleType typeIn, ClientLevel worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
@@ -122,7 +115,6 @@ public class DustParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ExpansiveDustProvider implements ParticleProvider<SimpleParticleType> {
 		protected SpriteSet sprite;
 		
@@ -138,7 +130,6 @@ public class DustParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ContractiveDustProvider implements ParticleProvider<SimpleParticleType> {
 		protected SpriteSet sprite;
 		
@@ -154,7 +145,6 @@ public class DustParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class NormalDustProvider implements ParticleProvider<SimpleParticleType> {
 		protected SpriteSet sprite;
 		

--- a/src/main/java/yesman/epicfight/client/particle/EnderParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/EnderParticle.java
@@ -7,10 +7,7 @@ import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class EnderParticle extends TextureSheetParticle {
 	private EnderParticle.Usage usage;
 	
@@ -55,7 +52,6 @@ public class EnderParticle extends TextureSheetParticle {
 		DRAGON_BREATH_FLAME, ENDERMAN_DEATH
     }
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class EndermanDeathEmitProvider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 
@@ -72,7 +68,6 @@ public class EnderParticle extends TextureSheetParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class BreathFlameProvider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 

--- a/src/main/java/yesman/epicfight/client/particle/EntityAfterimageParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/EntityAfterimageParticle.java
@@ -19,8 +19,6 @@ import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.client.model.SkinnedMesh;
@@ -31,7 +29,6 @@ import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class EntityAfterimageParticle extends CustomModelParticle<SkinnedMesh> {
 	protected final EntitySnapshot<?> entitySnapshot;
 	protected final Consumer<EntityAfterimageParticle> ticktask;
@@ -117,7 +114,6 @@ public class EntityAfterimageParticle extends CustomModelParticle<SkinnedMesh> {
 		poseStack.popPose();
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class WhiteAfterimageParticle extends EntityAfterimageParticle {
 		public WhiteAfterimageParticle(ClientLevel level, double x, double y, double z, double xd, double yd, double zd, EntitySnapshot<?> entitySnapshot, Consumer<EntityAfterimageParticle> ticktask) {
 			super(level, x, y, z, xd, yd, zd, entitySnapshot, ticktask);
@@ -141,7 +137,6 @@ public class EntityAfterimageParticle extends CustomModelParticle<SkinnedMesh> {
 		}
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class AdrenalineParticleProvider implements ParticleProvider<SimpleParticleType> {
 		public Particle createParticle(SimpleParticleType type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
 			Entity entity = level.getEntity((int) Double.doubleToLongBits(xSpeed));
@@ -169,7 +164,6 @@ public class EntityAfterimageParticle extends CustomModelParticle<SkinnedMesh> {
 		}
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class WhiteAfterimageProvider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/EpicFightParticleRenderTypes.java
+++ b/src/main/java/yesman/epicfight/client/particle/EpicFightParticleRenderTypes.java
@@ -19,10 +19,7 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightParticleRenderTypes {
 	public static final ParticleRenderType PARTICLE_MODEL_NO_NORMAL = new ParticleRenderType() {
 		@Override

--- a/src/main/java/yesman/epicfight/client/particle/EviscerateParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/EviscerateParticle.java
@@ -6,12 +6,9 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.registry.entries.EpicFightParticles;
 
-@OnlyIn(Dist.CLIENT)
 public class EviscerateParticle extends NoRenderParticle {
 	protected EviscerateParticle(ClientLevel world, double x, double y, double z, double motionX, double motionY, double motionZ) {
 		super(world, x, y, z, motionX, motionY, motionZ);
@@ -24,7 +21,6 @@ public class EviscerateParticle extends NoRenderParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/FeatherParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/FeatherParticle.java
@@ -7,8 +7,6 @@ import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
 public class FeatherParticle extends TextureSheetParticle {
 	protected FeatherParticle(ClientLevel level, double x, double y, double z, double dx, double dy, double dz) {
@@ -33,7 +31,6 @@ public class FeatherParticle extends TextureSheetParticle {
 		return ParticleRenderType.PARTICLE_SHEET_OPAQUE;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet sprite;
 

--- a/src/main/java/yesman/epicfight/client/particle/ForceFieldEndParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/ForceFieldEndParticle.java
@@ -12,12 +12,9 @@ import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.events.engine.RenderEngine;
 import yesman.epicfight.client.renderer.LightningRenderHelper;
 
-@OnlyIn(Dist.CLIENT)
 public class ForceFieldEndParticle extends Particle {
 	private boolean init;
 	
@@ -52,7 +49,6 @@ public class ForceFieldEndParticle extends Particle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/ForceFieldParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/ForceFieldParticle.java
@@ -9,8 +9,6 @@ import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.ClassicMesh;
 import yesman.epicfight.api.client.model.Meshes;
@@ -19,7 +17,6 @@ import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.entitypatch.boss.enderdragon.DragonCrystalLinkPhase;
 
-@OnlyIn(Dist.CLIENT)
 public class ForceFieldParticle extends TexturedCustomModelParticle {
 	private LivingEntityPatch<?> caster;
 	
@@ -68,7 +65,6 @@ public class ForceFieldParticle extends TexturedCustomModelParticle {
 		return 240 | k << 16;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/GroundSlamParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/GroundSlamParticle.java
@@ -12,13 +12,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.level.block.FractureBlockState;
 
-@OnlyIn(Dist.CLIENT)
 public class GroundSlamParticle extends NoRenderParticle {
 	protected GroundSlamParticle(ClientLevel level, double x, double y, double z, double dx, double dy, double dz, BlockPos bp, BlockState bs) {
 		super(level, x, y, z, dx, dy, dz);
@@ -59,7 +56,6 @@ public class GroundSlamParticle extends NoRenderParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/HitBluntParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/HitBluntParticle.java
@@ -5,11 +5,8 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.registry.entries.EpicFightParticles;
 
-@OnlyIn(Dist.CLIENT)
 public class HitBluntParticle extends HitParticle {
 	public HitBluntParticle(ClientLevel world, double x, double y, double z, double argX, double argY, double argZ, SpriteSet animatedSprite) {
 		super(world, x, y, z, animatedSprite);
@@ -29,7 +26,6 @@ public class HitBluntParticle extends HitParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet spriteSet;
 		public Provider(SpriteSet spriteSet) {

--- a/src/main/java/yesman/epicfight/client/particle/HitCutParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/HitCutParticle.java
@@ -5,11 +5,8 @@ import net.minecraft.client.particle.NoRenderParticle;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.registry.entries.EpicFightParticles;
 
-@OnlyIn(Dist.CLIENT)
 public class HitCutParticle extends NoRenderParticle {
 	public HitCutParticle(ClientLevel world, double x, double y, double z, double width, double height, double _null) {
 		super(world, x, y, z);
@@ -28,7 +25,6 @@ public class HitCutParticle extends NoRenderParticle {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {

--- a/src/main/java/yesman/epicfight/client/particle/HitParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/HitParticle.java
@@ -4,10 +4,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class HitParticle extends TextureSheetParticle {
 	protected final SpriteSet animatedSprite;
 	

--- a/src/main/java/yesman/epicfight/client/particle/LaserParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/LaserParticle.java
@@ -15,13 +15,10 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.ClassicMesh;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.utils.math.QuaternionUtils;
 
-@OnlyIn(Dist.CLIENT)
 public class LaserParticle extends CustomModelParticle<ClassicMesh> {
 	private final float length;
 	private final float xRot;
@@ -74,7 +71,6 @@ public class LaserParticle extends CustomModelParticle<ClassicMesh> {
 		return EpicFightParticleRenderTypes.TRANSLUCENT_GLOWING;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType typeIn, ClientLevel level, double startX, double startY, double startZ, double endX, double endY, double endZ) {

--- a/src/main/java/yesman/epicfight/client/particle/ProjectileTrailParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/ProjectileTrailParticle.java
@@ -16,8 +16,6 @@ import net.minecraft.world.entity.projectile.Arrow;
 import net.minecraft.world.entity.projectile.SpectralArrow;
 import net.minecraft.world.entity.projectile.ThrownTrident;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.animation.property.TrailInfo;
 import yesman.epicfight.api.physics.bezier.CubicBezierCurve;
 import yesman.epicfight.api.utils.math.MathUtils;
@@ -28,7 +26,6 @@ import yesman.epicfight.registry.entries.EpicFightParticles;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.projectile.ProjectilePatch;
 
-@OnlyIn(Dist.CLIENT)
 public class ProjectileTrailParticle extends AbstractTrailParticle<ProjectilePatch<AbstractArrow>> {
 	protected float lastXRot;
 	protected float lastYRot;
@@ -153,7 +150,6 @@ public class ProjectileTrailParticle extends AbstractTrailParticle<ProjectilePat
 		this.lastYRot = yRot;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		public static final TrailInfo ARROW_TRAIL_DEFAULT
 			= TrailInfo

--- a/src/main/java/yesman/epicfight/client/particle/TexturedCustomModelParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/TexturedCustomModelParticle.java
@@ -5,12 +5,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.ClassicMesh;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class TexturedCustomModelParticle extends CustomModelParticle<ClassicMesh> {
 	protected final ResourceLocation texture;
 	

--- a/src/main/java/yesman/epicfight/client/particle/TsunamiSplashParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/TsunamiSplashParticle.java
@@ -7,10 +7,7 @@ import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.SimpleParticleType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class TsunamiSplashParticle extends TextureSheetParticle {
 	private final SpriteSet sprites;
 
@@ -34,7 +31,6 @@ public class TsunamiSplashParticle extends TextureSheetParticle {
 		super.tick();
 	}
 
-	@OnlyIn(Dist.CLIENT)
 	public static class Provider implements ParticleProvider<SimpleParticleType> {
 		private final SpriteSet sprites;
 

--- a/src/main/java/yesman/epicfight/client/renderer/EpicFightRenderTypes.java
+++ b/src/main/java/yesman/epicfight/client/renderer/EpicFightRenderTypes.java
@@ -24,11 +24,8 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.InventoryMenu;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public final class EpicFightRenderTypes extends RenderType {
 	public static RenderType makeTriangulated(RenderType renderType) {
 		if (renderType.mode() == VertexFormat.Mode.TRIANGLES) {
@@ -124,7 +121,6 @@ public final class EpicFightRenderTypes extends RenderType {
 	// Custom shards
 	protected static final RenderStateShard.ShaderStateShard PARTICLE_SHADER = new RenderStateShard.ShaderStateShard(GameRenderer::getParticleShader);
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class ShaderColorStateShard extends RenderStateShard {
 		private Vector4f color;
 		
@@ -147,7 +143,6 @@ public final class EpicFightRenderTypes extends RenderType {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public static class MutableCompositeState extends CompositeState {
 		private ShaderColorStateShard shaderColorState = new ShaderColorStateShard(new Vector4f(1.0F));
 		
@@ -180,7 +175,6 @@ public final class EpicFightRenderTypes extends RenderType {
 	        return new EpicFightRenderTypes.MutableCompositeState.MutableCompositeStateBuilder();
 	    }
 		
-		@OnlyIn(Dist.CLIENT)
 		public static class MutableCompositeStateBuilder {
 			private RenderStateShard.EmptyTextureStateShard textureState = RenderStateShard.NO_TEXTURE;
 			private RenderStateShard.ShaderStateShard shaderState = RenderStateShard.NO_SHADER;

--- a/src/main/java/yesman/epicfight/client/renderer/EpicFightShaders.java
+++ b/src/main/java/yesman/epicfight/client/renderer/EpicFightShaders.java
@@ -9,13 +9,11 @@ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 @EventBusSubscriber(modid = EpicFightMod.MODID, value = Dist.CLIENT)
 public class EpicFightShaders {
 	public static ShaderInstance positionColorNormalShader;

--- a/src/main/java/yesman/epicfight/client/renderer/FakeBlockRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/FakeBlockRenderer.java
@@ -6,10 +6,7 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public interface FakeBlockRenderer {
 	public void render(Camera camera, PoseStack poseStack, MultiBufferSource buffers, Level level, BlockPos bp, float r, float g, float b, float a);
 }

--- a/src/main/java/yesman/epicfight/client/renderer/FirstPersonRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/FirstPersonRenderer.java
@@ -25,8 +25,6 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.PlayerSkin;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.Pose;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -42,7 +40,6 @@ import yesman.epicfight.client.renderer.patched.layer.WearableItemLayer;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.mixin.client.MixinLivingEntityRenderer;
 
-@OnlyIn(Dist.CLIENT)
 public class FirstPersonRenderer extends PatchedLivingEntityRenderer<LocalPlayer, LocalPlayerPatch, PlayerModel<LocalPlayer>, LivingEntityRenderer<LocalPlayer, PlayerModel<LocalPlayer>>, HumanoidMesh> {
 	public FirstPersonRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/LayerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/LayerRenderer.java
@@ -3,12 +3,9 @@ package yesman.epicfight.client.renderer;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.renderer.patched.layer.PatchedLayer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public interface LayerRenderer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> {
 	public void addPatchedLayer(Class<?> originalLayerClass, PatchedLayer<E, T, M, ? extends RenderLayer<E, M>> patchedLayer);
 	

--- a/src/main/java/yesman/epicfight/client/renderer/LightningRenderHelper.java
+++ b/src/main/java/yesman/epicfight/client/renderer/LightningRenderHelper.java
@@ -9,11 +9,8 @@ import org.joml.Vector3f;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.QuaternionUtils;
 
-@OnlyIn(Dist.CLIENT)
 public class LightningRenderHelper {
 	private static final float HALF_SQRT_3 = (float)(Math.sqrt(3.0D) / 2.0D);
 	

--- a/src/main/java/yesman/epicfight/client/renderer/RenderingTool.java
+++ b/src/main/java/yesman/epicfight/client/renderer/RenderingTool.java
@@ -3,11 +3,8 @@ package yesman.epicfight.client.renderer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.Vec3f;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderingTool {
 	public static void drawQuad(PoseStack poseStack, VertexConsumer vertexBuilder, Vec3f pos, float size, float r, float g, float b) {
 		vertexBuilder.addVertex(poseStack.last().pose(), pos.x + size, pos.y, pos.z + size).setColor(r, g, b, 1.0F);

--- a/src/main/java/yesman/epicfight/client/renderer/VanillaFakeBlockRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/VanillaFakeBlockRenderer.java
@@ -23,11 +23,8 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.model.data.ModelData;
 
-@OnlyIn(Dist.CLIENT)
 public class VanillaFakeBlockRenderer implements FakeBlockRenderer {
 	private static final Direction[] DIRECTIONS = Direction.values();
 	

--- a/src/main/java/yesman/epicfight/client/renderer/blockentity/FractureBlockRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/blockentity/FractureBlockRenderer.java
@@ -12,13 +12,10 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.world.level.block.entity.FractureBlockEntity;
 
-@OnlyIn(Dist.CLIENT)
 public class FractureBlockRenderer implements BlockEntityRenderer<FractureBlockEntity> {
 	private final BlockRenderDispatcher blockRenderDispatcher;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/entity/DroppedNetherStarRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/entity/DroppedNetherStarRenderer.java
@@ -9,11 +9,8 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.client.renderer.entity.ItemEntityRenderer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.renderer.LightningRenderHelper;
 
-@OnlyIn(Dist.CLIENT)
 public class DroppedNetherStarRenderer extends ItemEntityRenderer {
 	public DroppedNetherStarRenderer(Context context) {
 		super(context);

--- a/src/main/java/yesman/epicfight/client/renderer/entity/NoopLivingEntityRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/entity/NoopLivingEntityRenderer.java
@@ -8,12 +8,9 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.event.RenderLivingEvent;
 import net.neoforged.neoforge.common.NeoForge;
 
-@OnlyIn(Dist.CLIENT)
 public class NoopLivingEntityRenderer<T extends LivingEntity> extends LivingEntityRenderer<T, EntityModel<T>> {
 	public NoopLivingEntityRenderer(Context context, float shadowRadius) {
 		super(context, null, shadowRadius);

--- a/src/main/java/yesman/epicfight/client/renderer/entity/WitherGhostRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/entity/WitherGhostRenderer.java
@@ -3,12 +3,9 @@ package yesman.epicfight.client.renderer.entity;
 import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.renderer.patched.entity.PWitherRenderer;
 import yesman.epicfight.world.entity.WitherGhostClone;
 
-@OnlyIn(Dist.CLIENT)
 public class WitherGhostRenderer extends NoopLivingEntityRenderer<WitherGhostClone> {
 	public WitherGhostRenderer(Context context) {
 		super(context, 1.0F);

--- a/src/main/java/yesman/epicfight/client/renderer/entity/WitherSkeletonMinionRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/entity/WitherSkeletonMinionRenderer.java
@@ -4,11 +4,8 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.client.renderer.entity.WitherSkeletonRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.monster.WitherSkeleton;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class WitherSkeletonMinionRenderer extends WitherSkeletonRenderer {
 	private static final ResourceLocation WITHER_SKELETON_LOCATION = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/entity/wither_skeleton_minion.png");
 

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCreeperRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCreeperRenderer.java
@@ -7,15 +7,12 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Creeper;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.mesh.CreeperMesh;
 import yesman.epicfight.world.capabilities.entitypatch.mob.CreeperPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PCreeperRenderer extends PatchedLivingEntityRenderer<Creeper, CreeperPatch, CreeperModel<Creeper>, CreeperRenderer, CreeperMesh> {
 	public PCreeperRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCustomEntityRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCustomEntityRenderer.java
@@ -10,8 +10,6 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.NeoForge;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.SkinnedMesh;
@@ -19,7 +17,6 @@ import yesman.epicfight.api.client.neoevent.PrepareModelEvent;
 import yesman.epicfight.api.model.Armature;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PCustomEntityRenderer extends PatchedEntityRenderer<LivingEntity, LivingEntityPatch<LivingEntity>, EntityRenderer<LivingEntity>, SkinnedMesh> {
 	private final AssetAccessor<SkinnedMesh> mesh;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCustomHumanoidEntityRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PCustomHumanoidEntityRenderer.java
@@ -9,8 +9,6 @@ import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.Pose;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -24,7 +22,6 @@ import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.client.renderer.patched.layer.WearableItemLayer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PCustomHumanoidEntityRenderer<AM extends HumanoidMesh> extends PatchedLivingEntityRenderer<LivingEntity, LivingEntityPatch<LivingEntity>, HumanoidModel<LivingEntity>, LivingEntityRenderer<LivingEntity, HumanoidModel<LivingEntity>>, AM> {
 	private final AssetAccessor<AM> mesh;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PDrownedRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PDrownedRenderer.java
@@ -6,14 +6,11 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.layers.DrownedOuterLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Drowned;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.client.renderer.patched.layer.OuterLayerRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.DrownedPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PDrownedRenderer extends PHumanoidRenderer<Drowned, DrownedPatch, DrownedModel<Drowned>, DrownedRenderer, HumanoidMesh> {
 	public PDrownedRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(Meshes.BIPED, context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PEnderDragonRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PEnderDragonRenderer.java
@@ -13,8 +13,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.enderdragon.phases.DragonPhaseInstance;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.model.Armature;
@@ -27,7 +25,6 @@ import yesman.epicfight.world.capabilities.entitypatch.boss.enderdragon.DragonCr
 import yesman.epicfight.world.capabilities.entitypatch.boss.enderdragon.EnderDragonPatch;
 import yesman.epicfight.world.capabilities.entitypatch.boss.enderdragon.PatchedPhases;
 
-@OnlyIn(Dist.CLIENT)
 public class PEnderDragonRenderer extends PatchedEntityRenderer<EnderDragon, EnderDragonPatch, EnderDragonRenderer, DragonMesh> {
 	private static final ResourceLocation DRAGON_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/enderdragon/dragon.png");
 	private static final ResourceLocation DRAGON_EXPLODING_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/enderdragon/dragon_exploding.png");

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PEndermanRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PEndermanRenderer.java
@@ -7,15 +7,12 @@ import net.minecraft.client.renderer.entity.layers.EnderEyesLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.EnderMan;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.EndermanMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedEyesLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.EndermanPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PEndermanRenderer extends PatchedLivingEntityRenderer<EnderMan, EndermanPatch, EndermanModel<EnderMan>, EndermanRenderer, EndermanMesh> {
 	private static final ResourceLocation ENDERMAN_EYE_TEXTURE = ResourceLocation.withDefaultNamespace("textures/entity/enderman/enderman_eyes.png");
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PHoglinRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PHoglinRenderer.java
@@ -6,8 +6,6 @@ import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.monster.hoglin.HoglinBase;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.Pose;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -18,7 +16,6 @@ import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.client.mesh.HoglinMesh;
 import yesman.epicfight.world.capabilities.entitypatch.MobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PHoglinRenderer<E extends Mob & HoglinBase, T extends MobPatch<E>> extends PatchedLivingEntityRenderer<E, T, HoglinModel<E>, MobRenderer<E, HoglinModel<E>>, HoglinMesh> {
 	public PHoglinRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PHumanoidRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PHumanoidRenderer.java
@@ -9,8 +9,6 @@ import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.Pose;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -24,7 +22,6 @@ import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.client.renderer.patched.layer.WearableItemLayer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PHumanoidRenderer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends HumanoidModel<E>, R extends LivingEntityRenderer<E, M>, AM extends HumanoidMesh> extends PatchedLivingEntityRenderer<E, T, M, R, AM> {
 	private final AssetAccessor<AM> mesh;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PIllagerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PIllagerRenderer.java
@@ -7,8 +7,6 @@ import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.AbstractIllager;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.HumanoidMesh;
@@ -16,7 +14,6 @@ import yesman.epicfight.client.renderer.patched.layer.PatchedHeadLayer;
 import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.world.capabilities.entitypatch.MobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PIllagerRenderer<E extends AbstractIllager, T extends MobPatch<E>> extends PatchedLivingEntityRenderer<E, T, IllagerModel<E>, IllagerRenderer<E>, HumanoidMesh> {
 	public PIllagerRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PIronGolemRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PIronGolemRenderer.java
@@ -6,15 +6,12 @@ import net.minecraft.client.renderer.entity.IronGolemRenderer;
 import net.minecraft.client.renderer.entity.layers.IronGolemCrackinessLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.IronGolem;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.IronGolemMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedGolemCrackLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.IronGolemPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PIronGolemRenderer extends PatchedLivingEntityRenderer<IronGolem, IronGolemPatch, IronGolemModel<IronGolem>, IronGolemRenderer, IronGolemMesh> {
 	public PIronGolemRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PPlayerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PPlayerRenderer.java
@@ -10,8 +10,6 @@ import net.minecraft.client.renderer.entity.layers.PlayerItemInHandLayer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.client.resources.PlayerSkin;
 import net.minecraft.world.entity.EntityType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.HumanoidMesh;
@@ -21,7 +19,6 @@ import yesman.epicfight.client.renderer.patched.layer.PatchedCapeLayer;
 import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClientPlayerPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PPlayerRenderer extends PHumanoidRenderer<AbstractClientPlayer, AbstractClientPlayerPatch<AbstractClientPlayer>, PlayerModel<AbstractClientPlayer>, PlayerRenderer, HumanoidMesh> {
 	public PPlayerRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(Meshes.BIPED, context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PRavagerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PRavagerRenderer.java
@@ -5,14 +5,11 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.RavagerRenderer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Ravager;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.RavagerMesh;
 import yesman.epicfight.world.capabilities.entitypatch.mob.RavagerPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PRavagerRenderer extends PatchedLivingEntityRenderer<Ravager, RavagerPatch, RavagerModel, RavagerRenderer, RavagerMesh> {
 	public PRavagerRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PSpiderRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PSpiderRenderer.java
@@ -7,15 +7,12 @@ import net.minecraft.client.renderer.entity.layers.SpiderEyesLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Spider;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.SpiderMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedEyesLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.SpiderPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PSpiderRenderer extends PatchedLivingEntityRenderer<Spider, SpiderPatch<Spider>, SpiderModel<Spider>, SpiderRenderer<Spider>, SpiderMesh> {
 	private static final ResourceLocation SPIDER_EYE_TEXTURE = ResourceLocation.withDefaultNamespace("textures/entity/spider_eyes.png");
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PStrayRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PStrayRenderer.java
@@ -6,14 +6,11 @@ import net.minecraft.client.renderer.entity.HumanoidMobRenderer;
 import net.minecraft.client.renderer.entity.layers.SkeletonClothingLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.PathfinderMob;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.client.renderer.patched.layer.EmptyLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.SkeletonPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PStrayRenderer extends PHumanoidRenderer<PathfinderMob, SkeletonPatch<PathfinderMob>, HumanoidModel<PathfinderMob>, HumanoidMobRenderer<PathfinderMob, HumanoidModel<PathfinderMob>>, HumanoidMesh> {
 	public PStrayRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(Meshes.SKELETON, context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PVexRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PVexRenderer.java
@@ -6,15 +6,12 @@ import net.minecraft.client.renderer.entity.VexRenderer;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Vex;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.VexMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.VexPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PVexRenderer extends PatchedLivingEntityRenderer<Vex, VexPatch, VexModel, VexRenderer, VexMesh> {
 	public PVexRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PVindicatorRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PVindicatorRenderer.java
@@ -9,13 +9,10 @@ import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.AbstractIllager;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.world.capabilities.entitypatch.MobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PVindicatorRenderer extends PIllagerRenderer<AbstractIllager, MobPatch<AbstractIllager>> {
 	public PVindicatorRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitchRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitchRenderer.java
@@ -6,15 +6,12 @@ import net.minecraft.client.renderer.entity.WitchRenderer;
 import net.minecraft.client.renderer.entity.layers.WitchItemLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.Witch;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.VillagerMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedItemInHandLayer;
 import yesman.epicfight.world.capabilities.entitypatch.mob.WitchPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PWitchRenderer extends PatchedLivingEntityRenderer<Witch, WitchPatch, WitchModel<Witch>, WitchRenderer, VillagerMesh> {
 	public PWitchRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitherRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitherRenderer.java
@@ -14,8 +14,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.model.Armature;
@@ -24,7 +22,6 @@ import yesman.epicfight.client.renderer.patched.layer.PatchedWitherArmorLayer;
 import yesman.epicfight.mixin.client.MixinLivingEntityRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.boss.WitherPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PWitherRenderer extends PatchedLivingEntityRenderer<WitherBoss, WitherPatch, WitherBossModel<WitherBoss>, WitherBossRenderer, WitherMesh> {
 	public static final ResourceLocation WITHER_INVULNERABLE_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/wither/wither_invulnerable.png");
 	private static final ResourceLocation WITHER_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/wither/wither.png");

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitherSkeletonMinionRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PWitherSkeletonMinionRenderer.java
@@ -5,8 +5,6 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.HumanoidMobRenderer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.PathfinderMob;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.JointTransform;
 import yesman.epicfight.api.animation.Pose;
 import yesman.epicfight.api.client.model.Meshes;
@@ -16,7 +14,6 @@ import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.world.capabilities.entitypatch.HumanoidMobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PWitherSkeletonMinionRenderer extends PHumanoidRenderer<PathfinderMob, HumanoidMobPatch<PathfinderMob>, HumanoidModel<PathfinderMob>, HumanoidMobRenderer<PathfinderMob, HumanoidModel<PathfinderMob>>, HumanoidMesh> {
 	public PWitherSkeletonMinionRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(Meshes.SKELETON, context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PZombieVillagerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PZombieVillagerRenderer.java
@@ -6,14 +6,11 @@ import net.minecraft.client.renderer.entity.ZombieVillagerRenderer;
 import net.minecraft.client.renderer.entity.layers.VillagerProfessionLayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.ZombieVillager;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.client.mesh.VillagerMesh;
 import yesman.epicfight.client.renderer.patched.layer.PatchedVillagerProfessionLayer;
 import yesman.epicfight.world.capabilities.entitypatch.MobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PZombieVillagerRenderer extends PHumanoidRenderer<ZombieVillager, MobPatch<ZombieVillager>, ZombieVillagerModel<ZombieVillager>, ZombieVillagerRenderer, VillagerMesh> {
 	public PZombieVillagerRenderer(EntityRendererProvider.Context context, EntityType<?> entityType) {
 		super(Meshes.VILLAGER_ZOMBIE, context, entityType);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PatchedEntityRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PatchedEntityRenderer.java
@@ -6,8 +6,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.event.RenderNameTagEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import yesman.epicfight.api.animation.Pose;
@@ -20,7 +18,6 @@ import yesman.epicfight.api.utils.math.QuaternionUtils;
 import yesman.epicfight.mixin.client.MixinEntityRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class PatchedEntityRenderer<E extends LivingEntity, T extends LivingEntityPatch<E>, R extends EntityRenderer<E>, AM extends SkinnedMesh> {
 	public void render(E entity, T entitypatch, R renderer, MultiBufferSource buffer, PoseStack poseStack, int packedLight, float partialTick) {
 		RenderNameTagEvent renderNameplateEvent = new RenderNameTagEvent(entity, entity.getDisplayName(), renderer, poseStack, buffer, packedLight, partialTick);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PatchedLivingEntityRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PatchedLivingEntityRenderer.java
@@ -32,8 +32,6 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.NeoForge;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.neoevent.PatchedRenderersEvent;
@@ -51,7 +49,6 @@ import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.mixin.client.MixinLivingEntityRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class PatchedLivingEntityRenderer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends LivingEntityRenderer<E, M>, AM extends SkinnedMesh> extends PatchedEntityRenderer<E, T, R, AM> implements LayerRenderer<E, T, M> {
 	protected final Map<Class<?>, PatchedLayer<E, T, M, ? extends RenderLayer<E, M>>> patchedLayers = Maps.newHashMap();
 	protected final List<PatchedLayer<E, T, M, ? extends RenderLayer<E, M>>> customLayers = Lists.newArrayList();

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/PresetRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/PresetRenderer.java
@@ -29,8 +29,6 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.NeoForge;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.SkinnedMesh;
@@ -48,7 +46,6 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 /**
  * This class is for LivingEntity with renderer that doesn't extend LivingEntityRenderer (e.g. Geckolib renderer based entities)
  */
-@OnlyIn(Dist.CLIENT)
 public class PresetRenderer extends PatchedEntityRenderer<LivingEntity, LivingEntityPatch<LivingEntity>, EntityRenderer<LivingEntity>, SkinnedMesh> implements LayerRenderer<LivingEntity, LivingEntityPatch<LivingEntity>, EntityModel<LivingEntity>> {
 	private final LivingEntityRenderer<LivingEntity, EntityModel<LivingEntity>> presetRenderer;
 	protected final Map<Class<?>, PatchedLayer<LivingEntity, LivingEntityPatch<LivingEntity>, EntityModel<LivingEntity>, ? extends RenderLayer<LivingEntity, EntityModel<LivingEntity>>>> patchedLayers = Maps.newHashMap();

--- a/src/main/java/yesman/epicfight/client/renderer/patched/entity/WitherGhostCloneRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/entity/WitherGhostCloneRenderer.java
@@ -7,8 +7,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationPlayer;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.animation.Layer;
@@ -19,7 +17,6 @@ import yesman.epicfight.client.renderer.entity.WitherGhostRenderer;
 import yesman.epicfight.world.capabilities.entitypatch.boss.WitherGhostPatch;
 import yesman.epicfight.world.entity.WitherGhostClone;
 
-@OnlyIn(Dist.CLIENT)
 public class WitherGhostCloneRenderer extends PatchedEntityRenderer<WitherGhostClone, WitherGhostPatch, WitherGhostRenderer, WitherMesh> {
 	@Override
 	public void render(WitherGhostClone entity, WitherGhostPatch entitypatch, WitherGhostRenderer renderer, MultiBufferSource buffer, PoseStack poseStack, int packedLight, float partialTicks) {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/EpicFightItemProperties.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/EpicFightItemProperties.java
@@ -3,14 +3,11 @@ package yesman.epicfight.client.renderer.patched.item;
 import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.registry.entries.EpicFightItems;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.item.SkillBookItem;
 
-@OnlyIn(Dist.CLIENT)
 public class EpicFightItemProperties {
 	public static void registerItemProperties() {
 		ItemProperties.register(EpicFightItems.SKILLBOOK.get(), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill"), (itemstack, level, entity, i) -> {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderFilledMap.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderFilledMap.java
@@ -11,13 +11,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderFilledMap extends RenderItemBase {
 	private static final RenderType MAP_BACKGROUND = RenderType.text(ResourceLocation.parse("textures/map/map_background.png"));
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderItemBase.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderItemBase.java
@@ -16,8 +16,6 @@ import net.minecraft.util.GsonHelper;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.client.animation.property.TrailInfo;
 import yesman.epicfight.api.utils.math.MathUtils;
@@ -26,7 +24,6 @@ import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.model.armature.types.ToolHolderArmature;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderItemBase {
 	protected static final Map<String, OpenMatrix4f> GLOBAL_MAINHAND_ITEM_TRANSFORMS = ImmutableMap.<String, OpenMatrix4f>builder()
 		.put("Tool_L", new OpenMatrix4f().translate(0F, 0F, -0.13F).rotateDeg(-90.0F, Vec3f.X_AXIS).unmodifiable())

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderKatana.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderKatana.java
@@ -12,14 +12,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.registry.entries.EpicFightItems;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderKatana extends RenderItemBase {
 	private final ItemStack sheathStack;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderShield.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderShield.java
@@ -9,13 +9,10 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderShield extends RenderItemBase {
 	public RenderShield(JsonElement jsonElement) {
 		super(jsonElement);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderTrident.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderTrident.java
@@ -8,15 +8,12 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.Joint;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderTrident extends RenderItemBase {
 	private static final OpenMatrix4f TRANSFORM_WHEN_AIMING = new OpenMatrix4f().rotateDeg(-80F, Vec3f.X_AXIS).translate(0.0F, 0.1F, 0.0F).unmodifiable();
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderTwoHandedRangedWeapon.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/RenderTwoHandedRangedWeapon.java
@@ -7,13 +7,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderTwoHandedRangedWeapon extends RenderItemBase {
 	public RenderTwoHandedRangedWeapon(JsonElement jsonElement) {
 		super(jsonElement);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/EmptyLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/EmptyLayer.java
@@ -5,12 +5,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class EmptyLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> extends UniqueLayer<E, T, M> {
 	// Do nothing
 	@Override

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/LayerUtil.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/LayerUtil.java
@@ -19,8 +19,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.NeoForge;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.Meshes;
@@ -34,7 +32,6 @@ import yesman.epicfight.main.EpicFightSharedConstants;
 import yesman.epicfight.registry.entries.EpicFightConditions;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class LayerUtil {
 	@FunctionalInterface
 	public interface LayerProvider<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends LivingEntityRenderer<E, M>, AM extends SkinnedMesh> {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/ModelRenderLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/ModelRenderLayer.java
@@ -6,14 +6,11 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class ModelRenderLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends RenderLayer<E, M>, AM extends SkinnedMesh> extends PatchedLayer<E, T, M, R> {
 	protected final AssetAccessor<AM> mesh;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/OuterLayerRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/OuterLayerRenderer.java
@@ -9,14 +9,11 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.DrownedOuterLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.monster.Drowned;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.world.capabilities.entitypatch.mob.DrownedPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class OuterLayerRenderer extends ModelRenderLayer<Drowned, DrownedPatch, DrownedModel<Drowned>, DrownedOuterLayer<Drowned>, HumanoidMesh> {
 	public static final ResourceLocation DROWNED_OUTER_LAYER = ResourceLocation.withDefaultNamespace("textures/entity/zombie/drowned_outer_layer.png");
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedArrowLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedArrowLayer.java
@@ -12,11 +12,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.Arrow;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedArrowLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends PlayerModel<E>> extends PatchedStuckInBodyLayer<E, T, M, ArrowLayer<E, M>> {
 	private final EntityRenderDispatcher dispatcher;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedBeeStingerLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedBeeStingerLayer.java
@@ -13,11 +13,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedBeeStingerLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends PlayerModel<E>> extends PatchedStuckInBodyLayer<E, T, M, BeeStingerLayer<E, M>> {
 	private static final ResourceLocation BEE_STINGER_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/bee/bee_stinger.png");
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedCapeLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedCapeLayer.java
@@ -22,8 +22,6 @@ import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.client.online.EpicSkins;
 import yesman.epicfight.api.client.physics.cloth.ClothSimulator;
@@ -38,7 +36,6 @@ import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClie
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.gameasset.Armatures;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedCapeLayer extends PatchedLayer<AbstractClientPlayer, AbstractClientPlayerPatch<AbstractClientPlayer>, PlayerModel<AbstractClientPlayer>, CapeLayer> {
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedElytraLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedElytraLayer.java
@@ -7,14 +7,11 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.ElytraLayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedElytraLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> extends PatchedLayer<E, T, M, ElytraLayer<E, M>> {
 	@Override
 	protected void renderLayer(T entitypatch, E livingentity, ElytraLayer<E, M> vanillaLayer, PoseStack poseStack, MultiBufferSource buffer, int packedLight, OpenMatrix4f[] poses, float bob, float yRot, float xRot, float partialTicks) {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedEyesLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedEyesLayer.java
@@ -9,14 +9,11 @@ import net.minecraft.client.renderer.entity.layers.EyesLayer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedEyesLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, AM extends SkinnedMesh> extends ModelRenderLayer<E, T, M, EyesLayer<E, M>, AM> {
 	private final RenderType renderType;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedGolemCrackLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedGolemCrackLayer.java
@@ -13,14 +13,11 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Crackiness;
 import net.minecraft.world.entity.animal.IronGolem;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.mesh.IronGolemMesh;
 import yesman.epicfight.world.capabilities.entitypatch.mob.IronGolemPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedGolemCrackLayer extends ModelRenderLayer<IronGolem, IronGolemPatch, IronGolemModel<IronGolem>, IronGolemCrackinessLayer, IronGolemMesh> {
 	private static final Map<Crackiness.Level, ResourceLocation> CRACK_MAP = ImmutableMap.of(
 			Crackiness.Level.LOW, ResourceLocation.withDefaultNamespace("textures/entity/iron_golem/iron_golem_crackiness_low.png"),

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedHeadLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedHeadLayer.java
@@ -10,14 +10,11 @@ import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedHeadLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E> & HeadedModel> extends PatchedLayer<E, T, M, CustomHeadLayer<E, M>> {
 	@Override
 	protected void renderLayer(T entitypatch, E entityliving, CustomHeadLayer<E, M> vanillaLayer, PoseStack postStack, MultiBufferSource buffer, int packedLightIn, OpenMatrix4f[] poses, float bob, float yRot, float xRot, float partialTicks) {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedItemInHandLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedItemInHandLayer.java
@@ -9,13 +9,10 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.events.engine.RenderEngine;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedItemInHandLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> extends PatchedLayer<E, T, M, RenderLayer<E, M>> {
 	@Override
 	protected void renderLayer(T entitypatch, E entityliving, RenderLayer<E, M> vanillaLayer, PoseStack postStack, MultiBufferSource buffer, int packedLight, OpenMatrix4f[] poses, float bob, float yRot, float xRot, float partialTicks) {

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedLayer.java
@@ -8,12 +8,9 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class PatchedLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends RenderLayer<E, M>> {
 	public void renderLayer(E entityliving, T entitypatch, RenderLayer<E, M> vanillaLayer, PoseStack poseStack, MultiBufferSource buffer, int packedLight, OpenMatrix4f[] poses, float bob, float yRot, float xRot, float partialTicks) {
 		this.renderLayer(entitypatch, entityliving, this.castLayer(vanillaLayer), poseStack, buffer, packedLight, poses, bob, yRot, xRot, partialTicks);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedStuckInBodyLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedStuckInBodyLayer.java
@@ -9,15 +9,12 @@ import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class PatchedStuckInBodyLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends PlayerModel<E>, R extends StuckInBodyLayer<E, M>> extends PatchedLayer<E, T, M, R> {
 	private static final Vec3f VECTOR = new Vec3f();
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedVillagerProfessionLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedVillagerProfessionLayer.java
@@ -14,14 +14,11 @@ import net.minecraft.world.entity.monster.ZombieVillager;
 import net.minecraft.world.entity.npc.VillagerData;
 import net.minecraft.world.entity.npc.VillagerDataHolder;
 import net.minecraft.world.entity.npc.VillagerProfession;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.mesh.VillagerMesh;
 import yesman.epicfight.world.capabilities.entitypatch.MobPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedVillagerProfessionLayer extends ModelRenderLayer<ZombieVillager, MobPatch<ZombieVillager>, ZombieVillagerModel<ZombieVillager>, VillagerProfessionLayer<ZombieVillager, ZombieVillagerModel<ZombieVillager>>, VillagerMesh> {
 	public PatchedVillagerProfessionLayer() {
 		super(Meshes.VILLAGER_ZOMBIE);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedWitherArmorLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/PatchedWitherArmorLayer.java
@@ -10,8 +10,6 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.animation.AnimationPlayer;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.client.model.Meshes;
@@ -21,7 +19,6 @@ import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 import yesman.epicfight.gameasset.Animations;
 import yesman.epicfight.world.capabilities.entitypatch.boss.WitherPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class PatchedWitherArmorLayer extends ModelRenderLayer<WitherBoss, WitherPatch, WitherBossModel<WitherBoss>, WitherArmorLayer, WitherMesh> {
 	private static final ResourceLocation WITHER_ARMOR_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/wither/wither_armor.png");
 	

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/RenderOriginalModelLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/RenderOriginalModelLayer.java
@@ -7,14 +7,11 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class RenderOriginalModelLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> extends PatchedLayer<E, T, M, RenderLayer<E, M>> {
 	private final String parentJoint;
 	private final Vec3f vec;

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/UniqueLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/UniqueLayer.java
@@ -6,12 +6,9 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class UniqueLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>> extends PatchedLayer<E, T, M, RenderLayer<E, M>> {
 	// parameter vanillaLayer is always null
 	@Override

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/WearableItemLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/WearableItemLayer.java
@@ -35,8 +35,6 @@ import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.armortrim.ArmorTrim;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import yesman.epicfight.api.asset.AssetAccessor;
@@ -54,7 +52,6 @@ import yesman.epicfight.client.mesh.HumanoidMesh;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class WearableItemLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends HumanoidModel<E>, AM extends HumanoidMesh> extends ModelRenderLayer<E, T, M, HumanoidArmorLayer<E, M, M>, AM> {
 	private static final Map<ResourceLocation, SkinnedMesh> ARMOR_MODELS = new HashMap<> ();
 	private static final Map<String, ResourceLocation> EPICFIGHT_OVERRIDING_TEXTURES = new HashMap<> ();

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/WrappedConditionalLayer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/WrappedConditionalLayer.java
@@ -10,12 +10,9 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
-@OnlyIn(Dist.CLIENT)
 public class WrappedConditionalLayer<E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends RenderLayer<E, M>> extends PatchedLayer<E, T, M, R> {
 	private final PatchedLayer<E, T, M, R> layer;
 	private final Function<LivingEntityPatch<?>, Boolean> renderCondition;

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/ComputeShaderSetup.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/ComputeShaderSetup.java
@@ -24,8 +24,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.ShaderInstance;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.VertexBuilder;
 import yesman.epicfight.api.model.Armature;
@@ -38,7 +36,6 @@ import yesman.epicfight.client.renderer.shader.compute.backend.buffers.StaticSSB
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 import yesman.epicfight.main.EpicFightSharedConstants;
 
-@OnlyIn(Dist.CLIENT)
 public abstract class ComputeShaderSetup {
     protected static final int WORK_GROUP_SIZE = 128;
     
@@ -224,12 +221,10 @@ public abstract class ComputeShaderSetup {
 		format.clearBufferState();
     }
     
-	@OnlyIn(Dist.CLIENT)
 	public interface BufferUploadable {
 		public void store(FloatBuffer buffer);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public interface MeshPartBuffer {
 		// For vanilla compute shader
 		int vboId();
@@ -238,7 +233,6 @@ public abstract class ComputeShaderSetup {
 		int partIdx();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
     // VertexData
 	public record VertexObj(
 		float px, float py, float pz,
@@ -264,7 +258,6 @@ public abstract class ComputeShaderSetup {
 		}
 	}
 	
-    @OnlyIn(Dist.CLIENT)
     public record ElemInfo(int poolId, int partId) implements BufferUploadable {
         @Override
         public void store(FloatBuffer buffer) {
@@ -273,7 +266,6 @@ public abstract class ComputeShaderSetup {
         }
     }
     
-    @OnlyIn(Dist.CLIENT)
     public record WeightInfo(int jtId, float weight) implements BufferUploadable {
         @Override
         public void store(FloatBuffer buffer) {
@@ -282,7 +274,6 @@ public abstract class ComputeShaderSetup {
         }
     }
     
-    @OnlyIn(Dist.CLIENT)
     public static class PartBuffer implements MeshPartBuffer {
         private final int partIdx;
         

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/VanillaComputeShaderSetup.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/VanillaComputeShaderSetup.java
@@ -21,8 +21,6 @@ import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.OutlineBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.SkinnedMesh.SkinnedMeshPart;
 import yesman.epicfight.api.model.Armature;
@@ -31,7 +29,6 @@ import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.client.renderer.shader.compute.backend.program.ComputeProgram;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 
-@OnlyIn(Dist.CLIENT)
 public class VanillaComputeShaderSetup extends ComputeShaderSetup {
 	
 	public VanillaComputeShaderSetup(SkinnedMesh skinnedMesh) {

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/DynamicSSBO.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/DynamicSSBO.java
@@ -12,10 +12,7 @@ import org.lwjgl.opengl.GL43C;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class DynamicSSBO<T> implements Closeable, IArrayBufferProxy {
     public final T[] src;
     public final short srcSize;
@@ -89,7 +86,6 @@ public class DynamicSSBO<T> implements Closeable, IArrayBufferProxy {
         }
     }
     
-    @OnlyIn(Dist.CLIENT)
     public enum DataMode {
         STATIC(GL15C.GL_STATIC_DRAW), DYNAMIC(GL15C.GL_DYNAMIC_DRAW), STREAM(GL15C.GL_STREAM_DRAW);
     	

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/IArrayBufferProxy.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/IArrayBufferProxy.java
@@ -1,9 +1,6 @@
 package yesman.epicfight.client.renderer.shader.compute.backend.buffers;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public interface IArrayBufferProxy {
     void updateFromTo(int from, int to);
     void bindBufferBase(int binding);

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/OutputSSBO.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/OutputSSBO.java
@@ -8,10 +8,7 @@ import org.lwjgl.opengl.GL43C;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class OutputSSBO implements Closeable {
     public final int glSSBO;
     

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/StaticSSBO.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/buffers/StaticSSBO.java
@@ -13,10 +13,7 @@ import org.lwjgl.opengl.GL43C;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class StaticSSBO<T> implements Closeable {
     public final int glSSBO;
     private int lastBinding = -1;

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/BarrierFlags.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/BarrierFlags.java
@@ -2,10 +2,7 @@ package yesman.epicfight.client.renderer.shader.compute.backend.program;
 
 import org.lwjgl.opengl.GL46C;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public enum BarrierFlags {
     SHADER_STORAGE	(GL46C.GL_SHADER_STORAGE_BARRIER_BIT),
     ATOMIC_COUNTER	(GL46C.GL_ATOMIC_COUNTER_BARRIER_BIT),

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/ComputeProgram.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/ComputeProgram.java
@@ -4,10 +4,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL46;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ComputeProgram {
     private final int programHandle;
     private final int barrierFlags;

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/ComputeShader.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/ComputeShader.java
@@ -10,10 +10,7 @@ import static org.lwjgl.opengl.GL20.glGetShaderi;
 import static org.lwjgl.opengl.GL20.glShaderSource;
 import static org.lwjgl.opengl.GL43.GL_COMPUTE_SHADER;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class ComputeShader {
     public final int shaderId;
 

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/Uniform.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/backend/program/Uniform.java
@@ -5,10 +5,7 @@ import org.joml.Matrix4f;
 import org.lwjgl.opengl.GL46C;
 import org.lwjgl.system.MemoryStack;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 
-@OnlyIn(Dist.CLIENT)
 public class Uniform {
     private final int programHandle;
     private final int uniformLocation;

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/iris/IrisComputeShaderSetup.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/iris/IrisComputeShaderSetup.java
@@ -26,8 +26,6 @@ import net.irisshaders.iris.vertices.IrisVertexFormats;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.OutlineBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.api.client.model.SkinnedMesh.SkinnedMeshPart;
 import yesman.epicfight.api.model.Armature;
@@ -38,7 +36,6 @@ import yesman.epicfight.client.renderer.shader.compute.backend.buffers.StaticSSB
 import yesman.epicfight.client.renderer.shader.compute.backend.program.ComputeProgram;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 
-@OnlyIn(Dist.CLIENT)
 public class IrisComputeShaderSetup extends ComputeShaderSetup {
 	protected StaticSSBO<Float> midUVBO;
 	

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderLoader.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderLoader.java
@@ -8,13 +8,10 @@ import java.util.Optional;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceProvider;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.client.renderer.shader.compute.backend.program.BarrierFlags;
 import yesman.epicfight.client.renderer.shader.compute.backend.program.ComputeProgram;
 import yesman.epicfight.client.renderer.shader.compute.backend.program.ComputeShader;
 
-@OnlyIn(Dist.CLIENT)
 public final class ComputeShaderLoader {
 	public static ComputeProgram loadComputeShaderProgram(ResourceProvider resourceManager, ResourceLocation resourceLocation, BarrierFlags... barrierFlags) throws IllegalStateException {
 		Optional<Resource> resource = resourceManager.getResource(resourceLocation);
@@ -62,7 +59,6 @@ public final class ComputeShaderLoader {
 		return program;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
     public record ShaderSource(String source, int barrierFlags) {
     }
     

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderProvider.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderProvider.java
@@ -7,8 +7,6 @@ import java.util.function.Function;
 import org.lwjgl.opengl.GL33C;
 
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 import yesman.epicfight.api.client.model.SkinnedMesh;
 import yesman.epicfight.client.renderer.shader.compute.ComputeShaderSetup;
@@ -20,7 +18,6 @@ import yesman.epicfight.client.renderer.shader.compute.backend.program.ComputePr
 import yesman.epicfight.client.renderer.shader.compute.iris.IrisComputeShaderSetup;
 import yesman.epicfight.main.EpicFightMod;
 
-@OnlyIn(Dist.CLIENT)
 public class ComputeShaderProvider {
     public static ComputeProgram meshComputeVanilla;
     public static ComputeProgram meshComputeIris;

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/AbstractClientPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/AbstractClientPlayerPatch.java
@@ -13,8 +13,6 @@ import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.tick.EntityTickEvent;
@@ -49,7 +47,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem;
 
 import java.util.Optional;
 
-@OnlyIn(Dist.CLIENT)
 public class AbstractClientPlayerPatch<T extends AbstractClientPlayer> extends PlayerPatch<T> implements ClothSimulatable {
 	private Item prevHeldItem;
 	private Item prevHeldItemOffHand;

--- a/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
+++ b/src/main/java/yesman/epicfight/client/world/capabilites/entitypatch/player/LocalPlayerPatch.java
@@ -14,8 +14,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.entity.PartEntity;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
@@ -59,7 +57,6 @@ import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import java.util.List;
 import java.util.Optional;
 
-@OnlyIn(Dist.CLIENT)
 public class LocalPlayerPatch extends AbstractClientPlayerPatch<LocalPlayer> {
 	private final Minecraft minecraft;
     private final FirstPersonLayer firstPersonLayer = new FirstPersonLayer();
@@ -466,7 +463,6 @@ public class LocalPlayerPatch extends AbstractClientPlayerPatch<LocalPlayer> {
         }
     }
 
-	@OnlyIn(Dist.CLIENT)
 	public class FirstPersonLayer extends Layer {
 		private final TransformSheet linkCameraTransform = new TransformSheet(List.of(new Keyframe(0.0F, JointTransform.empty()), new Keyframe(Float.MAX_VALUE, JointTransform.empty())));
 		

--- a/src/main/java/yesman/epicfight/compat/azurelib/client/AzureArmorTransformer.java
+++ b/src/main/java/yesman/epicfight/compat/azurelib/client/AzureArmorTransformer.java
@@ -31,8 +31,6 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SingleGroupVertexBuilder;
@@ -44,7 +42,6 @@ import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
 
-@OnlyIn(Dist.CLIENT)
 public class AzureArmorTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> HEAD = new SimpleTransformer(9);
 	static final PartTransformer<GeoCube> LEFT_FEET = new SimpleTransformer(5);
@@ -55,7 +52,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> RIGHT_LEG = new LimbPartTransformer(1, 2, 3, 0.375F, true, AABB.ofSize(new Vec3(0.15D, 0.375D, 0), 0.5D, 0.85D, 0.5D));
 	static final PartTransformer<GeoCube> CHEST = new ChestPartTransformer(8, 7, 1.125F, AABB.ofSize(new Vec3(0, 1.125D, 0), 0.9D, 0.85D, 0.45D));
 	
-	@OnlyIn(Dist.CLIENT)
 	static class GeoModelPartition {
 		final PartTransformer<GeoCube> partTransformer;
 		final GeoBone geoBone;
@@ -216,7 +212,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		poseStack.popPose();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class SimpleTransformer extends PartTransformer<GeoCube> {
 		final int jointId;
 		
@@ -252,7 +247,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ChestPartTransformer extends PartTransformer<GeoCube> {
 		static final float X_PLANE = 0.0F;
 		static final VertexWeight[] WEIGHT_ALONG_Y = { new VertexWeight(13.6666F, 0.230F, 0.770F), new VertexWeight(15.8333F, 0.254F, 0.746F), new VertexWeight(18.0F, 0.5F, 0.5F), new VertexWeight(20.1666F, 0.744F, 0.256F), new VertexWeight(22.3333F, 0.770F, 0.230F)};
@@ -442,7 +436,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class LimbPartTransformer extends PartTransformer<GeoCube> {
 		final int upperJoint;
 		final int lowerJoint;
@@ -648,7 +641,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		return new ModelPart.Vertex(translatedPosition.x(), translatedPosition.y(), translatedPosition.z(), original.texU(), original.texV());
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedVertex extends ModelPart.Vertex {
 		final Vec3i jointId;
 		final Vec3f weight;
@@ -672,7 +664,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedPolygon {
 		public final AnimatedVertex[] animatedVertexPositions;
 		public final Vector3f normal;
@@ -718,7 +709,6 @@ public class AzureArmorTransformer extends HumanoidModelTransformer {
 		return partAnimation;
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public record AzureArmorMeshPartDefinition(String partName, List<String> path, OpenMatrix4f invertedParentTransform, GeoBone root) implements MeshPartDefinition {
 		public static MeshPartDefinition of(String partName) {
 			return new AzureArmorMeshPartDefinition(partName, null, null, null);

--- a/src/main/java/yesman/epicfight/compat/azurelib/client/AzureModelTransformer.java
+++ b/src/main/java/yesman/epicfight/compat/azurelib/client/AzureModelTransformer.java
@@ -31,8 +31,6 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.Mesh;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SingleGroupVertexBuilder;
@@ -44,7 +42,6 @@ import yesman.epicfight.api.utils.math.OpenMatrix4f;
 import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
 
-@OnlyIn(Dist.CLIENT)
 public class AzureModelTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> HEAD = new SimpleTransformer(9);
 	static final PartTransformer<GeoCube> LEFT_FEET = new SimpleTransformer(5);
@@ -55,7 +52,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> RIGHT_LEG = new LimbPartTransformer(1, 2, 3, 0.375F, true, AABB.ofSize(new Vec3(0.15D, 0.375D, 0), 0.5D, 0.85D, 0.5D));
 	static final PartTransformer<GeoCube> CHEST = new ChestPartTransformer(8, 7, 1.125F, AABB.ofSize(new Vec3(0, 1.125D, 0), 0.9D, 0.85D, 0.45D));
 	
-	@OnlyIn(Dist.CLIENT)
 	static class GeoModelPartition {
 		final PartTransformer<GeoCube> partTransformer;
 		final GeoBone geoBone;
@@ -216,7 +212,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		poseStack.popPose();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class SimpleTransformer extends PartTransformer<GeoCube> {
 		final int jointId;
 		
@@ -252,7 +247,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ChestPartTransformer extends PartTransformer<GeoCube> {
 		static final float X_PLANE = 0.0F;
 		static final VertexWeight[] WEIGHT_ALONG_Y = { new VertexWeight(13.6666F, 0.230F, 0.770F), new VertexWeight(15.8333F, 0.254F, 0.746F), new VertexWeight(18.0F, 0.5F, 0.5F), new VertexWeight(20.1666F, 0.744F, 0.256F), new VertexWeight(22.3333F, 0.770F, 0.230F)};
@@ -442,7 +436,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class LimbPartTransformer extends PartTransformer<GeoCube> {
 		final int upperJoint;
 		final int lowerJoint;
@@ -648,7 +641,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		return new ModelPart.Vertex(translatedPosition.x(), translatedPosition.y(), translatedPosition.z(), original.texU(), original.texV());
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedVertex extends ModelPart.Vertex {
 		final Vec3i jointId;
 		final Vec3f weight;
@@ -672,7 +664,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedPolygon {
 		public final AnimatedVertex[] animatedVertexPositions;
 		public final Vector3f normal;
@@ -692,7 +683,6 @@ public class AzureModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public record AzureMeshPartDefinition(String partName, List<String> path, OpenMatrix4f invertedParentTransform, GeoBone root) implements MeshPartDefinition {
 		public static MeshPartDefinition of(String partName) {
 			return new AzureMeshPartDefinition(partName, null, null, null);

--- a/src/main/java/yesman/epicfight/compat/geckolib/client/GeoModelTransformer.java
+++ b/src/main/java/yesman/epicfight/compat/geckolib/client/GeoModelTransformer.java
@@ -23,8 +23,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import software.bernie.geckolib.animatable.GeoAnimatable;
 import software.bernie.geckolib.animation.state.BoneSnapshot;
@@ -45,7 +43,6 @@ import yesman.epicfight.api.utils.math.Vec2f;
 import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.compat.geckolib.mixin.MixinGeoArmorRenderer;
 
-@OnlyIn(Dist.CLIENT)
 public class GeoModelTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> HEAD = new SimpleTransformer(9);
 	static final PartTransformer<GeoCube> LEFT_FEET = new SimpleTransformer(5);
@@ -56,7 +53,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 	static final PartTransformer<GeoCube> RIGHT_LEG = new LimbPartTransformer(1, 2, 3, 0.375F, true, AABB.ofSize(new Vec3(0.15D, 0.375D, 0), 0.5D, 0.85D, 0.5D));
 	static final PartTransformer<GeoCube> CHEST = new ChestPartTransformer(8, 7, 1.125F, AABB.ofSize(new Vec3(0, 1.125D, 0), 0.9D, 0.85D, 0.45D));
 	
-	@OnlyIn(Dist.CLIENT)
 	static class GeoModelPartition {
 		final PartTransformer<GeoCube> partTransformer;
 		final GeoBone geoBone;
@@ -222,7 +218,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		poseStack.popPose();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class SimpleTransformer extends PartTransformer<GeoCube> {
 		final int jointId;
 		
@@ -258,7 +253,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ChestPartTransformer extends PartTransformer<GeoCube> {
 		static final float X_PLANE = 0.0F;
 		static final VertexWeight[] WEIGHT_ALONG_Y = { new VertexWeight(13.6666F, 0.230F, 0.770F), new VertexWeight(15.8333F, 0.254F, 0.746F), new VertexWeight(18.0F, 0.5F, 0.5F), new VertexWeight(20.1666F, 0.744F, 0.256F), new VertexWeight(22.3333F, 0.770F, 0.230F)};
@@ -448,7 +442,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class LimbPartTransformer extends PartTransformer<GeoCube> {
 		final int upperJoint;
 		final int lowerJoint;
@@ -654,7 +647,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		return new ModelPart.Vertex(translatedPosition.x(), translatedPosition.y(), translatedPosition.z(), original.texU(), original.texV());
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedVertex extends ModelPart.Vertex {
 		final Vec3i jointId;
 		final Vec3f weight;
@@ -678,7 +670,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedPolygon {
 		public final AnimatedVertex[] animatedVertexPositions;
 		public final Vector3f normal;
@@ -698,7 +689,6 @@ public class GeoModelTransformer extends HumanoidModelTransformer {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public record GeoMeshPartDefinition(String partName, List<String> path, OpenMatrix4f invertedParentTransform, GeoBone root) implements MeshPartDefinition {
 		public static MeshPartDefinition of(String partName) {
 			return new GeoMeshPartDefinition(partName, null, null, null);

--- a/src/main/java/yesman/epicfight/compat/skinlayer3d/client/SkinLayer3DTransformer.java
+++ b/src/main/java/yesman/epicfight/compat/skinlayer3d/client/SkinLayer3DTransformer.java
@@ -26,8 +26,6 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.entity.player.PlayerModelPart;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import yesman.epicfight.api.client.model.MeshPartDefinition;
 import yesman.epicfight.api.client.model.SingleGroupVertexBuilder;
 import yesman.epicfight.api.client.model.SkinnedMesh;
@@ -40,7 +38,6 @@ import yesman.epicfight.api.utils.math.Vec3f;
 import yesman.epicfight.compat.skinlayer3d.mixin.MixinCustomModelPart;
 import yesman.epicfight.compat.skinlayer3d.mixin.MixinCustomizableCubeWrapper.SkinLayer3DMixinCustomModelCube;
 
-@OnlyIn(Dist.CLIENT)
 public class SkinLayer3DTransformer extends CustomizableCube {
 	private SkinLayer3DTransformer() {
 		super(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0, new dev.tr7zw.skinlayers.versionless.util.Direction[] {}, new dev.tr7zw.skinlayers.versionless.util.Direction[][] {{}});
@@ -55,7 +52,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 	static final PartTransformer<CustomizableCube> RIGHT_LEG = new LimbPartTransformer(1, 2, 3, 6.0F, true);
 	static final PartTransformer<CustomizableCube> CHEST = new ChestPartTransformer(18.0F);
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ModelPartition {
 		final PartTransformer<ModelPart.Cube> vanillaPartTransformer;
 		final PartTransformer<CustomizableCube> partTransformer;
@@ -183,7 +179,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 		poseStack.popPose();
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class SimpleTransformer extends PartTransformer<CustomizableCube> {
 		final int jointId;
 		
@@ -221,7 +216,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class ChestPartTransformer extends PartTransformer<CustomizableCube> {
 		static final float X_PLANE = 0.0F;
 		static final VertexWeight[] WEIGHT_ALONG_Y = { new VertexWeight(13.6666F, 0.230F, 0.770F), new VertexWeight(15.8333F, 0.254F, 0.746F), new VertexWeight(18.0F, 0.5F, 0.5F), new VertexWeight(20.1666F, 0.744F, 0.256F), new VertexWeight(22.3333F, 0.770F, 0.230F)};
@@ -397,7 +391,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class LimbPartTransformer extends PartTransformer<CustomizableCube> {
 		final int upperJoint;
 		final int lowerJoint;
@@ -546,7 +539,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 		return new ModelPart.Vertex(translatedPosition.x(), translatedPosition.y(), translatedPosition.z(), original.u, original.v);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedVertex extends ModelPart.Vertex {
 		final Vec3i jointId;
 		final Vec3f weight;
@@ -570,7 +562,6 @@ public class SkinLayer3DTransformer extends CustomizableCube {
 		}
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	static class AnimatedPolygon {
 		public final AnimatedVertex[] animatedVertexPositions;
 		public final Vector3f normal;

--- a/src/main/java/yesman/epicfight/compat/sodium/client/SodiumFakeBlockRenderer.java
+++ b/src/main/java/yesman/epicfight/compat/sodium/client/SodiumFakeBlockRenderer.java
@@ -35,13 +35,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import yesman.epicfight.client.renderer.EpicFightRenderTypes;
 import yesman.epicfight.client.renderer.FakeBlockRenderer;
 
-@OnlyIn(Dist.CLIENT)
 public class SodiumFakeBlockRenderer implements FakeBlockRenderer {
 	private static final Direction[] DIRECTIONS = Direction.values();
 	


### PR DESCRIPTION
Removes most of the `OnlyIn` annotation Forge imports to clos_e #2146 (intentionally made a typo to prevent GitHub from auto-closing).

### Script

This change was automated using a script, and not manually, so the conflicts can be fixed in any branch by using the same script.

<details><summary>Script</summary>
<p>

**Disclaimer:** Generated via AI to save development time.

```bash
#!/bin/bash

find src/main/java/yesman/epicfight -name "*.java" -print0 | while IFS= read -r -d '' f; do
  if grep -q "^package .*client" "$f"; then

    # Check if @EventBusSubscriber(... value = Dist.CLIENT) exists anywhere in the file
    if grep -Eq '@EventBusSubscriber\(.*value *= *Dist\.CLIENT' "$f"; then
      KEEP_DIST_IMPORT=1
    else
      KEEP_DIST_IMPORT=0
    fi

    # Remove the OnlyIn import ALWAYS (safe)
    sed -i '' '/^import net\.neoforged\.api\.distmarker\.OnlyIn;/d' "$f"

    # Remove Dist import ONLY if not used in @EventBusSubscriber
    if [ "$KEEP_DIST_IMPORT" -eq 0 ]; then
      sed -i '' '/^import net\.neoforged\.api\.distmarker\.Dist;/d' "$f"
    fi

    # Remove @OnlyIn(Dist.CLIENT) annotation lines
    sed -i '' '/^[[:space:]]*@OnlyIn(Dist.CLIENT)/d' "$f"
  fi
done
```


</p>
</details> 

### Details

This does not remove all `@OnlyIn` annotations and related imports, but:

- only if the target class file is in a client package (e.g., `yesman.epicfight.client.world.capabilites.entitypatch.player`, `yesman.epicfight.api.client.input`), so in other words, `"client"` is part of the String.
  - There are many cases where we use `@OnlyIn(Dist.CLIENT)` in the same package as a dedicated server (common side), 
which is not something Minecraft does, and NeoForge/Fabric encourages separating client-only code from the common. Example case that does not meet this condition: `yesman.epicfight.api.utils.LevelUtil#createParticle`. **We should handle these cases manually without AI or scripts, and in a separate PR/issue.**
- remove all `Dist` imports but only if it's not used by a `@EventBusSubscriber` annotation, to prevent compile errors.
  - `OnlyIn` imports are always removed if `@OnlyIn` is removed

This makes it significantly easier to clear these imports correctly (details ##2146) and handle them via a separate client package or class, which is more recommended, has fewer dedicated crashes, and is mixin-friendly.


### Reasons

Details have already been discussed in #2146 and on Discord

**Long story short:** these are internal details and are meant only for the mod-loader to handle the cases where client classes are not shipped on the dedicated server JAR file provided by the mod-loader. All of MinecraftForge, NeoForged, and FabricMC teams recommend not using them at any cost.

<img width="947" height="867" alt="image" src="https://github.com/user-attachments/assets/e90ef4f0-5e3d-4906-98d7-713e007f42e3" />

<img width="1005" height="726" alt="image" src="https://github.com/user-attachments/assets/26fa4566-ed07-4e0a-8dda-297ac04d22ca" />

<img width="1250" height="872" alt="image" src="https://github.com/user-attachments/assets/7c6fb181-7aa7-437e-a27e-87fa8c130f8c" />

Also, the [main maintainer of MinecraftForge strongly recommends against it](https://forums.minecraftforge.net/topic/86229-when-should-you-use-onlyindistdedicated_server/).


They block us from supporting Fabric, and also add a lot of conflicts between Forge and NeoForge branches, and make us more dependent on the mod loader, so in the future, if NeoForge gets forked, as happened before, we will need to update all these imports again, which is not future-proof at all.

There are more details to the discussion, but I have already discussed them with my team a few weeks ago.

### Testing

I have tested both the dedicated server, client and confirmed no issues; in fact, this could fix more issues (as happened with this PR https://github.com/Epic-Fight/epicfight/pull/2141#issuecomment-3463107453)

### Better alternatives?

- A separate package and class for anything that uses client-only methods or classes **(required)**
  - Sometimes, for example, in the `Animations` class, some may disagree and prefer to keep it coupled, so in these cases, we can just document the code or use `@ClientOnly` custom annotation, which just serves for documentation purposes, without bytecode runtime manipulation.
- **Bonus:** If we really want to solve the problem 100% further from core, no annotations, no hacks, no reflections, no workarounds, then it's better to separate the source sets as Fabric does (`main` and `client` instead of just `main` for both). This forces us to fix all issues at compile-time (type-safety). This is required in addition to applying the first solution.