### PR TITLE
[1.20.1] Camera update 1st stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the target indicator invisible for non Epic Fight patched entities
+- Fixed the lock-on target not being synced to the server when using mouse snap to change the target
+
+### Changed
+
+- Now Lock-on automatically searches a new target if there is no currently focusing entity
+
 ## [20.14.1] - 2025-12-07
 
 ### Added

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -346,10 +346,6 @@ public final class EpicFightCameraAPI {
 		return ClientConfig.lockOnRange;
 	}
 	
-	/**
-	 * @Deprecated Use more parameters friendly version below
-	 */
-	@Deprecated(forRemoval = true)
 	public boolean setNextLockOnTarget(int direction) {
 		return this.setNextLockOnTarget(direction, false, true);
 	}

--- a/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -288,23 +288,38 @@ public final class EpicFightCameraAPI {
 		if (this.lockingOnTarget == flag) {
             return;
         }
-
+		
+		boolean newlyFoundFocusingEntity = false;
+		
+		// Search a next target when trying to lock there is no focusing entity
+		if (flag && this.focusingEntity == null) {
+			newlyFoundFocusingEntity = this.setNextLockOnTarget(0, false, false);
+		}
+		
         if (!flag || this.focusingEntity != null) {
             boolean eventCanceled;
-
+            
             if (flag) {
                 LockOnEvent.Start lockOnEvent = new LockOnEvent.Start(this, this.focusingEntity);
                 EpicFightClientHooks.Camera.LOCK_ON_START.post(lockOnEvent);
                 eventCanceled = lockOnEvent.hasCanceled();
+                
+                if (eventCanceled && newlyFoundFocusingEntity) {
+                	this.focusingEntity = null;
+                }
             } else {
                 LockOnEvent.Release lockOnEvent = new LockOnEvent.Release(this, this.focusingEntity);
                 EpicFightClientHooks.Camera.LOCK_ON_RELEASED.post(lockOnEvent);
                 eventCanceled = lockOnEvent.hasCanceled();
             }
-
+            
             if (!eventCanceled) {
                 this.lockingOnTarget = flag;
-
+                
+                if (flag && newlyFoundFocusingEntity) {
+                	this.sendTargeting(this.focusingEntity);
+                }
+                
                 // Sycn the camera rotation according to the camera mode
                 if (!this.isTPSMode()) {
                     if (!flag) {
@@ -332,18 +347,28 @@ public final class EpicFightCameraAPI {
 	}
 	
 	/**
+	 * @Deprecated Use more parameters friendly version below
+	 */
+	@Deprecated(forRemoval = true)
+	public boolean setNextLockOnTarget(int direction) {
+		return this.setNextLockOnTarget(direction, false, true);
+	}
+	
+	/**
 	 * Find a new target on the screen based on the direction
 	 * <p>
 	 * @param direction 	determines which direction it will start to find a new target
 	 * 							-1: right
 	 * 							 1: left
 	 * 							 0: not considering a direction
+	 * @param necessarilyLockingOn 	whether it allows searching target when it's not locking
+	 * @param sendChange			whether it sends the switched focusing entity or not
 	 * <p>
 	 * @return 				true when found new lock-on target, else false
 	 */
-	public boolean setNextLockOnTarget(int direction) {
+	public boolean setNextLockOnTarget(int direction, boolean necessarilyLockingOn, boolean sendChange) {
 		// terminates when not locking-on
-		if (!this.lockingOnTarget) {
+		if (!this.lockingOnTarget && necessarilyLockingOn) {
 			return false;
 		}
 		
@@ -373,6 +398,7 @@ public final class EpicFightCameraAPI {
 		
 		next.ifPresent(pair -> {
 			this.focusingEntity = pair.getFirst();
+			if (sendChange) this.sendTargeting(this.focusingEntity);
 		});
 		
 		return next.isPresent();
@@ -531,7 +557,7 @@ public final class EpicFightCameraAPI {
 					this.accumulatedX += -dy * 0.15F;
 					
 					if (Math.abs(this.accumulatedX) > 20.0D && this.lockingOnTarget) {
-						this.setNextLockOnTarget(Mth.sign(this.accumulatedX));
+						this.setNextLockOnTarget(Mth.sign(this.accumulatedX), true, true);
 						this.accumulatedX = 0.0D;
 						this.quickShiftDelay = 4;
 					}
@@ -641,7 +667,7 @@ public final class EpicFightCameraAPI {
 				}
 				
 				if (this.focusingEntity != null) {
-					EpicFightNetworkManager.sendToServer(new CPSetPlayerTarget(this.focusingEntity.getId()));
+					this.sendTargeting(this.focusingEntity);
 				}
 			}
 		}
@@ -675,7 +701,7 @@ public final class EpicFightCameraAPI {
 		// Tick the target entity
 		if (this.focusingEntity != null) {
 			if (this.lockingOnTarget && !this.focusingEntity.isAlive()) {
-				boolean releaseLockOn = !ClientConfig.lockOnQuickShift || !this.setNextLockOnTarget(0);
+				boolean releaseLockOn = !ClientConfig.lockOnQuickShift || !this.setNextLockOnTarget(0, true, true);
 
                 // Searches a new lock-on target when current target is dead
                 if (releaseLockOn) {
@@ -702,7 +728,7 @@ public final class EpicFightCameraAPI {
 					}
 					
 					this.focusingEntity = null;
-					EpicFightNetworkManager.sendToServer(new CPSetPlayerTarget(-1));
+					this.sendTargeting(null);
 				}
 			}
 		}
@@ -961,6 +987,11 @@ public final class EpicFightCameraAPI {
 		return (this.isTPSMode() && (Mth.abs(Mth.wrapDegrees(this.cameraYRot - player.yBodyRot)) <= 51.0F || this.predicateCouplingPlayer())) ? this.cameraYRot : player.getYRot();
 	}
 	
+	@ApiStatus.Internal
+	public void onItemUseEvent(Player player, PlayerPatch<?> playerpatch, ItemStack itemstack, InteractionHand hand) {
+		if (this.isTPSMode()) EpicFightClientHooks.Camera.ITEM_USED_WHEN_DECOUPLED.post(new ItemUsedInDecoupledCamera(this, player, playerpatch, itemstack, hand));
+	}
+	
 	private boolean predicateFocusableEntity(Entity entity) {
         return entity instanceof LivingEntity livingEntity && !entity.isSpectator() && entity.isPickable() && entity.isAlive() && !entity.is(this.minecraft.player) && this.minecraft.player.canAttack(livingEntity);
     }
@@ -985,8 +1016,7 @@ public final class EpicFightCameraAPI {
         return coupleTPSCameraEvent.shouldCoupleCamera();
 	}
 	
-	@ApiStatus.Internal
-	public void onItemUseEvent(Player player, PlayerPatch<?> playerpatch, ItemStack itemstack, InteractionHand hand) {
-		if (this.isTPSMode()) EpicFightClientHooks.Camera.ITEM_USED_WHEN_DECOUPLED.post(new ItemUsedInDecoupledCamera(this, player, playerpatch, itemstack, hand));
+	private void sendTargeting(@Nullable LivingEntity target) {
+		EpicFightNetworkManager.sendToServer(new CPSetPlayerTarget(target == null ? -1 : target.getId()));
 	}
 }

--- a/src/main/java/yesman/epicfight/api/event/CancelableEventHook.java
+++ b/src/main/java/yesman/epicfight/api/event/CancelableEventHook.java
@@ -15,26 +15,26 @@ public class CancelableEventHook<T extends Event & CancelableEvent> extends Even
 	 * @return whether the event is canceled
 	 */
 	@Override
-	public boolean post(T eventInstance) {
-		EventContext eventContext = eventInstance.initEventContext();
+	public boolean post(T event) {
+		EventContext eventContext = event.getEventContext();
 		
 		for (EventListener<T> subscriber : this.subscriptions.values()) {
 			eventContext.subscriptionStart(subscriber.name());
 			
 			if (subscriber.subscription() instanceof DefaultEventSubscription<T> passiveSubscription) {
-				if (!eventInstance.hasCanceled()) {
-					passiveSubscription.fire(eventInstance);
+				if (!event.hasCanceled()) {
+					passiveSubscription.fire(event);
 					eventContext.onCalled();
 				}
 			} else if (subscriber.subscription() instanceof ContextAwareEventSubscription<T> contextAwareSubscription) {
-				contextAwareSubscription.fire(eventInstance, eventContext);
+				contextAwareSubscription.fire(event, eventContext);
 				eventContext.onCalled();
 			}
 		}
 		
 		eventContext.subscriptionEnd();
 		
-		return eventInstance.hasCanceled();
+		return event.hasCanceled();
 	}
 	
 	/**

--- a/src/main/java/yesman/epicfight/api/event/Event.java
+++ b/src/main/java/yesman/epicfight/api/event/Event.java
@@ -17,7 +17,7 @@ public abstract class Event {
 	 * the name of subscribers are specified as parameter in {@link EventHook#registerPassiveevent} and
 	 * {@link CancelableEventHook#registerCancelableevent} and {@link CancelableEventHook#registerContextAwareevent}
 	 */
-	private EventContext eventContext;
+	private final EventContext eventContext = new EventContext();
 	
 	/**
 	 * Returns whether the event event canceled
@@ -45,12 +45,11 @@ public abstract class Event {
 	}
 	
 	/**
-	 * Initialize {@link EventContext}, which is used by {@link ContextAwareEventSubscription}
+	 * Returns the holding event context used by {@link ContextAwareEventSubscription}
 	 * only called by {@link EventHook#post}
 	 */
 	@ApiStatus.Internal
-	public EventContext initEventContext() {
-		this.eventContext = new EventContext();
+	public EventContext getEventContext() {
 		return this.eventContext;
 	}
 }

--- a/src/main/java/yesman/epicfight/api/physics/bezier/CubicBezierCurve.java
+++ b/src/main/java/yesman/epicfight/api/physics/bezier/CubicBezierCurve.java
@@ -8,12 +8,9 @@ import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.doubles.DoubleList;
 import net.minecraft.world.phys.Vec3;
 
+/// Get more informations about cubic bezier curve here:
+/// [...](https://omaraflak.medium.com/bézier-interpolation-8033e9a262c2)
 public class CubicBezierCurve {
-	
-	/**
-	 * Get more informations about cubic bezier curve here:
-	 * https://towardsdatascience.com/b%C3%A9zier-interpolation-8033e9a262c2
-	 */
 	private static final DoubleList MATRIX_CONSTANTS = new DoubleArrayList();
 	
 	static {

--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -491,11 +491,11 @@ public class ControlEngine {
     }
     
     private void searchNewTargetFromLeft() {
-    	EpicFightCameraAPI.getInstance().setNextLockOnTarget(1);
+    	EpicFightCameraAPI.getInstance().setNextLockOnTarget(1, true, true);
     }
     
     private void searchNewTargetFromRight() {
-    	EpicFightCameraAPI.getInstance().setNextLockOnTarget(-1);
+    	EpicFightCameraAPI.getInstance().setNextLockOnTarget(-1, true, true);
     }
     
 	private void inputTick(Input input) {

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -488,13 +488,13 @@ public class RenderEngine {
 			
 			if (!renderEngine.minecraft.options.hideGui && !EpicFightGameRules.DISABLE_ENTITY_UI.getRuleValue(livingentity.level())) {
 				EpicFightCapabilities.getUnparameterizedEntityPatch(renderEngine.minecraft.player, LocalPlayerPatch.class).ifPresent(playerpatch -> {
-					EpicFightCapabilities.getUnparameterizedEntityPatch(livingentity, LivingEntityPatch.class).ifPresent(entitypatch -> {
-						for (EntityUI entityIndicator : EntityUI.ENTITY_UI_LIST) {
-							if (entityIndicator.shouldDraw(livingentity, entitypatch, playerpatch, event.getPartialTick())) {
-								entityIndicator.draw(livingentity, entitypatch, playerpatch, event.getPoseStack(), event.getMultiBufferSource(), event.getPartialTick());
-							}
+					LivingEntityPatch<?> entityPatch = EpicFightCapabilities.getEntityPatch(livingentity, LivingEntityPatch.class);
+					
+					for (EntityUI entityIndicator : EntityUI.ENTITY_UI_LIST) {
+						if (entityIndicator.shouldDraw(livingentity, entityPatch, playerpatch, event.getPartialTick())) {
+							entityIndicator.draw(livingentity, entityPatch, playerpatch, event.getPoseStack(), event.getMultiBufferSource(), event.getPartialTick());
 						}
-					});
+					}
 				});
 			}
 		}


### PR DESCRIPTION
Here are the very first issue reports from addon developers.
(Fixes #2300)

## [Lock-on target switch does not sync with the server](https://github.com/Epic-Fight/epicfight/issues/2300)

Found we're not sending a synchronization packet when switching a lock-on target via quick switch (through mouse snapping)
I added parameters for sending packets in the method that searches for a new target from the screen
```java
public boolean setNextLockOnTarget(int direction, boolean necessarilyLockingOn, boolean sendChange) {
    // ...
    if (sendChange) this.sendTargeting(this.focusingEntity);
}
```
Demonstration:

https://github.com/user-attachments/assets/73e641fe-dff7-41d1-9394-e9872ffd0933

<img width="707" height="126" alt="targeting_works" src="https://github.com/user-attachments/assets/8bb9bc74-154d-44d2-9d2c-2ae19f226806" />

I printed out the current target at the ticking method in `PlayerPatch`, only in logical server.
```java
if (!this.isLogicalClient()) System.out.println("Server Targeting: " + this.getTarget());
```

I expect this will solve the reported issue since the dev mentioned he used `getTarget` method to shot projectiles. Although, we need to fully test the usecase before we merge this pull request.
<img width="628" height="401" alt="image" src="https://github.com/user-attachments/assets/1951799d-38af-4583-9bbf-13ff0509b05c" />

## Non Epic Fight patched entities don't show the target indicator
<img width="1776" height="1084" alt="image" src="https://github.com/user-attachments/assets/ae6d6887-11cc-4d01-8d96-b822152df0ec" />

Fixed by not getting entitypatch through `EpicFightCapabilities.getUnparameterizedEntityPatch().ifPresent()` since the entity patch parameter for validation methods in `EntityUI` is nullable.

```java
public abstract boolean shouldDraw(LivingEntity entity, @Nullable LivingEntityPatch<?> entitypatch, LocalPlayerPatch playerpatch, float partialTicks);
```

Demonstration:
<img width="273" height="264" alt="indicator_works" src="https://github.com/user-attachments/assets/b51c729f-0b9d-425f-b2f1-14b1e2f513b3" />

## Automatic Lock-on by picking the nearest entity from the crosshair

Suggested by the original author of the **Better Lock-On** addon. He recommended adding this feature so he doesn't have to update his add-on as the Epic Fight version grows.

Demonstration:

https://github.com/user-attachments/assets/8d98f3c2-9b61-44b7-a6f1-c0a98dcf0cd3

## Game crash with [Cinematic Cataclysm](https://www.curseforge.com/minecraft/mc-mods/cinematic-cataclysm)

[mclo.gs](https://mclo.gs/NcjkMms)

This is an internal Epic Fight crash for some exceptional cases.

```java
BuildCameraTransform.Pre event = new BuildCameraTransform.Pre(this, camera, partialTick);

if (!camera.getEntity().is(this.minecraft.player)) {
	event.cancel();
	return event;
}
```

Calling `event.cancel()` is prevented before they are initialized. This was originally for getting an `EventContext` instance when posting events, but this structure has a danger of leading to a `NullPointerException`. So I made `eventContext` initialized while constructing.

Also, changed `initializeEventContext` to `getEventContext` since it is not an initialization method at all. Tho I believe no breaking changes happen since it's marked as `@ApiStatus.Internal`.