### PR TITLE
[1.21.1] Avoid changing user's client config when SSR is installed

### DIFF
--- a/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisableState.java
+++ b/src/main/java/yesman/epicfight/client/camera/EpicFightTpsCameraDisableState.java
@@ -2,7 +2,7 @@ package yesman.epicfight.client.camera;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import yesman.epicfight.config.ClientConfig;
+import yesman.epicfight.api.client.event.EpicFightClientHooks;
 import yesman.epicfight.main.EpicFightMod;
 
 import java.util.Objects;
@@ -12,12 +12,22 @@ public final class EpicFightTpsCameraDisableState {
     }
 
     private static @Nullable EpicFightTpsCameraDisabledReason reason = null;
+    private static boolean eventRegistered = false;
 
     public static void disable(@NotNull EpicFightTpsCameraDisabledReason reason) {
         Objects.requireNonNull(reason, "reason must not be null");
+
         EpicFightTpsCameraDisableState.reason = reason;
         EpicFightMod.LOGGER.info("Epic Fight TPS mode has been disabled due to a mod conflict with {}", reason.getModName());
-        ClientConfig.cameraMode = ClientConfig.TPSType.ALWAYS_BACK;
+
+        if (!eventRegistered) {
+            EpicFightClientHooks.Camera.ACTIVATE_TPS_CAMERA.registerEvent(e -> {
+                if (EpicFightTpsCameraDisableState.reason != null) {
+                    e.cancel();
+                }
+            });
+            eventRegistered = true;
+        }
     }
 
     public static @Nullable EpicFightTpsCameraDisabledReason getReason() {

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/EpicFightGraphicOptionScreen.java
@@ -19,6 +19,7 @@ import yesman.epicfight.client.gui.widgets.ColorSlider;
 import yesman.epicfight.client.gui.widgets.EpicFightOptionList;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
 import yesman.epicfight.config.ClientConfig;
+import yesman.epicfight.generated.LangKeys;
 import yesman.epicfight.main.EpicFightMod;
 
 import java.io.File;
@@ -81,15 +82,6 @@ public class EpicFightGraphicOptionScreen extends EpicFightOptionSubScreen {
             button.setMessage(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective." + ParseUtil.toLowerCase(ClientConfig.cameraMode.name()))));
             cameraSetupButton.active = ClientConfig.cameraMode.hasTPSTransition();
         }).pos(this.width / 2 - 165, this.height / 4 + buttonHeight).size(160, 20).tooltip(Tooltip.create(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective.tooltip")))).build();
-
-        final EpicFightTpsCameraDisabledReason tpsDisabledReason = EpicFightTpsCameraDisableState.getReason();
-        if (tpsDisabledReason != null) {
-            cameraTypeButton.active = false;
-            final Tooltip disabledReasonTooltip = Tooltip.create(Component.translatable(EpicFightMod.format("gui.%s.tps_perspective.disabled_due_to_mod_conflict"), tpsDisabledReason.getModName()));
-
-            cameraTypeButton.setTooltip(disabledReasonTooltip);
-            cameraSetupButton.setTooltip(disabledReasonTooltip);
-        }
 
         cameraSetupButton.active = ClientConfig.cameraMode.hasTPSTransition();
         this.optionsList.addSmall(cameraTypeButton, cameraSetupButton);
@@ -282,7 +274,21 @@ public class EpicFightGraphicOptionScreen extends EpicFightOptionSubScreen {
         );
 		
 		this.addWidget(this.optionsList);
+
+        maybeDisableCameraButtons(cameraTypeButton, cameraSetupButton);
 	}
+
+    private void maybeDisableCameraButtons(Button cameraTypeButton, Button cameraSetupButton) {
+        final EpicFightTpsCameraDisabledReason tpsDisabledReason = EpicFightTpsCameraDisableState.getReason();
+        if (tpsDisabledReason != null) {
+            cameraTypeButton.active = false;
+            cameraSetupButton.active = false;
+            final Tooltip disabledReasonTooltip = Tooltip.create(Component.translatable(LangKeys.GUI_TPS_PERSPECTIVE_DISABLED_DUE_TO_MOD_CONFLICT, tpsDisabledReason.getModName()));
+
+            cameraTypeButton.setTooltip(disabledReasonTooltip);
+            cameraSetupButton.setTooltip(disabledReasonTooltip);
+        }
+    }
 	
 	@Override
 	public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {


### PR DESCRIPTION
The previous code changes the user client config as a quick workaround to cause `EpicFightCameraAPI#isTPSMode` to return `false`.

This is inefficient and inconvenient, as IO operations are non-trivial and should be avoided for such simple compatibility.

Also, the user `IRBan` from Epic Fight Discord reported that this is causing game load crashes with some old configs when SSR is installed, so I updated the code to make use of the official supported API, for a more future-proof SSR compatibility.