### PR TITLE
[1.21.1] Fixed the player being dark in inventory screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the target indicator invisible for non Epic Fight patched entities
 - Fixed the lock-on target not being synced to the server when using mouse snap to change the target
+- Fixed the player being dark in inventory screen
 
 ### Changed
 

--- a/src/main/java/yesman/epicfight/api/utils/math/MathUtils.java
+++ b/src/main/java/yesman/epicfight/api/utils/math/MathUtils.java
@@ -288,11 +288,13 @@ public class MathUtils {
 		poseStack.scale(vector.x(), vector.y(), vector.z());
 	}
 	
-	private static final Matrix4f BUFFER = new Matrix4f();
+	private static final Matrix4f BUFFER4F = new Matrix4f();
+    private static final Matrix3f BUFFER3F = new Matrix3f();
 	
 	public static void mulStack(PoseStack poseStack, OpenMatrix4f mat) {
-		OpenMatrix4f.exportToMojangMatrix(mat, BUFFER);
-		poseStack.mulPose(BUFFER);
+		OpenMatrix4f.exportToMojangMatrix(mat, BUFFER4F);
+        poseStack.last().pose().mul(BUFFER4F);
+        poseStack.last().normal().mul(BUFFER3F);
 	}
 
     public static double getAngleBetween(Vec3f a, Vec3f b) {


### PR DESCRIPTION
<img width="623" height="381" alt="image" src="https://github.com/user-attachments/assets/c1b61fe0-6e59-4c83-835a-588a25fc61f7" />

Reported by @SAGESSE-CN, I confirmed the issue is only the case in 1.21.1.

Problem is coming from we're relying on `PoseStack#mulPose` which was added in 1.21.1 Minecraft. I expected this method to multiply the transform matrix by both the `pose` and `normal` matrices, but it wasn't.

```java
    Pose posestack$pose = (Pose)this.poseStack.getLast();
    posestack$pose.pose.mul(pose);
    if (!MatrixUtil.isPureTranslation(pose)) {
        if (MatrixUtil.isOrthonormal(pose)) {
            posestack$pose.normal.mul(new Matrix3f(pose));
        } else {
            posestack$pose.computeNormalMatrix();
        }
    }
```

It checks some conditions in the given matrix to apply a normal matrix. This isn't a problem for rendering entities in a world, but it is for entities in the GUI, especially the player in an inventory screen. So I switched to more reliable way, a method that directly multiplying the given matrix to `PoseStack`

```java
private static final Matrix4f BUFFER4F = new Matrix4f();
private static final Matrix3f BUFFER3F = new Matrix3f();

public static void mulStack(PoseStack poseStack, OpenMatrix4f mat) {
	OpenMatrix4f.exportToMojangMatrix(mat, BUFFER4F);
    poseStack.last().pose().mul(BUFFER4F);
    poseStack.last().normal().mul(BUFFER3F);
}
```

Demonstration:

<img width="474" height="304" alt="image" src="https://github.com/user-attachments/assets/c1fcc919-5339-4624-a1d3-5d9e26d573b3" />

Checked no regression in rendering the player in the world

<img width="184" height="169" alt="image" src="https://github.com/user-attachments/assets/76087e5b-22ef-44fb-9131-c2d554f77720" />

You now can see normals are applied well in the inventory screen too.

<img width="579" height="385" alt="image" src="https://github.com/user-attachments/assets/8001204c-2de5-46c6-aa0a-b1fc7d66c3fb" />

<img width="195" height="189" alt="image" src="https://github.com/user-attachments/assets/b0a943ca-eded-4038-9dd4-8a4cd02dc2bc" />

With a shader turned on, I also found no issues with this fix.

_For reminder: this is not an issue in 1.20.1._