### PR TITLE
[1.20.1] Fixed datapack animation loading failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed datapack animations not loading properly
+
 ## [20.14.2] - 2025-12-10
 
 ### Fixed

--- a/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
@@ -200,9 +200,9 @@ public class AnimationManager extends SimplePreparableReloadListener<List<Resour
                     JsonElement jsonelement = GsonHelper.fromJson(GSON, reader, JsonElement.class);
                     this.readResourcepackAnimation(animId, jsonelement.getAsJsonObject());
                 } catch (IOException | JsonParseException | IllegalArgumentException resourceReadException) {
-                    EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId);
+                    EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId, resourceReadException);
                 } catch (Exception e) {
-                    EpicFightMod.LOGGER.error("Failed at constructing {}", animId);
+                    EpicFightMod.LOGGER.error("Failed at constructing {}", animId, e);
                 }
             });
         

--- a/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
@@ -259,7 +259,7 @@ public class AnimationManager extends SimplePreparableReloadListener<List<Resour
 	
 	/// Converts animation id, acquired by [StaticAnimation#getRegistryName], to animation resource path acquired by [StaticAnimation#getLocation]
     public static ResourceLocation idToPath(ResourceLocation rl) {
-        return rl.getPath().matches(DIRECTORY + "/.*\\.json") ? rl : ResourceLocation.fromNamespaceAndPath(rl.getNamespace(), DIRECTORY + rl.getPath() + ".json");
+        return rl.getPath().matches(DIRECTORY + "/.*\\.json") ? rl : ResourceLocation.fromNamespaceAndPath(rl.getNamespace(), DIRECTORY + "/" + rl.getPath() + ".json");
     }
 
     /// Converts animation resource path, acquired by [StaticAnimation#getLocation], to animation id acquired by [StaticAnimation#getRegistryName]


### PR DESCRIPTION
Caused by a simple mistake, "/" was accidentally omitted in the conversion method, leading `NoSuchElementException`. (fixes #2312)

<img width="487" height="51" alt="image" src="https://github.com/user-attachments/assets/f52b6b5e-ca69-4aab-9053-ed48e2fe86d8" />

_Demonstration:_

https://github.com/user-attachments/assets/b6913dff-6f00-4029-b65c-4fc9a14341fd

Bokken, our official sample datapack, works fine.