### PR TITLE
[1.21.1] Fixed datapack animation loading failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed datapack animations not loading properly
+
 ## [21.14.2] - 2025-12-10
 
 ### Fixed

--- a/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
@@ -182,15 +182,13 @@ public class AnimationManager extends SimplePreparableReloadListener<List<Resour
 			.forEach(animId -> {
                 Optional<Resource> resource = resourceManager.getResource(idToPath(animId));
 
-                System.out.println("wrapped id " + idToPath(animId) + ", wrapped resource " + resource);
-
                 try (Reader reader = resource.orElseThrow().openAsReader()) {
                     JsonElement jsonelement = GsonHelper.fromJson(GSON, reader, JsonElement.class);
                     this.readResourcepackAnimation(animId, jsonelement.getAsJsonObject());
                 } catch (IOException | JsonParseException | IllegalArgumentException resourceReadException) {
-                    EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId);
+                    EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId, resourceReadException);
                 } catch (Exception e) {
-                    EpicFightMod.LOGGER.error("Failed at constructing {}", animId);
+                    EpicFightMod.LOGGER.error("Failed at constructing {}", animId, e);
                 }
             });
 


### PR DESCRIPTION
Same with #2318, but 1.21.1.

Note: We do not have a sample datapack that meets the 1.21.1 form, so we can't test whether this works correctly. Tho I wanted to fix what was an apparent malfunction.