### PR TITLE
TPS Camera and RightClickEvent

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -793,12 +793,27 @@ public class RenderEngine {
 				return;
 			}
 			
+			// Only adjust player rotations for Epic Fight's decoupled TPS camera.
+			// Doing this in vanilla / first-person causes a noticeable camera snap.
+			EpicFightCameraAPI cameraApi = EpicFightCameraAPI.getInstance();
+			if (!cameraApi.isTPSMode()) {
+				return;
+			}
+			
 			EpicFightCapabilities.getUnparameterizedEntityPatch(renderEngine.minecraft.player, LocalPlayerPatch.class).ifPresent(playerpatch -> {
 				Vec3 toHit = event.getHitVec().getLocation().subtract(playerpatch.getOriginal().getEyePosition());
-				playerpatch.getOriginal().setXRot((float)MathUtils.getXRotOfVector(toHit));
-				playerpatch.getOriginal().setYRot((float)MathUtils.getYRotOfVector(toHit));
+				float xRot = (float)MathUtils.getXRotOfVector(toHit);
+				float yRot = (float)MathUtils.getYRotOfVector(toHit);
+				
+				playerpatch.getOriginal().setXRot(xRot);
+				playerpatch.getOriginal().xRotO = xRot;
+				playerpatch.getOriginal().setYRot(yRot);
+				playerpatch.getOriginal().yRotO = yRot;
+				playerpatch.getOriginal().setYHeadRot(yRot);
+				playerpatch.getOriginal().yHeadRotO = yRot;
 			});
 		}
+
 		
 		@SubscribeEvent
 		public static void levelTickEvent(TickEvent.LevelTickEvent event) {


### PR DESCRIPTION
You had an error with the TPS camera, but I fixed it and it's working properly now
I just needed version 20.14, but I couldn't use it, so I decided to contribute.

<img width="1412" height="811" alt="image" src="https://github.com/user-attachments/assets/a1293b8a-16a2-44a8-ac50-475e2a4a2992" />
<img width="1846" height="920" alt="image" src="https://github.com/user-attachments/assets/b3adafea-4f34-4ad8-aff4-42f52459e024" />

https://youtu.be/rLt7aMZpQZY
https://youtu.be/vmifEkaw-mg