### PR TITLE
[1.20.1] Prepare for ResourceLocation rename and add more DRY static utility method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### For Devs
+
+- Deprecated `EpicFightMod.rl` and added `EpicFightMod.identifier` since
+  [Mojang renamed `ResourceLocation` to
+  `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).
+
 ## [20.14.3] - 2025-12-11
 
 ### Fixed

--- a/src/main/java/yesman/epicfight/api/animation/SynchedAnimationVariableKey.java
+++ b/src/main/java/yesman/epicfight/api/animation/SynchedAnimationVariableKey.java
@@ -30,8 +30,8 @@ public interface SynchedAnimationVariableKey<T> {
 	public static <T> SynchedIndependentAnimationVariableKey<T> independent(Function<Animator, T> defaultValueSupplier, boolean mutable, PacketBufferCodec<T> codec) {
 		return new SynchedIndependentAnimationVariableKey<> (defaultValueSupplier, mutable, codec);
 	}
-	
-	public static final ResourceLocation BY_ID_REGISTRY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "variablekeytoid");
+
+    public static final ResourceLocation BY_ID_REGISTRY = EpicFightMod.identifier("variablekeytoid");
 	
 	public static class SynchedAnimationVariableKeyCallbacks implements IForgeRegistry.BakeCallback<SynchedAnimationVariableKey<?>>, IForgeRegistry.CreateCallback<SynchedAnimationVariableKey<?>>, IForgeRegistry.ClearCallback<SynchedAnimationVariableKey<?>> {
 		private static final SynchedAnimationVariableKeyCallbacks INSTANCE = new SynchedAnimationVariableKeyCallbacks();

--- a/src/main/java/yesman/epicfight/api/animation/SynchedAnimationVariableKeys.java
+++ b/src/main/java/yesman/epicfight/api/animation/SynchedAnimationVariableKeys.java
@@ -15,7 +15,7 @@ import yesman.epicfight.main.EpicFightMod;
 public class SynchedAnimationVariableKeys {
 	private static final Supplier<RegistryBuilder<SynchedAnimationVariableKey<?>>> BUILDER = () -> new RegistryBuilder<SynchedAnimationVariableKey<?>>().addCallback(SynchedAnimationVariableKey.getRegistryCallback());
 	
-	public static final DeferredRegister<SynchedAnimationVariableKey<?>> SYNCHED_ANIMATION_VARIABLE_KEYS = DeferredRegister.create(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "synched_animation_variable_keys"), EpicFightMod.MODID);
+	public static final DeferredRegister<SynchedAnimationVariableKey<?>> SYNCHED_ANIMATION_VARIABLE_KEYS = DeferredRegister.create(EpicFightMod.identifier("synched_animation_variable_keys"), EpicFightMod.MODID);
 	public static final Supplier<IForgeRegistry<SynchedAnimationVariableKey<?>>> REGISTRY = SYNCHED_ANIMATION_VARIABLE_KEYS.makeRegistry(BUILDER);
 	
 	public static final RegistryObject<SynchedIndependentAnimationVariableKey<Vec3>> DESTINATION = SYNCHED_ANIMATION_VARIABLE_KEYS.register("destination", () ->

--- a/src/main/java/yesman/epicfight/api/animation/types/DynamicAnimation.java
+++ b/src/main/java/yesman/epicfight/api/animation/types/DynamicAnimation.java
@@ -142,7 +142,7 @@ public abstract class DynamicAnimation {
 	}
 	
 	public ResourceLocation getRegistryName() {
-		return ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "");
+		return EpicFightMod.identifier("");
 	}
 	
 	public int getId() {

--- a/src/main/java/yesman/epicfight/api/animation/types/StaticAnimation.java
+++ b/src/main/java/yesman/epicfight/api/animation/types/StaticAnimation.java
@@ -97,8 +97,8 @@ public class StaticAnimation extends DynamicAnimation implements InverseKinemati
 	
 	public StaticAnimation() {
 		super(0.0F, true);
-		
-		this.resourceLocation = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "emtpy");
+
+		this.resourceLocation = EpicFightMod.identifier("emtpy");
 		this.armature = null;
 		this.filehash = StringUtil.EMPTY_STRING;
 	}

--- a/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskReloadListener.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/JointMaskReloadListener.java
@@ -23,7 +23,7 @@ import yesman.epicfight.main.EpicFightMod;
 public class JointMaskReloadListener extends SimpleJsonResourceReloadListener {
 	private static final BiMap<ResourceLocation, JointMaskSet> JOINT_MASKS = HashBiMap.create();
 	private static final Map<String, JointMask.BindModifier> BIND_MODIFIERS = Maps.newHashMap();
-	private static final ResourceLocation NONE_MASK = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "none");
+    private static final ResourceLocation NONE_MASK = EpicFightMod.identifier("none");
 	
 	static {
 		BIND_MODIFIERS.put("keep_child_locrot", JointMask.KEEP_CHILD_LOCROT);

--- a/src/main/java/yesman/epicfight/api/client/animation/property/TrailInfo.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/property/TrailInfo.java
@@ -40,8 +40,8 @@ public record TrailInfo(
 	, ResourceLocation texturePath
 	, InteractionHand hand
 ) {
-	public static final ResourceLocation GENERIC_TRAIL_TEXTURE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/swing_trail.png");
-	public static final ResourceLocation SWORDMASTER_SWING_TRAIL_TEX = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/swordmaster_trail.png");
+    public static final ResourceLocation GENERIC_TRAIL_TEXTURE = EpicFightMod.identifier("textures/particle/swing_trail.png");
+    public static final ResourceLocation SWORDMASTER_SWING_TRAIL_TEX = EpicFightMod.identifier("textures/particle/swordmaster_trail.png");
 	
 	public static final TrailInfo PREVIEWER_DEFAULT_TRAIL = TrailInfo.builder()
 			.startPos(new Vec3(0.0D, 0.0D, 0.0D))

--- a/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulator.java
+++ b/src/main/java/yesman/epicfight/api/client/physics/cloth/ClothSimulator.java
@@ -59,8 +59,8 @@ import yesman.epicfight.main.EpicFightSharedConstants;
  * https://www.youtube.com/@TenMinutePhysics
  **/
 public class ClothSimulator extends AbstractSimulator<ResourceLocation, ClothObjectBuilder, SoftBodyTranslatable, ClothSimulatable, ClothSimulator.ClothObject> {
-	public static final ResourceLocation PLAYER_CLOAK = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "ingame_cloak");
-	public static final ResourceLocation MODELPREVIEWER_CLOAK = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "previewer_cloak");
+    public static final ResourceLocation PLAYER_CLOAK = EpicFightMod.identifier("ingame_cloak");
+    public static final ResourceLocation MODELPREVIEWER_CLOAK = EpicFightMod.identifier("previewer_cloak");
 	private static final float SPATIAL_HASH_SPACING = 0.05F;
 	
 	public static class ClothObjectBuilder extends SimulationObject.SimulationObjectBuilder {

--- a/src/main/java/yesman/epicfight/api/data/reloader/MobPatchReloadListener.java
+++ b/src/main/java/yesman/epicfight/api/data/reloader/MobPatchReloadListener.java
@@ -505,7 +505,7 @@ public class MobPatchReloadListener extends SimpleJsonResourceReloadListener {
 		if (type.contains(":")) {
 			rl = ResourceLocation.parse(type);
 		} else {
-			rl = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, type);
+			rl = EpicFightMod.identifier(type);
 		}
 		
 		Supplier<Condition<T>> predicateProvider = EpicFightConditions.getConditionOrNull(rl);

--- a/src/main/java/yesman/epicfight/api/data/reloader/SkillManager.java
+++ b/src/main/java/yesman/epicfight/api/data/reloader/SkillManager.java
@@ -47,7 +47,7 @@ import yesman.epicfight.skill.SkillSlots;
 import yesman.epicfight.world.capabilities.skill.CapabilitySkill;
 
 public class SkillManager extends SimpleJsonResourceReloadListener {
-	public static final ResourceKey<Registry<Skill>> SKILL_REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill"));
+	public static final ResourceKey<Registry<Skill>> SKILL_REGISTRY_KEY = ResourceKey.createRegistryKey(EpicFightMod.identifier("skill"));
 	public static final Codec<Skill> CODEC = ExtraCodecs.lazyInitializedCodec(() -> RegistryManager.ACTIVE.getRegistry(SKILL_REGISTRY_KEY).getCodec());
 	private static final List<CompoundTag> SKILL_PARAMS = Lists.newArrayList();
 	private static final Gson GSON = (new GsonBuilder()).create();
@@ -58,7 +58,7 @@ public class SkillManager extends SimpleJsonResourceReloadListener {
 	}
 	
 	public static void createSkillRegistry(NewRegistryEvent event) {
-		event.create(RegistryBuilder.of(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill")).addCallback(SkillRegistryCallbacks.INSTANCE));
+		event.create(RegistryBuilder.of(EpicFightMod.identifier("skill")).addCallback(SkillRegistryCallbacks.INSTANCE));
 	}
 	
 	public static void registerSkills(RegisterEvent event) {
@@ -83,7 +83,7 @@ public class SkillManager extends SimpleJsonResourceReloadListener {
 		if (name.indexOf(':') >= 0) {
 			rl = ResourceLocation.parse(name);
 		} else {
-			rl = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, name);
+            rl = EpicFightMod.identifier(name);
 		}
 		
 		if (skillRegistry.containsKey(rl)) {
@@ -185,7 +185,7 @@ public class SkillManager extends SimpleJsonResourceReloadListener {
 	}
 	
 	private static class SkillRegistryCallbacks implements IForgeRegistry.BakeCallback<Skill>, IForgeRegistry.CreateCallback<Skill>, IForgeRegistry.ClearCallback<Skill> {
-		private static final ResourceLocation LEARNABLE_SKILLS = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "learnableskills");
+        private static final ResourceLocation LEARNABLE_SKILLS = EpicFightMod.identifier("learnableskills");
 		private static final SkillRegistryCallbacks INSTANCE = new SkillRegistryCallbacks();
 		
 		@Override

--- a/src/main/java/yesman/epicfight/client/events/ClientModBusEvent.java
+++ b/src/main/java/yesman/epicfight/client/events/ClientModBusEvent.java
@@ -155,7 +155,7 @@ public class ClientModBusEvent {
 			
 			ItemOverrides overrides = event.getModels().get(skillbookLocation).getOverrides();
 			overrides.overrides = skillCategoryOverrides.toArray(i -> new ItemOverrides.BakedOverride[i]);
-			overrides.properties = new ResourceLocation[] {ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill")};
+			overrides.properties = new ResourceLocation[]{EpicFightMod.identifier("skill")};
 		}
 	}
 }

--- a/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/RenderEngine.java
@@ -140,7 +140,7 @@ public class RenderEngine {
 		builder.put(ResourceLocation.withDefaultNamespace("map"), RenderFilledMap::new);
 		builder.put(ResourceLocation.withDefaultNamespace("shield"), RenderShield::new);
 		builder.put(ResourceLocation.withDefaultNamespace("trident"), RenderTrident::new);
-		builder.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "uchigatana"), RenderKatana::new);
+		builder.put(EpicFightMod.identifier("uchigatana"), RenderKatana::new);
 		
 		ModLoader.get().postEvent(new PatchedRenderersEvent.RegisterItemRenderer(builder));
 		
@@ -342,7 +342,7 @@ public class RenderEngine {
 	
 	public Set<ResourceLocation> getRendererEntries() {
 		Set<ResourceLocation> availableRendererEntities = this.entityRendererProvider.keySet().stream().map((entityType) -> EntityType.getKey(entityType)).collect(Collectors.toSet());
-		availableRendererEntities.add(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "custom"));
+		availableRendererEntities.add(EpicFightMod.identifier("custom"));
 		
 		return availableRendererEntities;
 	}

--- a/src/main/java/yesman/epicfight/client/gui/EntityUI.java
+++ b/src/main/java/yesman/epicfight/client/gui/EntityUI.java
@@ -26,7 +26,7 @@ public abstract class EntityUI {
 	public static final List<EntityUI> ENTITY_UI_LIST = Lists.newArrayList();
 	public static final TargetIndicator TARGET_INDICATOR = new TargetIndicator();
 	public static final HealthBar HEALTH_BAR  = new HealthBar();
-	public static final ResourceLocation BATTLE_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/battle_icons.png");
+    public static final ResourceLocation BATTLE_ICON = EpicFightMod.identifier("textures/gui/battle_icons.png");
 	
 	public EntityUI() {
 		ENTITY_UI_LIST.add(this);

--- a/src/main/java/yesman/epicfight/client/gui/HealthBar.java
+++ b/src/main/java/yesman/epicfight/client/gui/HealthBar.java
@@ -31,8 +31,8 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.effect.VisibleMobEffect;
 
 public class HealthBar extends EntityUI {
-	public static final ResourceLocation HEALTHBARS1 = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png");
-	public static final ResourceLocation HEALTHBARS2 = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars2.png");
+    public static final ResourceLocation HEALTHBARS1 = EpicFightMod.identifier("textures/gui/healthbars1.png");
+    public static final ResourceLocation HEALTHBARS2 = EpicFightMod.identifier("textures/gui/healthbars2.png");
 	
 	private final Map<LivingEntity, EntityAttributeTracker> trackingEntities = Maps.newConcurrentMap();
 	

--- a/src/main/java/yesman/epicfight/client/gui/datapack/screen/DatapackEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/screen/DatapackEditScreen.java
@@ -754,7 +754,7 @@ public class DatapackEditScreen extends Screen {
 										} else {
 											grid.setValueChangeEnabled(false);
 											int rowposition = grid.addRowWithDefaultValues("pack_item", EpicFightMod.prefix(""));
-											this.packList.add(rowposition, PackEntry.of(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, ""), CompoundTag::new));
+											this.packList.add(rowposition, PackEntry.of(EpicFightMod.identifier(""), CompoundTag::new));
 											grid.setGridFocus(rowposition, "pack_item");
 											grid.setValueChangeEnabled(true);
 										}

--- a/src/main/java/yesman/epicfight/client/gui/datapack/widgets/PopupBox.java
+++ b/src/main/java/yesman/epicfight/client/gui/datapack/widgets/PopupBox.java
@@ -53,7 +53,7 @@ import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 import yesman.epicfight.world.capabilities.provider.EntityPatchProvider;
 
 public abstract class PopupBox<T> extends AbstractWidget implements DataBindingComponent<T, Pair<String, T>> {
-	public static final ResourceLocation POPUP_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/widget/popup_icon.png");
+    public static final ResourceLocation POPUP_ICON = EpicFightMod.identifier("textures/gui/widget/popup_icon.png");
 	
 	protected final Screen owner;
 	protected final Font font;

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillBookScreen.java
@@ -61,7 +61,7 @@ import yesman.epicfight.world.item.SkillBookItem;
 public class SkillBookScreen extends Screen {
 	private static final Map<WeaponCategory, ItemStack> WEAPON_CATEGORY_ICONS = Maps.newHashMap();
 	private static final Map<Attribute, TextureInfo> ATTRIBUTE_ICONS = Maps.newHashMap();
-	private static final ResourceLocation SKILLBOOK_BACKGROUND = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/screen/skillbook.png");
+    private static final ResourceLocation SKILLBOOK_BACKGROUND = EpicFightMod.identifier("textures/gui/screen/skillbook.png");
 	
 	public static final TextureInfo HEALTH_TEXTURE_INFO = new TextureInfo(SKILLBOOK_BACKGROUND, 22, 205, 10, 10);
 	public static final TextureInfo STAMINA_TEXTURE_INFO = new TextureInfo(SKILLBOOK_BACKGROUND, 32, 205, 10, 10);

--- a/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/SkillEditScreen.java
@@ -34,11 +34,11 @@ import yesman.epicfight.world.capabilities.skill.CapabilitySkill;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 
 public class SkillEditScreen extends Screen {
-	public static final ResourceLocation EMPTY_SKILL_SLOT_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/empty.png");
-	public static final ResourceLocation SCROLL_ARROW_UP = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/scroll_arrow_up.png");
-	public static final ResourceLocation SCROLL_ARROW_DOWN = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/scroll_arrow_down.png");
-	
-	private static final ResourceLocation SKILL_EDIT_UI = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/screen/skill_edit.png");
+    public static final ResourceLocation EMPTY_SKILL_SLOT_ICON = EpicFightMod.identifier("textures/gui/empty.png");
+    public static final ResourceLocation SCROLL_ARROW_UP = EpicFightMod.identifier("textures/gui/scroll_arrow_up.png");
+    public static final ResourceLocation SCROLL_ARROW_DOWN = EpicFightMod.identifier("textures/gui/scroll_arrow_down.png");
+
+    private static final ResourceLocation SKILL_EDIT_UI = EpicFightMod.identifier("textures/gui/screen/skill_edit.png");
 	private static final MutableComponent NO_SKILLS = Component.translatable(EpicFightMod.format("gui.%s.no_skills"));
 	
 	private static final int MAX_SKILL_OPTIONS_ROWS = 6;

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/TPSSettingScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/TPSSettingScreen.java
@@ -17,7 +17,7 @@ import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.main.EpicFightMod;
 
 public class TPSSettingScreen extends Screen {
-	private static final ResourceLocation BUTTON_TEXTURE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/widget/camera_settings.png");
+    private static final ResourceLocation BUTTON_TEXTURE = EpicFightMod.identifier("textures/gui/widget/camera_settings.png");
 	protected final Screen parentScreen;
 	protected Button up;
 	protected Button down;

--- a/src/main/java/yesman/epicfight/client/gui/screen/config/UISetupScreen.java
+++ b/src/main/java/yesman/epicfight/client/gui/screen/config/UISetupScreen.java
@@ -39,8 +39,8 @@ public class UISetupScreen extends Screen {
 		
 		// Weapon innate icon
 		this.addRenderableWidget(new UIComponent(weaponInnateX, weaponInnateY, weaponInnateXHandler, weaponInnateYHandler, weaponInnateBaseXHandler, weaponInnateBaseYHandler,
-			32, 32, 0, 0, 1, 1, 1, 1, 0, 163, 184, this, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/skills/weapon_innate/sweeping_edge.png")
-		));
+                32, 32, 0, 0, 1, 1, 1, 1, 0, 163, 184, this, EpicFightMod.identifier("textures/gui/skills/weapon_innate/sweeping_edge.png")
+        ));
 		
 		int staminaX = ClientConfig.staminaBarBaseX.positionGetter.apply(this.width, ClientConfig.staminaBarX);
 		int staminaY = ClientConfig.staminaBarBaseY.positionGetter.apply(this.height, ClientConfig.staminaBarY);
@@ -51,8 +51,8 @@ public class UISetupScreen extends Screen {
 		
 		// Stamina bar
 		this.addRenderableWidget(new UIComponent(staminaX, staminaY, staminaBarXHandler, staminaBarYHandler, staminaBarBaseXHandler, staminaBarBaseYHandler,
-			118, 4, 2, 38, 237, 9, 256, 256, 255, 128, 64, this, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/battle_icons.png")
-		));
+                118, 4, 2, 38, 237, 9, 256, 256, 255, 128, 64, this, EpicFightMod.identifier("textures/gui/battle_icons.png")
+        ));
 		
 		int chargingBarX = ClientConfig.chargingBarBaseX.positionGetter.apply(this.width, ClientConfig.chargingBarX);
 		int chargingBarY = ClientConfig.chargingBarBaseY.positionGetter.apply(this.height, ClientConfig.chargingBarY);
@@ -63,8 +63,8 @@ public class UISetupScreen extends Screen {
 		
 		// Charging bar
 		this.addRenderableWidget(new UIComponent(chargingBarX, chargingBarY, chargingBarXHandler, chargingBarYHandler, chargingBarBaseXHandler, chargingBarBaseYHandler,
-			238, 13, 1, 71, 237, 13, 256, 256, 255, 255, 255, this, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/battle_icons.png")
-		));
+                238, 13, 1, 71, 237, 13, 256, 256, 255, 255, 255, this, EpicFightMod.identifier("textures/gui/battle_icons.png")
+        ));
 		
 		int passiveX = ClientConfig.passiveBaseX.positionGetter.apply(this.width, ClientConfig.passiveX);
 		int passiveY = ClientConfig.passiveBaseY.positionGetter.apply(this.height, ClientConfig.passiveY);
@@ -76,8 +76,8 @@ public class UISetupScreen extends Screen {
 		
 		// Passive skill icons
 		this.addRenderableWidget(new PassiveUIComponent(passiveX, passiveY, passiveXHandler, passiveYHandler, passiveBaseXHandler, passiveBaseYHandler, passiveAlignDirectionHandler
-			, 24, 24, 0, 0, 1, 1, 1, 1, 255, 255, 255, this, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/skills/guard/guard.png"), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/skills/passive/berserker.png")
-		));
+                , 24, 24, 0, 0, 1, 1, 1, 1, 255, 255, 255, this, EpicFightMod.identifier("textures/gui/skills/guard/guard.png"), EpicFightMod.identifier("textures/gui/skills/passive/berserker.png")
+        ));
 		
 		this.addRenderableWidget(
 			Button.builder(Component.literal("⟳"), button -> {

--- a/src/main/java/yesman/epicfight/client/gui/widgets/UIComponentPop.java
+++ b/src/main/java/yesman/epicfight/client/gui/widgets/UIComponentPop.java
@@ -182,7 +182,7 @@ public class UIComponentPop<T extends UIComponent> extends Screen implements Con
 		}
 		
 		public static class AlignButton extends Button {
-			private static final ResourceLocation BATTLE_ICONS = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/battle_icons.png");
+            private static final ResourceLocation BATTLE_ICONS = EpicFightMod.identifier("textures/gui/battle_icons.png");
 			private final OptionHandler<HorizontalBasis> horBasis;
 			private final OptionHandler<VerticalBasis> verBasis;
 			private final OptionHandler<AlignDirection> alignDirection;

--- a/src/main/java/yesman/epicfight/client/particle/AirBurstParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/AirBurstParticle.java
@@ -12,7 +12,7 @@ import yesman.epicfight.api.client.model.Meshes;
 import yesman.epicfight.main.EpicFightMod;
 
 public class AirBurstParticle extends TexturedCustomModelParticle {
-	public static final ResourceLocation AIR_BURST_PARTICLE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/air_burst.png");
+    public static final ResourceLocation AIR_BURST_PARTICLE = EpicFightMod.identifier("textures/particle/air_burst.png");
 	
 	public AirBurstParticle(ClientLevel level, double x, double y, double z, double xd, double yd, double zd, AssetAccessor<ClassicMesh> particleMesh, ResourceLocation texture) {
 		super(level, x, y, z, xd, yd, zd, particleMesh, texture);

--- a/src/main/java/yesman/epicfight/client/particle/ProjectileTrailParticle.java
+++ b/src/main/java/yesman/epicfight/client/particle/ProjectileTrailParticle.java
@@ -160,7 +160,7 @@ public class ProjectileTrailParticle extends AbstractTrailParticle<ProjectilePat
 				.interpolations(4)
 				.lifetime(9)
 				.updateInterval(1)
-				.texture(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/projectile_trail.png"))
+				.texture(EpicFightMod.identifier("textures/particle/projectile_trail.png"))
 				.create();
 		
 		public static final TrailInfo SPECTRAL_ARROW_TRAIL_DEFAULT
@@ -175,7 +175,7 @@ public class ProjectileTrailParticle extends AbstractTrailParticle<ProjectilePat
 				.r(252.0F / 255.0F)
 				.g(252.0F / 255.0F)
 				.b(118.0F / 255.0F)
-				.texture(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/projectile_trail.png"))
+				.texture(EpicFightMod.identifier("textures/particle/projectile_trail.png"))
 				.create();
 		
 		public static final TrailInfo TRIDENT_TRAIL_DEFAULT
@@ -190,7 +190,7 @@ public class ProjectileTrailParticle extends AbstractTrailParticle<ProjectilePat
 				.r(0.0F / 255.0F)
 				.g(232.0F / 255.0F)
 				.b(245.0F / 255.0F)
-				.texture(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/particle/projectile_trail.png"))
+				.texture(EpicFightMod.identifier("textures/particle/projectile_trail.png"))
 				.create();
 		
 		@SuppressWarnings("unchecked")

--- a/src/main/java/yesman/epicfight/client/renderer/EpicFightRenderTypes.java
+++ b/src/main/java/yesman/epicfight/client/renderer/EpicFightRenderTypes.java
@@ -393,7 +393,7 @@ public final class EpicFightRenderTypes extends RenderType {
 			true,
 			RenderType.CompositeState.builder()
 				.setShaderState(PARTICLE_SHADER)
-				.setTextureState(new RenderStateShard.TextureStateShard(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/common/white.png"), false, false))
+				.setTextureState(new RenderStateShard.TextureStateShard(EpicFightMod.identifier("textures/common/white.png"), false, false))
 				.setCullState(NO_CULL)
 				.setWriteMaskState(COLOR_WRITE)
 				.setDepthTestState(EQUAL_DEPTH_TEST)
@@ -412,7 +412,7 @@ public final class EpicFightRenderTypes extends RenderType {
 			true,
 			RenderType.CompositeState.builder()
 				.setShaderState(PARTICLE_SHADER)
-				.setTextureState(new RenderStateShard.TextureStateShard(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/common/white.png"), false, false))
+				.setTextureState(new RenderStateShard.TextureStateShard(EpicFightMod.identifier("textures/common/white.png"), false, false))
 				.setCullState(NO_CULL)
 				.setWriteMaskState(COLOR_WRITE)
 				.setDepthTestState(EQUAL_DEPTH_TEST)
@@ -500,7 +500,7 @@ public final class EpicFightRenderTypes extends RenderType {
 			false,
 			true,
 			RenderType.CompositeState.builder()
-				.setTextureState(new RenderStateShard.TextureStateShard(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/common/white.png"), false, false))
+				.setTextureState(new RenderStateShard.TextureStateShard(EpicFightMod.identifier("textures/common/white.png"), false, false))
 				.setLightmapState(LIGHTMAP)
 				.setShaderState(RENDERTYPE_TRANSLUCENT_SHADER)
 				.setTransparencyState(TRANSLUCENT_TRANSPARENCY)
@@ -629,7 +629,7 @@ public final class EpicFightRenderTypes extends RenderType {
 				false,
 				EpicFightRenderTypes.MutableCompositeState.mutableStateBuilder()
 					.setShaderState(RENDERTYPE_ARMOR_ENTITY_GLINT_SHADER)
-					.setTextureState(new RenderStateShard.TextureStateShard(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/entity/overlay/glint_white.png"), true, false))
+					.setTextureState(new RenderStateShard.TextureStateShard(EpicFightMod.identifier("textures/entity/overlay/glint_white.png"), true, false))
 					.setWriteMaskState(COLOR_WRITE)
 					.setCullState(NO_CULL)
 					.setDepthTestState(EQUAL_DEPTH_TEST)

--- a/src/main/java/yesman/epicfight/client/renderer/EpicFightShaders.java
+++ b/src/main/java/yesman/epicfight/client/renderer/EpicFightShaders.java
@@ -26,7 +26,7 @@ public class EpicFightShaders {
 	
 	@SubscribeEvent
 	public static void registerShadersEvent(RegisterShadersEvent event) throws IOException {
-		event.registerShader(new ShaderInstance(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "solid_model"), DefaultVertexFormat.POSITION_COLOR_NORMAL), reloadedShader -> {
+		event.registerShader(new ShaderInstance(event.getResourceProvider(), EpicFightMod.identifier("solid_model"), DefaultVertexFormat.POSITION_COLOR_NORMAL), reloadedShader -> {
 			positionColorNormalShader = reloadedShader;
 		});
 	}

--- a/src/main/java/yesman/epicfight/client/renderer/entity/WitherSkeletonMinionRenderer.java
+++ b/src/main/java/yesman/epicfight/client/renderer/entity/WitherSkeletonMinionRenderer.java
@@ -7,7 +7,7 @@ import net.minecraft.world.entity.monster.AbstractSkeleton;
 import yesman.epicfight.main.EpicFightMod;
 
 public class WitherSkeletonMinionRenderer extends WitherSkeletonRenderer {
-	private static final ResourceLocation WITHER_SKELETON_LOCATION = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/entity/wither_skeleton_minion.png");
+    private static final ResourceLocation WITHER_SKELETON_LOCATION = EpicFightMod.identifier("textures/entity/wither_skeleton_minion.png");
 
 	public WitherSkeletonMinionRenderer(Context context) {
 		super(context);

--- a/src/main/java/yesman/epicfight/client/renderer/patched/item/EpicFightItemProperties.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/item/EpicFightItemProperties.java
@@ -9,14 +9,14 @@ import yesman.epicfight.world.item.SkillBookItem;
 
 public class EpicFightItemProperties {
 	public static void registerItemProperties() {
-		ItemProperties.register(EpicFightItems.SKILLBOOK.get(), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill"), (itemstack, level, entity, i) -> {
-			Skill skill = SkillBookItem.getContainSkill(itemstack);
-			
-			if (skill != null) {
-				return skill.getCategory().universalOrdinal();
-			}
-			
-			return Float.NEGATIVE_INFINITY;
-		});
+		ItemProperties.register(EpicFightItems.SKILLBOOK.get(), EpicFightMod.identifier("skill"), (itemstack, level, entity, i) -> {
+            Skill skill = SkillBookItem.getContainSkill(itemstack);
+
+            if (skill != null) {
+                return skill.getCategory().universalOrdinal();
+            }
+
+            return Float.NEGATIVE_INFINITY;
+        });
 	}
 }

--- a/src/main/java/yesman/epicfight/client/renderer/patched/layer/LayerUtil.java
+++ b/src/main/java/yesman/epicfight/client/renderer/patched/layer/LayerUtil.java
@@ -41,9 +41,9 @@ public class LayerUtil {
 	public static <E extends LivingEntity, T extends LivingEntityPatch<E>, M extends EntityModel<E>, R extends LivingEntityRenderer<E, M>, AM extends SkinnedMesh> void addLayer(LayerRenderer<E, T, M> renderer, EntityType<?> entityType, List<Pair<ResourceLocation, JsonElement>> layers) {
 		Map<ResourceLocation, LayerProvider<E, T, M, R, AM>> layersbyid = Maps.newHashMap();
 		
-		layersbyid.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "invisible"), LayerUtil::getInvisibleLayer);
-		layersbyid.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "eyes"), LayerUtil::getEyesLayer);
-		layersbyid.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "model_original"), LayerUtil::getOriginalModelLayer);
+		layersbyid.put(EpicFightMod.identifier("invisible"), LayerUtil::getInvisibleLayer);
+		layersbyid.put(EpicFightMod.identifier("eyes"), LayerUtil::getEyesLayer);
+		layersbyid.put(EpicFightMod.identifier("model_original"), LayerUtil::getOriginalModelLayer);
 		
 		MinecraftForge.EVENT_BUS.post(new RegisterResourceLayersEvent<> (layersbyid));
 		

--- a/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderProvider.java
+++ b/src/main/java/yesman/epicfight/client/renderer/shader/compute/loader/ComputeShaderProvider.java
@@ -56,8 +56,8 @@ public class ComputeShaderProvider {
         clear();
         
         try {
-            meshComputeVanilla = ComputeShaderLoader.loadComputeShaderProgram(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "shaders/compute/vanilla_mesh_transformer.comp"), BarrierFlags.SHADER_STORAGE, BarrierFlags.VERTEX_ATTRIB_ARRAY);
-            if (irisLoaded) meshComputeIris = ComputeShaderLoader.loadComputeShaderProgram(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "shaders/compute/iris_mesh_transformer.comp"), BarrierFlags.SHADER_STORAGE, BarrierFlags.VERTEX_ATTRIB_ARRAY);
+            meshComputeVanilla = ComputeShaderLoader.loadComputeShaderProgram(event.getResourceProvider(), EpicFightMod.identifier("shaders/compute/vanilla_mesh_transformer.comp"), BarrierFlags.SHADER_STORAGE, BarrierFlags.VERTEX_ATTRIB_ARRAY);
+            if (irisLoaded) meshComputeIris = ComputeShaderLoader.loadComputeShaderProgram(event.getResourceProvider(), EpicFightMod.identifier("shaders/compute/iris_mesh_transformer.comp"), BarrierFlags.SHADER_STORAGE, BarrierFlags.VERTEX_ATTRIB_ARRAY);
         } catch (Exception e) {
             supportComputeShader = false;
             EpicFightMod.LOGGER.warn("[Computer Shader Acceleration] There were some errors while loading the compute shader, and this feature will be forcibly disabled.");

--- a/src/main/java/yesman/epicfight/compat/JEIEpicFightPlugin.java
+++ b/src/main/java/yesman/epicfight/compat/JEIEpicFightPlugin.java
@@ -12,7 +12,7 @@ import yesman.epicfight.main.EpicFightMod;
 public class JEIEpicFightPlugin implements IModPlugin{
 	@Override
 	public ResourceLocation getPluginUid() {
-		return ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "jei_plugin");
+        return EpicFightMod.identifier("jei_plugin");
 	}
 	
 	@Override

--- a/src/main/java/yesman/epicfight/compat/SkinLayer3DCompat.java
+++ b/src/main/java/yesman/epicfight/compat/SkinLayer3DCompat.java
@@ -90,14 +90,14 @@ public class SkinLayer3DCompat implements ICompatModule {
 	@OnlyIn(Dist.CLIENT)
 	public void onCapabilityRegister(AttachCapabilitiesEvent<Entity> event) {
 		if (event.getObject().level().isClientSide() && event.getObject().getType() == EntityType.PLAYER) {
-			event.addCapability(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "animated_3d_skinlayer_mesh"), new ICapabilityProvider() {
-				final SkinLayer3DMeshes epicFight3dSkinLayerCapability = new SkinLayer3DMeshes();
-				
-				@Override
-				public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
-					return cap == SKIN_LAYER_3D_CAPABILITY ? LazyOptional.of(() -> this.epicFight3dSkinLayerCapability).cast() :  LazyOptional.empty();
-				}
-			});
+			event.addCapability(EpicFightMod.identifier("animated_3d_skinlayer_mesh"), new ICapabilityProvider() {
+                final SkinLayer3DMeshes epicFight3dSkinLayerCapability = new SkinLayer3DMeshes();
+
+                @Override
+                public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+                    return cap == SKIN_LAYER_3D_CAPABILITY ? LazyOptional.of(() -> this.epicFight3dSkinLayerCapability).cast() : LazyOptional.empty();
+                }
+            });
 			
 			event.addListener(() -> {
 				event.getObject().getCapability(SKIN_LAYER_3D_CAPABILITY).ifPresent((skinlayers3dMeshes) -> {

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyBindContexts.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyBindContexts.java
@@ -17,14 +17,14 @@ public final class EpicFightControlifyBindContexts {
         }
 
         public static final BindContext COMBAT_MODE = new BindContext(
-                EpicFightMod.rl("epicfight_combat"),
+                EpicFightMod.identifier("epicfight_combat"),
                 mc -> {
                     final boolean isInGame = isInGame(mc);
                     return isInGame && ClientEngine.getInstance().isEpicFightMode();
                 }
         );
         public static final BindContext LOCK_ON = new BindContext(
-                EpicFightMod.rl("epicfight_lock_on"),
+                EpicFightMod.identifier("epicfight_lock_on"),
                 mc -> {
                     final boolean isInGame = isInGame(mc);
                     return isInGame && EpicFightCameraAPI.getInstance().isLockingOnTarget();

--- a/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
+++ b/src/main/java/yesman/epicfight/compat/controlify/EpicFightControlifyEntrypoint.java
@@ -123,8 +123,8 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
     }
 
     private enum EpicFightRadialIcons {
-        UCHIGATANA(EpicFightMod.rl("textures/item/uchigatana_gui.png")),
-        SKILL_BOOK(EpicFightMod.rl("textures/item/skillbook.png"));
+        UCHIGATANA(EpicFightMod.identifier("textures/item/uchigatana_gui.png")),
+        SKILL_BOOK(EpicFightMod.identifier("textures/item/skillbook.png"));
 
         private final @NotNull ResourceLocation id;
 
@@ -298,7 +298,7 @@ public class EpicFightControlifyEntrypoint implements ControlifyEntrypoint {
             case OPEN_CONFIG_SCREEN -> "open_config_screen";
             case SWITCH_VANILLA_MODEL_DEBUGGING -> "switch_vanilla_mode_debugging";
         };
-        return EpicFightMod.rl(path);
+        return EpicFightMod.identifier(path);
     }
 
     private static void registerModIntegration() {

--- a/src/main/java/yesman/epicfight/data/conditions/EpicFightConditions.java
+++ b/src/main/java/yesman/epicfight/data/conditions/EpicFightConditions.java
@@ -20,7 +20,7 @@ import yesman.epicfight.data.conditions.itemstack.TagValueCondition;
 import yesman.epicfight.main.EpicFightMod;
 
 public class EpicFightConditions {
-	public static final DeferredRegister<Supplier<Condition<?>>> CONDITIONS = DeferredRegister.create(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "conditions"), EpicFightMod.MODID);
+	public static final DeferredRegister<Supplier<Condition<?>>> CONDITIONS = DeferredRegister.create(EpicFightMod.identifier("conditions"), EpicFightMod.MODID);
 	public static final Supplier<IForgeRegistry<Supplier<Condition<?>>>> REGISTRY = CONDITIONS.makeRegistry(RegistryBuilder::new);
 	
 	public static <T extends Condition<?>> Supplier<T> getConditionOrThrow(ResourceLocation key) throws NoSuchElementException, ClassCastException {

--- a/src/main/java/yesman/epicfight/data/loot/EpicFightLootTables.java
+++ b/src/main/java/yesman/epicfight/data/loot/EpicFightLootTables.java
@@ -30,7 +30,7 @@ public class EpicFightLootTables {
 	public static final LootItemFunctionType SET_SKILLBOOK_SKILL = new LootItemFunctionType(new SetSkillFunction.Serializer());
 	
 	public static void registerLootItemFunctionType() {
-		Registry.register(BuiltInRegistries.LOOT_FUNCTION_TYPE, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "set_skill"), SET_SKILLBOOK_SKILL);
+		Registry.register(BuiltInRegistries.LOOT_FUNCTION_TYPE, EpicFightMod.identifier("set_skill"), SET_SKILLBOOK_SKILL);
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/yesman/epicfight/events/CapabilityEvents.java
+++ b/src/main/java/yesman/epicfight/events/CapabilityEvents.java
@@ -16,9 +16,9 @@ import yesman.epicfight.world.capabilities.provider.SkillCapabilityProvider;
 
 @Mod.EventBusSubscriber(modid = EpicFightMod.MODID)
 public class CapabilityEvents {
-	private static final ResourceLocation ENTITY_CAPABILITY_KEY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "entity_cap");
-	private static final ResourceLocation ITEM_CAPABILITY_KEY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "item_cap");
-	private static final ResourceLocation SKILL_CAPABILITY_KEY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill_cap");
+    private static final ResourceLocation ENTITY_CAPABILITY_KEY = EpicFightMod.identifier("entity_cap");
+    private static final ResourceLocation ITEM_CAPABILITY_KEY = EpicFightMod.identifier("item_cap");
+    private static final ResourceLocation SKILL_CAPABILITY_KEY = EpicFightMod.identifier("skill_cap");
 	
 	@SubscribeEvent
 	public static void attachItemCapability(AttachCapabilitiesEvent<ItemStack> event) {

--- a/src/main/java/yesman/epicfight/gameasset/Animations.java
+++ b/src/main/java/yesman/epicfight/gameasset/Animations.java
@@ -510,9 +510,9 @@ public class Animations {
 					return dot < 0.0D ? 1 : 0;
 				},
 				accessor,
-				new DirectStaticAnimation(EpicFightSharedConstants.GENERAL_ANIMATION_TRANSITION_TIME, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "biped/living/creative_fly_forward"), Armatures.BIPED)
+				new DirectStaticAnimation(EpicFightSharedConstants.GENERAL_ANIMATION_TRANSITION_TIME, true, EpicFightMod.identifier("biped/living/creative_fly_forward"), Armatures.BIPED)
 					.addProperty(StaticAnimationProperty.POSE_MODIFIER, Animations.ReusableSources.FLYING_CORRECTION),
-				new DirectStaticAnimation(EpicFightSharedConstants.GENERAL_ANIMATION_TRANSITION_TIME, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "biped/living/creative_fly_backward"), Armatures.BIPED)
+				new DirectStaticAnimation(EpicFightSharedConstants.GENERAL_ANIMATION_TRANSITION_TIME, true, EpicFightMod.identifier("biped/living/creative_fly_backward"), Armatures.BIPED)
 					.addProperty(StaticAnimationProperty.POSE_MODIFIER, Animations.ReusableSources.FLYING_CORRECTION2)
 			)
 		);
@@ -566,8 +566,8 @@ public class Animations {
 			new SelectiveAnimation(
 				(entitypatch) -> entitypatch.getOriginal().swingingArm == InteractionHand.OFF_HAND ? 1 : 0,
 				accessor,
-				new DirectStaticAnimation(0.1F, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "biped/living/dig_mainhand"), Armatures.BIPED),
-				new DirectStaticAnimation(0.1F, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "biped/living/dig_offhand"), Armatures.BIPED)
+				new DirectStaticAnimation(0.1F, true, EpicFightMod.identifier("biped/living/dig_mainhand"), Armatures.BIPED),
+				new DirectStaticAnimation(0.1F, true, EpicFightMod.identifier("biped/living/dig_offhand"), Armatures.BIPED)
 			)
 		);
 		

--- a/src/main/java/yesman/epicfight/gameasset/ColliderPreset.java
+++ b/src/main/java/yesman/epicfight/gameasset/ColliderPreset.java
@@ -45,51 +45,51 @@ public class ColliderPreset implements PreparableReloadListener {
 		return PRESETS.get(rl);
 	}
 	
-	public static final Collider DAGGER = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dagger"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.6D, 0.0D, 0.0D, -0.1D));
-	public static final Collider DUAL_DAGGER_DASH = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dual_dagger_dash"), new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D));
-	public static final Collider BIPED_BODY_COLLIDER = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "biped_body_collider"), new MultiOBBCollider(
-			new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D),
-			new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D)
-		));
-	public static final Collider DRAGON_BODY = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dragon_body"), new OBBCollider(2.0D, 1.5D, 4.0D, 0.0D, 1.5D, -0.5D));
-	public static final Collider DRAGON_LEG = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dragon_leg"), new MultiOBBCollider(3, 0.8D, 1.6D, 0.8D, 0.0D, -0.6D, 0.7D));
-	public static final Collider DUAL_SWORD = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dual_sword"), new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 0.5D, -1.0D));
-	public static final Collider DUAL_SWORD_DASH = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dual_sword_dash"), new OBBCollider(0.8D, 0.5D, 1.0D, 0D, 1.0D, -1.0D));
-	public static final Collider BATTOJUTSU = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "battojutsu"), new OBBCollider(3.0D, 0.4D, 1.5D, 0.0D, 1.2D, -1.0D));
-	public static final Collider BATTOJUTSU_DASH = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "battojutsu_dash"), new MultiOBBCollider(
-			new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
-			new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
-			new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
-			new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
-			new OBBCollider(1.5D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D)
-		));
-	public static final Collider FIST = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "fist"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.4D, 0D, 0D, 0D));
-	public static final Collider GREATSWORD = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "greatsword"), new MultiOBBCollider(3, 0.5D, 0.8D, 1.0D, 0D, 0D, -1.0D));
-	public static final Collider HEAD = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "head"), new OBBCollider(0.4D, 0.4D, 0.4D, 0D, 0D, -0.3D));
-	public static final Collider HEADBUTT_RAVAGER = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "headbutt_ravager"), new OBBCollider(0.8D, 0.8D, 0.8D, 0D, 0D, -0.3D));
-	public static final Collider UCHIGATANA = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "uchigatana"), new MultiOBBCollider(5, 0.4D, 0.4D, 0.7D, 0D, 0D, -0.7D));
-	public static final Collider TACHI = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "tachi"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.95D, 0D, 0D, -0.95D));
-	public static final Collider SWORD = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "sword"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.7D, 0D, 0D, -0.35D));
-	public static final Collider LONGSWORD = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "longsword"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.8D, 0D, 0D, -0.75D));
-	public static final Collider SPEAR = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "spear"), new MultiOBBCollider(3, 0.6D, 0.6D, 1.0D, 0D, 0D, -1.0D));
-	public static final Collider SPIDER = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "spider"), new OBBCollider(0.8D, 0.8D, 0.8D, 0D, 0D, -0.4D));
+	public static final Collider DAGGER = registerCollider(EpicFightMod.identifier("dagger"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.6D, 0.0D, 0.0D, -0.1D));
+	public static final Collider DUAL_DAGGER_DASH = registerCollider(EpicFightMod.identifier("dual_dagger_dash"), new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D));
+	public static final Collider BIPED_BODY_COLLIDER = registerCollider(EpicFightMod.identifier("biped_body_collider"), new MultiOBBCollider(
+            new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D),
+            new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 1.0D, -0.6D)
+    ));
+	public static final Collider DRAGON_BODY = registerCollider(EpicFightMod.identifier("dragon_body"), new OBBCollider(2.0D, 1.5D, 4.0D, 0.0D, 1.5D, -0.5D));
+	public static final Collider DRAGON_LEG = registerCollider(EpicFightMod.identifier("dragon_leg"), new MultiOBBCollider(3, 0.8D, 1.6D, 0.8D, 0.0D, -0.6D, 0.7D));
+	public static final Collider DUAL_SWORD = registerCollider(EpicFightMod.identifier("dual_sword"), new OBBCollider(0.8D, 0.5D, 1.0D, 0.0D, 0.5D, -1.0D));
+	public static final Collider DUAL_SWORD_DASH = registerCollider(EpicFightMod.identifier("dual_sword_dash"), new OBBCollider(0.8D, 0.5D, 1.0D, 0D, 1.0D, -1.0D));
+	public static final Collider BATTOJUTSU = registerCollider(EpicFightMod.identifier("battojutsu"), new OBBCollider(3.0D, 0.4D, 1.5D, 0.0D, 1.2D, -1.0D));
+	public static final Collider BATTOJUTSU_DASH = registerCollider(EpicFightMod.identifier("battojutsu_dash"), new MultiOBBCollider(
+            new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
+            new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
+            new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
+            new OBBCollider(0.7D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D),
+            new OBBCollider(1.5D, 0.7D, 1.0D, 0.0D, 1.0D, -1.0D)
+    ));
+	public static final Collider FIST = registerCollider(EpicFightMod.identifier("fist"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.4D, 0D, 0D, 0D));
+	public static final Collider GREATSWORD = registerCollider(EpicFightMod.identifier("greatsword"), new MultiOBBCollider(3, 0.5D, 0.8D, 1.0D, 0D, 0D, -1.0D));
+	public static final Collider HEAD = registerCollider(EpicFightMod.identifier("head"), new OBBCollider(0.4D, 0.4D, 0.4D, 0D, 0D, -0.3D));
+	public static final Collider HEADBUTT_RAVAGER = registerCollider(EpicFightMod.identifier("headbutt_ravager"), new OBBCollider(0.8D, 0.8D, 0.8D, 0D, 0D, -0.3D));
+	public static final Collider UCHIGATANA = registerCollider(EpicFightMod.identifier("uchigatana"), new MultiOBBCollider(5, 0.4D, 0.4D, 0.7D, 0D, 0D, -0.7D));
+	public static final Collider TACHI = registerCollider(EpicFightMod.identifier("tachi"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.95D, 0D, 0D, -0.95D));
+	public static final Collider SWORD = registerCollider(EpicFightMod.identifier("sword"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.7D, 0D, 0D, -0.35D));
+	public static final Collider LONGSWORD = registerCollider(EpicFightMod.identifier("longsword"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.8D, 0D, 0D, -0.75D));
+	public static final Collider SPEAR = registerCollider(EpicFightMod.identifier("spear"), new MultiOBBCollider(3, 0.6D, 0.6D, 1.0D, 0D, 0D, -1.0D));
+	public static final Collider SPIDER = registerCollider(EpicFightMod.identifier("spider"), new OBBCollider(0.8D, 0.8D, 0.8D, 0D, 0D, -0.4D));
 	
-	public static final Collider STEEL_WHIRLWIND = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "steel_whirlwind"), new MultiOBBCollider(
-			new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
-			new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
-			new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
-			new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D)
-		));
+	public static final Collider STEEL_WHIRLWIND = registerCollider(EpicFightMod.identifier("steel_whirlwind"), new MultiOBBCollider(
+            new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
+            new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
+            new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D),
+            new OBBCollider(1.8D, 0.6D, 1.5D, 0.0D, 1.0D, -0.5D)
+    ));
 	
-	public static final Collider TOOLS = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "tools"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.55D, 0D, 0.0D, -0.25D));
-	public static final Collider ENDERMAN_LIMB = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "enderman_limb"), new OBBCollider(0.4D, 0.8D, 0.4D, 0D, 0D, 0D));
-	public static final Collider GOLEM_SMASHDOWN = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "golem_smashdown"), new MultiOBBCollider(3, 0.75D, 0.5D, 0.5D, 0.6D, 0.5D, 0D));
-	public static final Collider GOLEM_SWING_ARM = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "golem_swing_arm"), new MultiOBBCollider(2, 0.6D, 0.9D, 0.6D, 0D, 0D, 0D));
-	public static final Collider FIST_FIXED = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "fist_fixed"), new OBBCollider(0.4D, 0.4D, 0.5D, 0D, 1.25D, -0.85D));
-	public static final Collider DUAL_SWORD_AIR_SLASH = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dual_sword_air_slash"), new OBBCollider(0.8D, 0.4D, 1.0D, 0D, 0.5D, -0.5D));
-	public static final Collider DUAL_DAGGER_AIR_SLASH = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dual_dagger_air_slash"), new OBBCollider(0.8D, 0.4D, 0.75D, 0D, 0.5D, -0.5D));
-	public static final Collider WITHER_CHARGE = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "wither_charge"), new MultiOBBCollider(5, 0.7D, 0.9D, 0.7D, 0D, 1.0D, -0.35D));
-	public static final Collider VEX_CHARGE = registerCollider(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "vex_charge"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.95D, 0D, 0.2D, -0.85D));
+	public static final Collider TOOLS = registerCollider(EpicFightMod.identifier("tools"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.55D, 0D, 0.0D, -0.25D));
+	public static final Collider ENDERMAN_LIMB = registerCollider(EpicFightMod.identifier("enderman_limb"), new OBBCollider(0.4D, 0.8D, 0.4D, 0D, 0D, 0D));
+	public static final Collider GOLEM_SMASHDOWN = registerCollider(EpicFightMod.identifier("golem_smashdown"), new MultiOBBCollider(3, 0.75D, 0.5D, 0.5D, 0.6D, 0.5D, 0D));
+	public static final Collider GOLEM_SWING_ARM = registerCollider(EpicFightMod.identifier("golem_swing_arm"), new MultiOBBCollider(2, 0.6D, 0.9D, 0.6D, 0D, 0D, 0D));
+	public static final Collider FIST_FIXED = registerCollider(EpicFightMod.identifier("fist_fixed"), new OBBCollider(0.4D, 0.4D, 0.5D, 0D, 1.25D, -0.85D));
+	public static final Collider DUAL_SWORD_AIR_SLASH = registerCollider(EpicFightMod.identifier("dual_sword_air_slash"), new OBBCollider(0.8D, 0.4D, 1.0D, 0D, 0.5D, -0.5D));
+	public static final Collider DUAL_DAGGER_AIR_SLASH = registerCollider(EpicFightMod.identifier("dual_dagger_air_slash"), new OBBCollider(0.8D, 0.4D, 0.75D, 0D, 0.5D, -0.5D));
+	public static final Collider WITHER_CHARGE = registerCollider(EpicFightMod.identifier("wither_charge"), new MultiOBBCollider(5, 0.7D, 0.9D, 0.7D, 0D, 1.0D, -0.35D));
+	public static final Collider VEX_CHARGE = registerCollider(EpicFightMod.identifier("vex_charge"), new MultiOBBCollider(3, 0.4D, 0.4D, 0.95D, 0D, 0.2D, -0.85D));
 	
 	public static Collider deserializeSimpleCollider(CompoundTag tag) throws IllegalArgumentException {
 		int number = tag.getInt("number");

--- a/src/main/java/yesman/epicfight/gameasset/EpicFightSounds.java
+++ b/src/main/java/yesman/epicfight/gameasset/EpicFightSounds.java
@@ -56,7 +56,7 @@ public class EpicFightSounds {
 	public static final RegistryObject<SoundEvent> VENGEANCE = registerSound("skill.vengeance");
 	
 	private static RegistryObject<SoundEvent> registerSound(String name) {
-		ResourceLocation res = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, name);
+        ResourceLocation res = EpicFightMod.identifier(name);
 		return SOUNDS.register(name, () -> SoundEvent.createVariableRangeEvent(res));
 	}
 }

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -1,16 +1,6 @@
 package yesman.epicfight.main;
 
-import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
-
 import com.mojang.logging.LogUtils;
-
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
@@ -37,6 +27,9 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -56,18 +49,7 @@ import yesman.epicfight.client.gui.screen.SkillBookScreen;
 import yesman.epicfight.client.gui.screen.config.IngameConfigurationScreen;
 import yesman.epicfight.client.renderer.patched.item.EpicFightItemProperties;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
-import yesman.epicfight.compat.AzureLibArmorCompat;
-import yesman.epicfight.compat.AzureLibCompat;
-import yesman.epicfight.compat.CuriosCompat;
-import yesman.epicfight.compat.FirstPersonCompat;
-import yesman.epicfight.compat.GeckolibCompat;
-import yesman.epicfight.compat.ICompatModule;
-import yesman.epicfight.compat.IRISCompat;
-import yesman.epicfight.compat.IceAndFireCompat;
-import yesman.epicfight.compat.PlayerAnimatorCompat;
-import yesman.epicfight.compat.SkinLayer3DCompat;
-import yesman.epicfight.compat.VampirismCompat;
-import yesman.epicfight.compat.WerewolvesCompat;
+import yesman.epicfight.compat.*;
 import yesman.epicfight.compat.betterthirdperson.BetterThirdPersonCompat;
 import yesman.epicfight.config.ClientConfig;
 import yesman.epicfight.config.CommonConfig;
@@ -87,11 +69,7 @@ import yesman.epicfight.server.commands.PlayerModeCommand;
 import yesman.epicfight.server.commands.PlayerSkillCommand;
 import yesman.epicfight.server.commands.PlayerStaminaCommand;
 import yesman.epicfight.server.commands.arguments.EpicFightCommandArgumentTypes;
-import yesman.epicfight.skill.SkillCategories;
-import yesman.epicfight.skill.SkillCategory;
-import yesman.epicfight.skill.SkillDataKeys;
-import yesman.epicfight.skill.SkillSlot;
-import yesman.epicfight.skill.SkillSlots;
+import yesman.epicfight.skill.*;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.Faction;
 import yesman.epicfight.world.capabilities.entitypatch.Factions;
@@ -114,6 +92,11 @@ import yesman.epicfight.world.item.EpicFightItems;
 import yesman.epicfight.world.item.SkillBookItem;
 import yesman.epicfight.world.level.block.EpicFightBlocks;
 import yesman.epicfight.world.level.block.entity.EpicFightBlockEntities;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  *  --- Future list ---
@@ -405,7 +388,16 @@ public class EpicFightMod {
 		});
 	}
 
-    public static @NotNull ResourceLocation rl(@NotNull String path) {
-        return ResourceLocation.fromNamespaceAndPath(MODID, path);
-    }
+	/// Creates an identifier that points to an Epic Fight resource.
+	///
+	/// This was called `identifier` and not `resourceLocation` since [Mojang renamed `ResourceLocation` to `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).
+	public static @NotNull ResourceLocation identifier(@NotNull String path) {
+		return ResourceLocation.fromNamespaceAndPath(MODID, path);
+	}
+
+	/// @deprecated Use [#identifier(String)] instead. [Mojang renamed `ResourceLocation` to `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).
+	@Deprecated(forRemoval = true)
+	public static @NotNull ResourceLocation rl(@NotNull String path) {
+		return identifier(path);
+	}
 }

--- a/src/main/java/yesman/epicfight/network/EpicFightNetworkManager.java
+++ b/src/main/java/yesman/epicfight/network/EpicFightNetworkManager.java
@@ -23,11 +23,11 @@ public class EpicFightNetworkManager {
 	private static final String PROTOCOL_VERSION = "1";
 	public static final SimpleChannel INSTANCE =
 		NetworkRegistry.newSimpleChannel(
-			ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "network_manager"),
-			() -> PROTOCOL_VERSION,
-			PROTOCOL_VERSION::equals,
-			PROTOCOL_VERSION::equals
-		);
+                EpicFightMod.identifier("network_manager"),
+                () -> PROTOCOL_VERSION,
+                PROTOCOL_VERSION::equals,
+                PROTOCOL_VERSION::equals
+        );
 
 	public static void sendToServer(Object message) {
 		INSTANCE.sendToServer(message);

--- a/src/main/java/yesman/epicfight/skill/SkillCategories.java
+++ b/src/main/java/yesman/epicfight/skill/SkillCategories.java
@@ -5,14 +5,14 @@ import yesman.epicfight.main.EpicFightMod;
 
 public enum SkillCategories implements SkillCategory {
 	BASIC_ATTACK(false, false, false),
-	DODGE(true, true, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook_dodge")),
-	PASSIVE(true, true, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook_passive")),
+	DODGE(true, true, true, EpicFightMod.identifier("skillbook_dodge")),
+	PASSIVE(true, true, true, EpicFightMod.identifier("skillbook_passive")),
 	WEAPON_PASSIVE(false, false, false),
 	WEAPON_INNATE(false, true, false),
-	GUARD(true, true, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook_guard")),
+	GUARD(true, true, true, EpicFightMod.identifier("skillbook_guard")),
 	KNOCKDOWN_WAKEUP(false, false, false),
-	MOVER(true, true, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook_mover")),
-	IDENTITY(true, true, true, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook_identity"));
+	MOVER(true, true, true, EpicFightMod.identifier("skillbook_mover")),
+	IDENTITY(true, true, true, EpicFightMod.identifier("skillbook_identity"));
 	
 	
 	final boolean shouldSave;

--- a/src/main/java/yesman/epicfight/skill/SkillCategory.java
+++ b/src/main/java/yesman/epicfight/skill/SkillCategory.java
@@ -7,7 +7,7 @@ import yesman.epicfight.client.gui.screen.SkillEditScreen;
 import yesman.epicfight.main.EpicFightMod;
 
 public interface SkillCategory extends ExtendableEnum {
-	ResourceLocation DEFAULT_BOOK_ICON = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skillbook");
+    ResourceLocation DEFAULT_BOOK_ICON = EpicFightMod.identifier("skillbook");
 	
 	ExtendableEnumManager<SkillCategory> ENUM_MANAGER = new ExtendableEnumManager<> ("skill_category");
 	

--- a/src/main/java/yesman/epicfight/skill/SkillDataKey.java
+++ b/src/main/java/yesman/epicfight/skill/SkillDataKey.java
@@ -20,8 +20,8 @@ import yesman.epicfight.main.EpicFightMod;
 
 public class SkillDataKey<T> {
 	private static final HashMultimap<Class<?>, SkillDataKey<?>> SKILL_DATA_KEYS = HashMultimap.create();
-	private static final ResourceLocation CLASS_TO_DATA_KEYS = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "classtodatakeys");
-	private static final ResourceLocation DATA_KEY_TO_ID = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "datakeytoid");
+    private static final ResourceLocation CLASS_TO_DATA_KEYS = EpicFightMod.identifier("classtodatakeys");
+    private static final ResourceLocation DATA_KEY_TO_ID = EpicFightMod.identifier("datakeytoid");
 	
 	private static class SkillDataKeyCallbacks implements IForgeRegistry.BakeCallback<SkillDataKey<?>>, IForgeRegistry.CreateCallback<SkillDataKey<?>>, IForgeRegistry.ClearCallback<SkillDataKey<?>> {
 		static final SkillDataKeyCallbacks INSTANCE = new SkillDataKeyCallbacks();

--- a/src/main/java/yesman/epicfight/skill/SkillDataKeys.java
+++ b/src/main/java/yesman/epicfight/skill/SkillDataKeys.java
@@ -32,7 +32,7 @@ import yesman.epicfight.world.damagesource.EpicFightDamageTypeTags;
 public class SkillDataKeys {
 	private static final Supplier<RegistryBuilder<SkillDataKey<?>>> BUILDER = () -> new RegistryBuilder<SkillDataKey<?>>().addCallback(SkillDataKey.getRegistryCallback());
 	
-	public static final DeferredRegister<SkillDataKey<?>> DATA_KEYS = DeferredRegister.create(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "skill_data_keys"), EpicFightMod.MODID);
+	public static final DeferredRegister<SkillDataKey<?>> DATA_KEYS = DeferredRegister.create(EpicFightMod.identifier("skill_data_keys"), EpicFightMod.MODID);
 	public static final Supplier<IForgeRegistry<SkillDataKey<?>>> REGISTRY = DATA_KEYS.makeRegistry(BUILDER);
 	
 	/**

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/EntityDecorations.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/EntityDecorations.java
@@ -27,24 +27,24 @@ public final class EntityDecorations {
 	private final Map<ResourceLocation, AnimationPropertyModifier<TrailInfo, CapabilityItem>> trail = new HashMap<> ();
 	private final Map<ResourceLocation, ParticleGenerator> particleGenerator = new HashMap<> ();
 	private final Map<ResourceLocation, DecorationOverlay> decorationOverlays = new HashMap<> ();
-	
-	public static final ResourceLocation ADAPTIVE_SKIN_COLOR = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "adaptive_skin_color");
-	public static final ResourceLocation ADAPTIVE_SKIN_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "adaptive_skin_overlay");
-	public static final ResourceLocation BERSERKER_PARTICLE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "berserker_particle");
-	public static final ResourceLocation BERSERKER_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "berserker_overlay");
-	public static final ResourceLocation BONEBREAKER_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "bonebreaker_overlay");
-	public static final ResourceLocation EMERGENCY_ESCAPE_TRANSPARENCY_MODIFIER = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "emergency_escape_transparency_modifier");
-	public static final ResourceLocation HYPERVITALITY_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "hypervitality_overlay");
-	public static final ResourceLocation STAMINA_PILLAGER_ASHES_COLOR = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "stamina_pillager_ashes_color");
-	public static final ResourceLocation STAMINA_PILLAGER_ASHES_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "stamina_pillager_ashes_overlay");
-	public static final ResourceLocation STAMINA_PILLAGER_ASHES_PARTICLE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "stamina_pillager_ashes_particle");
-	public static final ResourceLocation STAMINA_PILLAGER_FILLS_UP_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "stamina_pillager_fills_up_overlay");
-	public static final ResourceLocation STAMINA_PILLAGER_FILLS_UP_LIGHT = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "stamina_pillager_fills_up_light");
-	public static final ResourceLocation FLASH_WHITE_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "flash_white_overlay");
-	public static final ResourceLocation FLASH_WHITE_LIGHT = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "flash_white_light");
-	public static final ResourceLocation SWORDMASTER_SWING_SOUND = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "swordmaster_swing_sound_modifier");
-	public static final ResourceLocation SWORDMASTER_TRAIL_MODIFIER = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "swordmaster_trail_modifier");
-	public static final ResourceLocation VENGEANCE_OVERLAY = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "vengeance_overlay");
+
+    public static final ResourceLocation ADAPTIVE_SKIN_COLOR = EpicFightMod.identifier("adaptive_skin_color");
+    public static final ResourceLocation ADAPTIVE_SKIN_OVERLAY = EpicFightMod.identifier("adaptive_skin_overlay");
+    public static final ResourceLocation BERSERKER_PARTICLE = EpicFightMod.identifier("berserker_particle");
+    public static final ResourceLocation BERSERKER_OVERLAY = EpicFightMod.identifier("berserker_overlay");
+    public static final ResourceLocation BONEBREAKER_OVERLAY = EpicFightMod.identifier("bonebreaker_overlay");
+    public static final ResourceLocation EMERGENCY_ESCAPE_TRANSPARENCY_MODIFIER = EpicFightMod.identifier("emergency_escape_transparency_modifier");
+    public static final ResourceLocation HYPERVITALITY_OVERLAY = EpicFightMod.identifier("hypervitality_overlay");
+    public static final ResourceLocation STAMINA_PILLAGER_ASHES_COLOR = EpicFightMod.identifier("stamina_pillager_ashes_color");
+    public static final ResourceLocation STAMINA_PILLAGER_ASHES_OVERLAY = EpicFightMod.identifier("stamina_pillager_ashes_overlay");
+    public static final ResourceLocation STAMINA_PILLAGER_ASHES_PARTICLE = EpicFightMod.identifier("stamina_pillager_ashes_particle");
+    public static final ResourceLocation STAMINA_PILLAGER_FILLS_UP_OVERLAY = EpicFightMod.identifier("stamina_pillager_fills_up_overlay");
+    public static final ResourceLocation STAMINA_PILLAGER_FILLS_UP_LIGHT = EpicFightMod.identifier("stamina_pillager_fills_up_light");
+    public static final ResourceLocation FLASH_WHITE_OVERLAY = EpicFightMod.identifier("flash_white_overlay");
+    public static final ResourceLocation FLASH_WHITE_LIGHT = EpicFightMod.identifier("flash_white_light");
+    public static final ResourceLocation SWORDMASTER_SWING_SOUND = EpicFightMod.identifier("swordmaster_swing_sound_modifier");
+    public static final ResourceLocation SWORDMASTER_TRAIL_MODIFIER = EpicFightMod.identifier("swordmaster_trail_modifier");
+    public static final ResourceLocation VENGEANCE_OVERLAY = EpicFightMod.identifier("vengeance_overlay");
 	
 	public void addOverlayCoordModifier(ResourceLocation id, RenderAttributeModifier<Vec2i> overlayModifier) {
 		this.overlay.put(id, overlayModifier);
@@ -232,7 +232,7 @@ public final class EntityDecorations {
 	
 	@OnlyIn(Dist.CLIENT)
 	public interface DecorationOverlay {
-		static ResourceLocation GENERIC = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/common/white.png");
+        static ResourceLocation GENERIC = EpicFightMod.identifier("textures/common/white.png");
 		static Vector4f NO_COLOR = new Vector4f(1.0F);
 		
 		default Vector4f color(float partialTick) {

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/Factions.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/Factions.java
@@ -5,15 +5,15 @@ import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.main.EpicFightMod;
 
 public enum Factions implements Faction {
-	NEUTRAL(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(255, 255, 0, 100), 0),
-	UNDEAD(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 1),
-	BLAZE(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(183, 227, 255, 255), 2),
-	ENDERMAN(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 3),
-	ILLAGER(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 4),
-	PIGLINS(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 5),
-	WITHER(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 1),
-	VILLAGER(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 0),
-	ZOMBIFIED_PIGLIN(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 2)
+	NEUTRAL(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(255, 255, 0, 100), 0),
+	UNDEAD(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 1),
+	BLAZE(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(183, 227, 255, 255), 2),
+	ENDERMAN(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 3),
+	ILLAGER(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 4),
+	PIGLINS(EpicFightMod.identifier("textures/gui/healthbars1.png"), MathUtils.packColor(255, 0, 0, 100), 5),
+	WITHER(EpicFightMod.identifier("textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 1),
+	VILLAGER(EpicFightMod.identifier("textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 0),
+	ZOMBIFIED_PIGLIN(EpicFightMod.identifier("textures/gui/healthbars2.png"), MathUtils.packColor(255, 0, 0, 100), 2)
 	;
 	
 	final ResourceLocation healthBar;

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/LivingEntityPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/LivingEntityPatch.java
@@ -268,7 +268,7 @@ public abstract class LivingEntityPatch<T extends LivingEntity> extends Hurtable
 			switch (packet.getPairingPacketType().toEnum(EntityPairingPacketTypes.class)) {
 			case BONEBREAKER_BEGIN -> {
 				this.entityDecorations.addDecorationOverlay(EntityDecorations.BONEBREAKER_OVERLAY, new DecorationOverlay() {
-					static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/entity/overlay/crack_level1.png");
+                    static final ResourceLocation TEXTURE = EpicFightMod.identifier("textures/entity/overlay/crack_level1.png");
 					
 					@Override
 					public RenderType getRenderType() {
@@ -278,7 +278,7 @@ public abstract class LivingEntityPatch<T extends LivingEntity> extends Hurtable
 			}
 			case BONEBREAKER_MAX_STACK -> {
 				this.entityDecorations.addDecorationOverlay(EntityDecorations.BONEBREAKER_OVERLAY, new DecorationOverlay() {
-					static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/entity/overlay/crack_level2.png");
+                    static final ResourceLocation TEXTURE = EpicFightMod.identifier("textures/entity/overlay/crack_level2.png");
 					
 					@Override
 					public RenderType getRenderType() {

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponTypeReloadListener.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponTypeReloadListener.java
@@ -51,22 +51,22 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 public class WeaponTypeReloadListener extends SimpleJsonResourceReloadListener {
 	public static void registerDefaultWeaponTypes() {
 		Map<ResourceLocation, Function<Item, CapabilityItem.Builder>> typeEntry = Maps.newHashMap();
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "axe"), WeaponCapabilityPresets.AXE);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "fist"), WeaponCapabilityPresets.FIST);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "hoe"), WeaponCapabilityPresets.HOE);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "pickaxe"), WeaponCapabilityPresets.PICKAXE);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "shovel"), WeaponCapabilityPresets.SHOVEL);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "sword"), WeaponCapabilityPresets.SWORD);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "spear"), WeaponCapabilityPresets.SPEAR);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "greatsword"), WeaponCapabilityPresets.GREATSWORD);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "uchigatana"), WeaponCapabilityPresets.UCHIGATANA);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "tachi"), WeaponCapabilityPresets.TACHI);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "longsword"), WeaponCapabilityPresets.LONGSWORD);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "dagger"), WeaponCapabilityPresets.DAGGER);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "bow"), WeaponCapabilityPresets.BOW);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "crossbow"), WeaponCapabilityPresets.CROSSBOW);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "trident"), WeaponCapabilityPresets.TRIDENT);
-		typeEntry.put(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "shield"), WeaponCapabilityPresets.SHIELD);
+		typeEntry.put(EpicFightMod.identifier("axe"), WeaponCapabilityPresets.AXE);
+		typeEntry.put(EpicFightMod.identifier("fist"), WeaponCapabilityPresets.FIST);
+		typeEntry.put(EpicFightMod.identifier("hoe"), WeaponCapabilityPresets.HOE);
+		typeEntry.put(EpicFightMod.identifier("pickaxe"), WeaponCapabilityPresets.PICKAXE);
+		typeEntry.put(EpicFightMod.identifier("shovel"), WeaponCapabilityPresets.SHOVEL);
+		typeEntry.put(EpicFightMod.identifier("sword"), WeaponCapabilityPresets.SWORD);
+		typeEntry.put(EpicFightMod.identifier("spear"), WeaponCapabilityPresets.SPEAR);
+		typeEntry.put(EpicFightMod.identifier("greatsword"), WeaponCapabilityPresets.GREATSWORD);
+		typeEntry.put(EpicFightMod.identifier("uchigatana"), WeaponCapabilityPresets.UCHIGATANA);
+		typeEntry.put(EpicFightMod.identifier("tachi"), WeaponCapabilityPresets.TACHI);
+		typeEntry.put(EpicFightMod.identifier("longsword"), WeaponCapabilityPresets.LONGSWORD);
+		typeEntry.put(EpicFightMod.identifier("dagger"), WeaponCapabilityPresets.DAGGER);
+		typeEntry.put(EpicFightMod.identifier("bow"), WeaponCapabilityPresets.BOW);
+		typeEntry.put(EpicFightMod.identifier("crossbow"), WeaponCapabilityPresets.CROSSBOW);
+		typeEntry.put(EpicFightMod.identifier("trident"), WeaponCapabilityPresets.TRIDENT);
+		typeEntry.put(EpicFightMod.identifier("shield"), WeaponCapabilityPresets.SHIELD);
 		
 		WeaponCapabilityPresetRegistryEvent weaponCapabilityPresetRegistryEvent = new WeaponCapabilityPresetRegistryEvent(typeEntry);
 		ModLoader.get().postEvent(weaponCapabilityPresetRegistryEvent);

--- a/src/main/java/yesman/epicfight/world/damagesource/EpicFightDamageTypeTags.java
+++ b/src/main/java/yesman/epicfight/world/damagesource/EpicFightDamageTypeTags.java
@@ -63,6 +63,6 @@ public interface EpicFightDamageTypeTags {
 	TagKey<DamageType> IS_MAGIC = create("is_magic");
 	
 	private static TagKey<DamageType> create(String tagName) {
-		return TagKey.create(Registries.DAMAGE_TYPE, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, tagName));
+		return TagKey.create(Registries.DAMAGE_TYPE, EpicFightMod.identifier(tagName));
 	}
 }

--- a/src/main/java/yesman/epicfight/world/damagesource/EpicFightDamageTypes.java
+++ b/src/main/java/yesman/epicfight/world/damagesource/EpicFightDamageTypes.java
@@ -9,6 +9,6 @@ import yesman.epicfight.main.EpicFightMod;
 public final class EpicFightDamageTypes {
 	private EpicFightDamageTypes() {}
 	
-	public static final ResourceKey<DamageType> SHOCKWAVE = ResourceKey.create(Registries.DAMAGE_TYPE, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "shockwave"));
-	public static final ResourceKey<DamageType> WITHER_BEAM = ResourceKey.create(Registries.DAMAGE_TYPE, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "wither_beam"));
+	public static final ResourceKey<DamageType> SHOCKWAVE = ResourceKey.create(Registries.DAMAGE_TYPE, EpicFightMod.identifier("shockwave"));
+	public static final ResourceKey<DamageType> WITHER_BEAM = ResourceKey.create(Registries.DAMAGE_TYPE, EpicFightMod.identifier("wither_beam"));
 }

--- a/src/main/java/yesman/epicfight/world/effect/EpicFightMobEffects.java
+++ b/src/main/java/yesman/epicfight/world/effect/EpicFightMobEffects.java
@@ -15,16 +15,16 @@ public class EpicFightMobEffects {
 	public static final DeferredRegister<MobEffect> EFFECTS = DeferredRegister.create(ForgeRegistries.MOB_EFFECTS, EpicFightMod.MODID);
 	
 	public static final RegistryObject<MobEffect> STUN_IMMUNITY = EFFECTS.register("stun_immunity", () -> 
-		new VisibleMobEffect(MobEffectCategory.BENEFICIAL, 16758016, ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/mob_effect/stun_immunity.png")));
+		new VisibleMobEffect(MobEffectCategory.BENEFICIAL, 16758016, EpicFightMod.identifier("textures/mob_effect/stun_immunity.png")));
 	
 	//public static final RegistryObject<MobEffect> BLOOMING = EFFECTS.register("blooming", () -> 
 	//	new VisibleMobEffect(MobEffectCategory.BENEFICIAL, 16735744, new ResourceLocation(EpicFightMod.MODID, "textures/mob_effect/blooming.png")));
 	
 	public static final RegistryObject<MobEffect> INSTABILITY = EFFECTS.register("instability", () -> 
 		new VisibleMobEffect(MobEffectCategory.HARMFUL, 0, (effectInstance) -> Math.min(effectInstance.getAmplifier(), 2)
-														 , ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/mob_effect/instability1.png")
-														 , ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/mob_effect/instability2.png")
-														 , ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/mob_effect/instability3.png")));
+                , EpicFightMod.identifier("textures/mob_effect/instability1.png")
+                , EpicFightMod.identifier("textures/mob_effect/instability2.png")
+                , EpicFightMod.identifier("textures/mob_effect/instability3.png")));
 	
 	public static void addOffhandModifier() {
 		MobEffects.DIG_SPEED.addAttributeModifier(EpicFightAttributes.OFFHAND_ATTACK_SPEED.get(), "AF8B6E3F-3328-4C0A-AA36-5BA2BB9DBEF3", 0.1D, AttributeModifier.Operation.MULTIPLY_TOTAL);

--- a/src/main/java/yesman/epicfight/world/item/EpicFightCreativeTabs.java
+++ b/src/main/java/yesman/epicfight/world/item/EpicFightCreativeTabs.java
@@ -17,7 +17,7 @@ public class EpicFightCreativeTabs {
 					.title(Component.translatable("itemGroup.epicfight.items"))
 					.icon(() -> new ItemStack(EpicFightItems.SKILLBOOK.get()))
 					.withTabsBefore(CreativeModeTabs.SPAWN_EGGS)
-					.withBackgroundLocation(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/container/epicfight_creative_tab.png"))
+					.withBackgroundLocation(EpicFightMod.identifier("textures/gui/container/epicfight_creative_tab.png"))
 					.hideTitle()
 					.displayItems((params, output) -> {
 						EpicFightItems.ITEMS.getEntries().forEach(item -> {


### PR DESCRIPTION
Backports #2337

This was done for a consistent API, and to allow current addons adapt to this change while minimizing the conflicts with future branches.

Addon devs will need to require a higher minimum required Epic Fight version if they plan to use `EpicFightMod.identifier`.