### PR TITLE
[1.21.1] Support Automatic Modrinth Sources JAR download

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,11 @@ repositories {
 }
 
 base {
-    archivesName = modId
+    // "epic-fight" is intentionally being used instead of the mod ID,
+    // to keep the JAR file name consistent with the project slug URL,
+    // and therefore Modrinth will automatically download the sources JAR file: https://support.modrinth.com/en/articles/8801191-modrinth-maven#h_1b24106498
+    // This workaround is not needed if the mod ID matches the project slug.
+    archivesName = "epic-fight"
     version = getFullModVersion()
 }
 


### PR DESCRIPTION
Changes the JAR file name from `epicfight` -> `epic-fight`, and therefore matches the Modrinth project [slug URL to enable automatic sources JAR file](https://support.modrinth.com/en/articles/8801191-modrinth-maven#h_1b24106498) for convenient development.

CurseForge Maven doesn't support this feature, so the JAR file name format is irrelevant. 

See also [this Epic Fight WIKI](https://epicfight-docs.readthedocs.io/API/Starting/#setting-up-your-gradle-build).

The ideal way is to address #2332, but for now, this is good enough.