### PR TITLE
[1.21.1] Type Safe Entity Patch Registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### For Devs
+
+- Renamed the JAR file to be consistent with the Modrinth project slug URL, to support automatic sources download.
+- Added `EntityPatchRegistryEvent#registerEntityPatch` and `EntityPatchRegistryEvent#registerEntityPatchUnsafe`, which
+  are more type-safe and recommended over `EntityPatchRegistryEvent#getTypeEntry`. 
+
 ## [21.14.4] - 2025-12-17
 
 ### Fixed

--- a/src/main/java/yesman/epicfight/api/neoevent/EntityPatchRegistryEvent.java
+++ b/src/main/java/yesman/epicfight/api/neoevent/EntityPatchRegistryEvent.java
@@ -1,22 +1,68 @@
 package yesman.epicfight.api.neoevent;
 
-import java.util.Map;
-import java.util.function.Function;
-
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
 import yesman.epicfight.world.capabilities.entitypatch.EntityPatch;
+import yesman.epicfight.world.capabilities.provider.CommonEntityPatchProvider;
+
+import java.util.Map;
+import java.util.function.Function;
 
 public class EntityPatchRegistryEvent extends Event implements IModBusEvent {
 	private final Map<EntityType<?>, Function<Entity, EntityPatch<?>>> typeEntry;
-	
+
 	public EntityPatchRegistryEvent(Map<EntityType<?>, Function<Entity, EntityPatch<?>>> typeEntry) {
 		this.typeEntry = typeEntry;
 	}
-	
-	public Map<EntityType<?>, Function<Entity, EntityPatch<?>>> getTypeEntry() {
-		return this.typeEntry;
-	}
+
+    /// Prefer using [#registerEntityPatch] or [#registerEntityPatchUnsafe] when registering entity patches for type-safety.
+    public Map<EntityType<?>, Function<Entity, EntityPatch<?>>> getTypeEntry() {
+        return this.typeEntry;
+    }
+
+    /// Preferred over [#getTypeEntry()] and [#registerEntityPatchUnsafe] for type-safety:
+    ///
+    /// ```java
+    /// registerEntityPatch(EntityType.ZOMBIE, ZombiePatch::new);
+    /// ```
+    ///
+    /// @param entityType         the type of entity to patch
+    /// @param entityPatchFactory a factory function that provides the original entity to create the entity patch.
+    /// @param <T>                the entity type
+    public <T extends Entity> void registerEntityPatch(
+            EntityType<T> entityType,
+            Function<T, EntityPatch<T>> entityPatchFactory
+    ) {
+        CommonEntityPatchProvider.registerEntityPatch(
+                typeEntry,
+                entityType,
+                entityPatchFactory
+        );
+    }
+
+    /// Strongly prefer [#registerEntityPatch] over this unsafe version
+    /// for type-safety and strict design.
+    /// Use this only as a last resort.
+    ///
+    /// Sometimes it is necessary to use this when dealing with vanilla types:
+    ///
+    /// ```java
+    /// registerEntityPatchUnsafe(
+    ///        registry,
+    ///        EntityType.PLAYER,
+    ///        entity -> new ServerPlayerPatch((ServerPlayer) entity)
+    /// );
+    /// ```
+    public <T extends Entity> void registerEntityPatchUnsafe(
+            EntityType<T> entityType,
+            Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
+    ) {
+        CommonEntityPatchProvider.registerEntityPatchUnsafe(
+                typeEntry,
+                entityType,
+                entityPatchFactory
+        );
+    }
 }

--- a/src/main/java/yesman/epicfight/world/capabilities/projectile/ArrowPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/projectile/ArrowPatch.java
@@ -6,13 +6,13 @@ import yesman.epicfight.world.damagesource.EpicFightDamageSource;
 import yesman.epicfight.world.damagesource.EpicFightDamageSources;
 import yesman.epicfight.world.damagesource.StunType;
 
-public class ArrowPatch extends ProjectilePatch<AbstractArrow> {
-	public ArrowPatch(AbstractArrow original) {
+public class ArrowPatch<T extends AbstractArrow> extends ProjectilePatch<T> {
+	public ArrowPatch(T original) {
 		super(original);
 	}
 	
 	@Override
-	protected void setMaxStrikes(AbstractArrow projectileEntity, int maxStrikes) {
+	protected void setMaxStrikes(T projectileEntity, int maxStrikes) {
 		projectileEntity.setPierceLevel((byte)(maxStrikes - 1));
 	}
 	

--- a/src/main/java/yesman/epicfight/world/capabilities/provider/CommonEntityPatchProvider.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/provider/CommonEntityPatchProvider.java
@@ -9,17 +9,13 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.entity.animal.IronGolem;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
-import net.minecraft.world.entity.boss.wither.WitherBoss;
-import net.minecraft.world.entity.monster.*;
-import net.minecraft.world.entity.monster.hoglin.Hoglin;
-import net.minecraft.world.entity.monster.piglin.Piglin;
-import net.minecraft.world.entity.monster.piglin.PiglinBrute;
-import net.minecraft.world.entity.projectile.*;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.entity.projectile.Projectile;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModLoader;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.neoevent.EntityPatchRegistryEvent;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.AbstractClientPlayerPatch;
@@ -34,8 +30,6 @@ import yesman.epicfight.world.capabilities.entitypatch.boss.enderdragon.EnderDra
 import yesman.epicfight.world.capabilities.entitypatch.mob.*;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
 import yesman.epicfight.world.capabilities.projectile.*;
-import yesman.epicfight.world.entity.WitherGhostClone;
-import yesman.epicfight.world.entity.WitherSkeletonMinion;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 
 import java.util.ArrayList;
@@ -55,66 +49,90 @@ public final class CommonEntityPatchProvider {
 	
 	public void registerVanillaEntityPatches() {
 		Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry = new HashMap<> ();
-		registry.put(EntityType.PLAYER, entity -> new ServerPlayerPatch((ServerPlayer)entity));
-		registry.put(EntityType.ZOMBIE, entity -> new ZombiePatch<> ((Zombie)entity));
-		registry.put(EntityType.CREEPER, entity -> new CreeperPatch((Creeper)entity));
-		registry.put(EntityType.ENDERMAN, entity -> new EndermanPatch((EnderMan)entity));
-		registry.put(EntityType.SKELETON, entity -> new SkeletonPatch<Skeleton> ((Skeleton)entity));
-		registry.put(EntityType.WITHER_SKELETON, entity -> new WitherSkeletonPatch<> ((WitherSkeleton)entity));
-		registry.put(EntityType.STRAY, entity -> new StrayPatch<> ((Stray)entity));
-		registry.put(EntityType.ZOMBIFIED_PIGLIN, entity -> new ZombifiedPiglinPatch((ZombifiedPiglin)entity));
-		registry.put(EntityType.ZOMBIE_VILLAGER, entity -> new ZombiePatch<> ((ZombieVillager)entity));
-		registry.put(EntityType.HUSK, entity -> new ZombiePatch<> ((Husk)entity));
-		registry.put(EntityType.SPIDER, entity -> new SpiderPatch<> ((Spider)entity));
-		registry.put(EntityType.CAVE_SPIDER, entity -> new CaveSpiderPatch<> ((CaveSpider)entity));
-		registry.put(EntityType.IRON_GOLEM, entity -> new IronGolemPatch((IronGolem)entity));
-		registry.put(EntityType.VINDICATOR, entity -> new VindicatorPatch<> ((Vindicator)entity));
-		registry.put(EntityType.EVOKER, entity -> new EvokerPatch<> ((Evoker)entity));
-		registry.put(EntityType.WITCH, entity -> new WitchPatch((Witch)entity));
-		registry.put(EntityType.DROWNED, entity -> new DrownedPatch((Drowned)entity));
-		registry.put(EntityType.PILLAGER, entity -> new PillagerPatch((Pillager)entity));
-		registry.put(EntityType.RAVAGER, entity -> new RavagerPatch((Ravager)entity));
-		registry.put(EntityType.VEX, entity -> new VexPatch((Vex)entity));
-		registry.put(EntityType.PIGLIN, entity -> new PiglinPatch((Piglin)entity));
-		registry.put(EntityType.PIGLIN_BRUTE, entity -> new PiglinBrutePatch((PiglinBrute)entity));
-		registry.put(EntityType.HOGLIN, entity -> new HoglinPatch((Hoglin)entity));
-		registry.put(EntityType.ZOGLIN, entity -> new ZoglinPatch((Zoglin)entity));
-		registry.put(EntityType.ENDER_DRAGON, entity -> {
+		registerEntityPatchUnsafe(registry, EntityType.PLAYER, entity -> new ServerPlayerPatch((ServerPlayer) entity));
+		registerEntityPatch(registry, EntityType.ZOMBIE, ZombiePatch::new);
+		registerEntityPatch(registry, EntityType.CREEPER, CreeperPatch::new);
+		registerEntityPatch(registry, EntityType.ENDERMAN, EndermanPatch::new);
+		registerEntityPatch(registry, EntityType.SKELETON, SkeletonPatch::new);
+		registerEntityPatch(registry, EntityType.WITHER_SKELETON, WitherSkeletonPatch::new);
+		registerEntityPatch(registry, EntityType.STRAY, StrayPatch::new);
+		registerEntityPatch(registry, EntityType.ZOMBIFIED_PIGLIN, ZombifiedPiglinPatch::new);
+		registerEntityPatch(registry, EntityType.ZOMBIE_VILLAGER, ZombiePatch::new);
+		registerEntityPatch(registry, EntityType.HUSK, ZombiePatch::new);
+		registerEntityPatch(registry, EntityType.SPIDER, SpiderPatch::new);
+		registerEntityPatch(registry, EntityType.CAVE_SPIDER, CaveSpiderPatch::new);
+		registerEntityPatch(registry, EntityType.IRON_GOLEM, IronGolemPatch::new);
+		registerEntityPatch(registry, EntityType.VINDICATOR, VindicatorPatch::new);
+		registerEntityPatch(registry, EntityType.EVOKER, EvokerPatch::new);
+		registerEntityPatch(registry, EntityType.WITCH, WitchPatch::new);
+		registerEntityPatch(registry, EntityType.DROWNED, DrownedPatch::new);
+		registerEntityPatch(registry, EntityType.PILLAGER, PillagerPatch::new);
+		registerEntityPatch(registry, EntityType.RAVAGER, RavagerPatch::new);
+		registerEntityPatch(registry, EntityType.VEX, VexPatch::new);
+		registerEntityPatch(registry, EntityType.PIGLIN, PiglinPatch::new);
+		registerEntityPatch(registry, EntityType.PIGLIN_BRUTE, PiglinBrutePatch::new);
+		registerEntityPatch(registry, EntityType.HOGLIN, HoglinPatch::new);
+		registerEntityPatch(registry, EntityType.ZOGLIN, ZoglinPatch::new);
+		registerEntityPatch(registry, EntityType.ENDER_DRAGON, entity -> {
 			if (entity instanceof EnderDragon enderdragon) {
 				return new EnderDragonPatch(enderdragon);
 			}
 			return null;
 		});
-		registry.put(EntityType.WITHER, entity -> new WitherPatch((WitherBoss)entity));
-		registry.put(EpicFightEntityTypes.WITHER_SKELETON_MINION.get(), entity -> new WitherSkeletonPatch<> ((WitherSkeletonMinion)entity));
-		registry.put(EpicFightEntityTypes.WITHER_GHOST_CLONE.get(), entity -> new WitherGhostPatch((WitherGhostClone)entity));
-		registry.put(EntityType.ARROW, entity -> new ArrowPatch((Arrow)entity));
-		registry.put(EntityType.SPECTRAL_ARROW, entity -> new ArrowPatch((SpectralArrow)entity));
-		registry.put(EntityType.WITHER_SKULL, entity -> new WitherSkullPatch((WitherSkull)entity));
-		registry.put(EntityType.DRAGON_FIREBALL, entity -> new DragonFireballPatch((DragonFireball)entity));
-		registry.put(EntityType.TRIDENT, entity -> new ThrownTridentPatch((ThrownTrident)entity));
+		registerEntityPatch(registry, EntityType.WITHER, WitherPatch::new);
+		registerEntityPatch(registry, EpicFightEntityTypes.WITHER_SKELETON_MINION.get(), WitherSkeletonPatch::new);
+		registerEntityPatch(registry, EpicFightEntityTypes.WITHER_GHOST_CLONE.get(), WitherGhostPatch::new);
+		registerEntityPatch(registry, EntityType.ARROW, ArrowPatch::new);
+		registerEntityPatch(registry, EntityType.SPECTRAL_ARROW, ArrowPatch::new);
+		registerEntityPatch(registry, EntityType.WITHER_SKULL, WitherSkullPatch::new);
+		registerEntityPatch(registry, EntityType.DRAGON_FIREBALL, DragonFireballPatch::new);
+		registerEntityPatch(registry, EntityType.TRIDENT, ThrownTridentPatch::new);
 		
-		this.typedCapabilities.put(AbstractArrow.class, entity -> new ArrowPatch((AbstractArrow)entity));
+		this.typedCapabilities.put(AbstractArrow.class, entity -> new ArrowPatch<>((AbstractArrow) entity));
 		
 		EntityPatchRegistryEvent entitypatchRegistryEvent = new EntityPatchRegistryEvent(registry);
 		ModLoader.postEvent(entitypatchRegistryEvent);
 		
 		this.capabilities.putAll(registry);
 	}
-	
+
+	/// For more details, refer to [EntityPatchRegistryEvent#registerEntityPatch].
+	@ApiStatus.Internal
+	public static <T extends Entity> void registerEntityPatch(
+			Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
+			EntityType<T> entityType,
+			Function<T, EntityPatch<T>> entityPatchFactory
+	) {
+		//noinspection unchecked
+		registry.put(
+				entityType, (entity) -> entityPatchFactory.apply((T) entity)
+		);
+	}
+
+	/// Strongly prefer [#registerEntityPatch] over this unsafe version
+	/// for type-safety and strict design. Use this only as a last resort.
+	/// For more details, refer to [EntityPatchRegistryEvent#registerEntityPatchUnsafe].
+	@ApiStatus.Internal
+	public static <T extends Entity> void registerEntityPatchUnsafe(
+			Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
+			EntityType<T> entityType,
+			Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
+	) {
+		//noinspection unchecked
+		registry.put(
+				entityType,
+				entity -> entityPatchFactory.apply((T) entity)
+		);
+	}
+
 	@OnlyIn(Dist.CLIENT)
 	public void registerClientPlayerPatches() {
-		this.capabilities.put(EntityType.PLAYER, entity -> {
-			if (entity instanceof LocalPlayer localPlayer) {
-				return new LocalPlayerPatch(localPlayer);
-			} else if (entity instanceof RemotePlayer remotePlayer) {
-				return new AbstractClientPlayerPatch<RemotePlayer> (remotePlayer);
-			} else if (entity instanceof ServerPlayer serverPlayer) {
-				return new ServerPlayerPatch (serverPlayer);
-			} else {
-				return null;
-			}
-		});
+		this.capabilities.put(EntityType.PLAYER, entity -> switch (entity) {
+            case LocalPlayer localPlayer -> new LocalPlayerPatch(localPlayer);
+            case RemotePlayer remotePlayer -> new AbstractClientPlayerPatch<>(remotePlayer);
+            case ServerPlayer serverPlayer -> new ServerPlayerPatch(serverPlayer);
+            case null, default -> null;
+        });
 	}
 	
 	public void clearDatapackEntities() {


### PR DESCRIPTION
There was an error in `1.21.1` (#2329), which causes the vindicator Epic Fight patch to be fully broken (spams the log as well). It was due to casting `Vindicator` as `Spider`.
This PR enforces a cleaner design that is less error-prone, easier, and more convenient to use with documentation.

**Before:**

```java
registry.put(EntityType.PLAYER, entity -> new ServerPlayerPatch((ServerPlayer)entity));
registry.put(EntityType.ZOMBIE, entity -> new ZombiePatch<> ((Zombie)entity));
registry.put(EntityType.CREEPER, entity -> new CreeperPatch((Creeper)entity));
registry.put(EntityType.ARROW, entity -> new ArrowPatch((Arrow)entity));
registry.put(EntityType.SPECTRAL_ARROW, entity -> new ArrowPatch((SpectralArrow)entity));
```

**After:**

```java
registerEntityPatchUnsafe(registry, EntityType.PLAYER, entity -> new ServerPlayerPatch((ServerPlayer) entity));
registerEntityPatch(registry, EntityType.ZOMBIE, ZombiePatch::new);
registerEntityPatch(registry, EntityType.CREEPER, CreeperPatch::new);
registerEntityPatch(registry, EntityType.ARROW, ArrowPatch::new);
registerEntityPatch(registry, EntityType.SPECTRAL_ARROW, ArrowPatch::new);
```

The only case where `registerEntityPatchUnsafe` is needed is when dealing with some vanilla types, which is the case with `ServerPlayerPatch`.

This improvement applies to addons as well, since putting the patch directly to the `Map` is not type-safe and is not developer-friendly.

```diff
public void registerEntityPatches(EntityPatchRegistryEvent event) {
-    event.getTypeEntry().put(ModEntityTypes.EXAMPLE, entity -> new ExamplePatch<>((Example)entity));
+    event.registerEntityPatch(ModEntityTypes.EXAMPLE, ExamplePatch::new);
}
```

I already have these utilities in my [Epic Fight addon](https://github.com/EchoEllet/dragonfist-legacy), though I think it makes sense to merge them to the upstream core mod.

<img width="1155" height="636" alt="image" src="https://github.com/user-attachments/assets/fddc4e4f-e494-4c02-ae31-9032f7542078" />

<details><summary>Tested the dedicated server with arrows</summary>
<p>

<img width="1708" height="960" alt="image" src="https://github.com/user-attachments/assets/9acab458-a53c-42a7-8c59-be8f430b266f" />

</p>
</details> 

<details><summary>A screenshot while cleaning up</summary>
<p>

<img width="2302" height="1396" alt="image" src="https://github.com/user-attachments/assets/3b1d94bb-54e1-4dba-a688-df31ff8e70f4" />


</p>
</details> 

