### PR TITLE
Initial ModPlatform and ClientModPlatform design

### DIFF
--- a/common/src/main/java/yesman/epicfight/EpicFight.java
+++ b/common/src/main/java/yesman/epicfight/EpicFight.java
@@ -1,0 +1,33 @@
+package yesman.epicfight;
+
+import net.minecraft.resources.ResourceLocation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.ModPlatform;
+import yesman.epicfight.platform.ModPlatformProvider;
+
+/// Common functionalities shared between the platform entrypoints.
+public final class EpicFight {
+    private EpicFight() {
+    }
+
+    public static final String MODID = "epicfight";
+    public static final String EPICSKINS_MODID = "epicskins";
+    public static final Logger LOGGER = LogManager.getLogger(MODID);
+
+    /// Creates an identifier that points to an Epic Fight resource.
+    ///
+    /// This was called `identifier` and not `resourceLocation` since [Mojang renamed `ResourceLocation` to `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).
+    public static @NotNull ResourceLocation identifier(@NotNull final String path) {
+        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
+
+    /// Initializes common functionalities.
+    ///
+    /// Provides the global [ModPlatform] instance given by the mod platform (e.g., NeoForge, Fabric)
+    /// to common vanilla code for sharing.
+    public static void initialize(@NotNull final ModPlatform platform) {
+        ModPlatformProvider.initialize(platform);
+    }
+}

--- a/common/src/main/java/yesman/epicfight/EpicFightClient.java
+++ b/common/src/main/java/yesman/epicfight/EpicFightClient.java
@@ -1,0 +1,20 @@
+package yesman.epicfight;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.client.ClientModPlatform;
+import yesman.epicfight.platform.client.ClientModPlatformProvider;
+
+/// Common functionalities shared between the platform client entrypoints.
+public final class EpicFightClient {
+    private EpicFightClient() {
+
+    }
+
+    /// Initializes common client-only functionalities.
+    ///
+    /// Provides the global [ClientModPlatform] instance given by the mod platform (e.g., NeoForge, Fabric)
+    /// to common vanilla code for sharing.
+    public static void initialize(@NotNull final ClientModPlatform platform) {
+        ClientModPlatformProvider.initialize(platform);
+    }
+}

--- a/common/src/main/java/yesman/epicfight/platform/ModPlatform.java
+++ b/common/src/main/java/yesman/epicfight/platform/ModPlatform.java
@@ -1,0 +1,10 @@
+package yesman.epicfight.platform;
+
+import org.jetbrains.annotations.NotNull;
+
+/// Provides access to mod-loader specific functionalities that cannot be achieved using vanilla classes otherwise.
+public interface ModPlatform {
+    boolean isDevelopmentEnvironment();
+
+    boolean isModLoaded(@NotNull final String id);
+}

--- a/common/src/main/java/yesman/epicfight/platform/ModPlatformProvider.java
+++ b/common/src/main/java/yesman/epicfight/platform/ModPlatformProvider.java
@@ -1,0 +1,30 @@
+package yesman.epicfight.platform;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/// Provides access to the universal [ModPlatform] instance.
+///
+/// Mod platforms (e.g., NeoForge or Fabric) are expected to call [#initialize()].
+public final class ModPlatformProvider {
+    private ModPlatformProvider() {
+    }
+
+    private static @Nullable ModPlatform INSTANCE = null;
+
+    @ApiStatus.Internal
+    public static void initialize(@NotNull final ModPlatform platform) {
+        Objects.requireNonNull(platform, "The platform argument cannot be null.");
+        if (INSTANCE != null) {
+            throw new IllegalStateException("A mod platform implementation can be provided only once.");
+        }
+        INSTANCE = platform;
+    }
+
+    public static @NotNull ModPlatform get() {
+        return Objects.requireNonNull(INSTANCE, "A mod platform implementation has not been provided.");
+    }
+}

--- a/common/src/main/java/yesman/epicfight/platform/client/ClientModPlatform.java
+++ b/common/src/main/java/yesman/epicfight/platform/client/ClientModPlatform.java
@@ -1,0 +1,7 @@
+package yesman.epicfight.platform.client;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface ClientModPlatform {
+    @NotNull KeyMappingRegistrar keyMappingRegistrar();
+}

--- a/common/src/main/java/yesman/epicfight/platform/client/ClientModPlatformProvider.java
+++ b/common/src/main/java/yesman/epicfight/platform/client/ClientModPlatformProvider.java
@@ -1,0 +1,30 @@
+package yesman.epicfight.platform.client;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/// Provides access to the universal [ClientModPlatform] instance.
+///
+/// Mod platforms (e.g., NeoForge or Fabric) are expected to call [#initialize()].
+public final class ClientModPlatformProvider {
+    private ClientModPlatformProvider() {
+    }
+
+    private static @Nullable ClientModPlatform INSTANCE = null;
+
+    @ApiStatus.Internal
+    public static void initialize(@NotNull final ClientModPlatform platform) {
+        Objects.requireNonNull(platform, "The platform argument cannot be null.");
+        if (INSTANCE != null) {
+            throw new IllegalStateException("A client mod platform implementation can be provided only once.");
+        }
+        INSTANCE = platform;
+    }
+
+    public static @NotNull ClientModPlatform get() {
+        return Objects.requireNonNull(INSTANCE, "A client mod platform implementation has not been provided.");
+    }
+}

--- a/common/src/main/java/yesman/epicfight/platform/client/KeyMappingRegistrar.java
+++ b/common/src/main/java/yesman/epicfight/platform/client/KeyMappingRegistrar.java
@@ -1,0 +1,8 @@
+package yesman.epicfight.platform.client;
+
+import net.minecraft.client.KeyMapping;
+import org.jetbrains.annotations.NotNull;
+
+public interface KeyMappingRegistrar {
+    void registerKeyMapping(@NotNull final KeyMapping keyMapping);
+}

--- a/fabric/src/main/java/yesman/epicfight/platform/fabric/EpicFightFabric.java
+++ b/fabric/src/main/java/yesman/epicfight/platform/fabric/EpicFightFabric.java
@@ -1,10 +1,11 @@
 package yesman.epicfight.platform.fabric;
 
 import net.fabricmc.api.ModInitializer;
+import yesman.epicfight.EpicFight;
 
 public final class EpicFightFabric implements ModInitializer {
     @Override
     public void onInitialize() {
-
+        EpicFight.initialize(new FabricModPlatform());
     }
 }

--- a/fabric/src/main/java/yesman/epicfight/platform/fabric/EpicFightFabricClient.java
+++ b/fabric/src/main/java/yesman/epicfight/platform/fabric/EpicFightFabricClient.java
@@ -1,10 +1,12 @@
 package yesman.epicfight.platform.fabric;
 
 import net.fabricmc.api.ClientModInitializer;
+import yesman.epicfight.EpicFightClient;
+import yesman.epicfight.platform.fabric.client.FabricClientModPlatform;
 
 public final class EpicFightFabricClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-
+        EpicFightClient.initialize(new FabricClientModPlatform());
     }
 }

--- a/fabric/src/main/java/yesman/epicfight/platform/fabric/FabricModPlatform.java
+++ b/fabric/src/main/java/yesman/epicfight/platform/fabric/FabricModPlatform.java
@@ -1,0 +1,17 @@
+package yesman.epicfight.platform.fabric;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.ModPlatform;
+
+public final class FabricModPlatform implements ModPlatform {
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return FabricLoader.getInstance().isDevelopmentEnvironment();
+    }
+
+    @Override
+    public boolean isModLoaded(@NotNull final String id) {
+        return FabricLoader.getInstance().isModLoaded(id);
+    }
+}

--- a/fabric/src/main/java/yesman/epicfight/platform/fabric/client/FabricClientModPlatform.java
+++ b/fabric/src/main/java/yesman/epicfight/platform/fabric/client/FabricClientModPlatform.java
@@ -1,0 +1,14 @@
+package yesman.epicfight.platform.fabric.client;
+
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.client.ClientModPlatform;
+import yesman.epicfight.platform.client.KeyMappingRegistrar;
+
+public final class FabricClientModPlatform implements ClientModPlatform {
+    private final FabricKeyMappingRegistrar keyMappingRegistrar = new FabricKeyMappingRegistrar();
+
+    @Override
+    public @NotNull KeyMappingRegistrar keyMappingRegistrar() {
+        return keyMappingRegistrar;
+    }
+}

--- a/fabric/src/main/java/yesman/epicfight/platform/fabric/client/FabricKeyMappingRegistrar.java
+++ b/fabric/src/main/java/yesman/epicfight/platform/fabric/client/FabricKeyMappingRegistrar.java
@@ -1,0 +1,13 @@
+package yesman.epicfight.platform.fabric.client;
+
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.minecraft.client.KeyMapping;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.client.KeyMappingRegistrar;
+
+public final class FabricKeyMappingRegistrar implements KeyMappingRegistrar {
+    @Override
+    public void registerKeyMapping(@NotNull final KeyMapping keyMapping) {
+        KeyBindingHelper.registerKeyBinding(keyMapping);
+    }
+}

--- a/neoforge/src/main/java/yesman/epicfight/client/input/EpicFightKeyMappings.java
+++ b/neoforge/src/main/java/yesman/epicfight/client/input/EpicFightKeyMappings.java
@@ -2,163 +2,161 @@ package yesman.epicfight.client.input;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.settings.KeyConflictContext;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.generated.LangKeys;
+import yesman.epicfight.platform.client.ClientModPlatformProvider;
 
-@EventBusSubscriber(value = Dist.CLIENT)
+import java.util.ArrayList;
+import java.util.List;
+
 public class EpicFightKeyMappings {
 
     // GUI key-mappings
     public static final KeyMapping WEAPON_INNATE_SKILL_TOOLTIP =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_SHOW_TOOLTIP,
                     KeyConflictContext.GUI,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_LSHIFT,
                     EpicFightInputCategories.GUI
-            );
+            ));
 
     public static final KeyMapping SKILL_EDIT =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_SKILL_GUI,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_K,
                     EpicFightInputCategories.GUI
-            );
+            ));
 
     public static final KeyMapping OPEN_CONFIG_SCREEN =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_CONFIG,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     -1,
                     EpicFightInputCategories.GUI
-            );
+            ));
 
     public static final KeyMapping OPEN_EMOTE_WHEEL =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_EMOTE,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_Y,
                     EpicFightInputCategories.GUI
-            );
+            ));
 
     // In-game keymappings
     public static final KeyMapping DODGE =
-            new CombatKeyMapping(
+            registerKey(new CombatKeyMapping(
                     LangKeys.KEY_DODGE,
                     InputConstants.KEY_LALT,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping GUARD =
-            new CombatKeyMapping(
+            registerKey(new CombatKeyMapping(
                     LangKeys.KEY_GUARD,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_RIGHT,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping ATTACK =
-            new CombatKeyMapping(
+            registerKey(new CombatKeyMapping(
                     LangKeys.KEY_ATTACK,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_LEFT,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping WEAPON_INNATE_SKILL =
-            new CombatKeyMapping(
+            registerKey(new CombatKeyMapping(
                     LangKeys.KEY_WEAPON_INNATE_SKILL,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_LEFT,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping MOVER_SKILL =
-            new CombatKeyMapping(
+            registerKey(new CombatKeyMapping(
                     LangKeys.KEY_MOVER_SKILL,
                     InputConstants.KEY_SPACE,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping SWITCH_MODE =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_SWITCH_MODE,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_R,
                     EpicFightInputCategories.COMBAT
-            );
+            ));
 
     public static final KeyMapping LOCK_ON =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_LOCK_ON,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_G,
                     EpicFightInputCategories.CAMERA
-            );
+            ));
 
     public static final KeyMapping LOCK_ON_SHIFT_LEFT =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_LOCK_ON_SHIFT_LEFT,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_LEFT,
                     EpicFightInputCategories.CAMERA
-            );
+            ));
 
     public static final KeyMapping LOCK_ON_SHIFT_RIGHT =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_LOCK_ON_SHIFT_RIGHT,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     InputConstants.KEY_RIGHT,
                     EpicFightInputCategories.CAMERA
-            );
+            ));
 
     public static final KeyMapping LOCK_ON_SHIFT_FREELY =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_LOCK_ON_SHIFT_FREELY,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.MOUSE,
                     InputConstants.MOUSE_BUTTON_RIGHT,
                     EpicFightInputCategories.CAMERA
-            );
+            ));
 
     // Systemical key mappings especially for debugging
     public static final KeyMapping SWITCH_VANILLA_MODEL_DEBUGGING =
-            new KeyMapping(
+            registerKey(new KeyMapping(
                     LangKeys.KEY_SWITCH_VANILLA_MODEL_DEBUG,
                     KeyConflictContext.IN_GAME,
                     InputConstants.Type.KEYSYM,
                     -1,
                     EpicFightInputCategories.SYSTEM
-            );
+            ));
 
-    @SubscribeEvent
-    public static void registerKeys(RegisterKeyMappingsEvent event) {
-        event.register(WEAPON_INNATE_SKILL_TOOLTIP);
-        event.register(SWITCH_MODE);
-        event.register(DODGE);
-        event.register(GUARD);
-        event.register(ATTACK);
-        event.register(WEAPON_INNATE_SKILL);
-        event.register(MOVER_SKILL);
-        event.register(SKILL_EDIT);
-        event.register(LOCK_ON);
-        event.register(LOCK_ON_SHIFT_LEFT);
-        event.register(LOCK_ON_SHIFT_RIGHT);
-        event.register(LOCK_ON_SHIFT_FREELY);
-        event.register(OPEN_CONFIG_SCREEN);
-        event.register(OPEN_EMOTE_WHEEL);
-        event.register(SWITCH_VANILLA_MODEL_DEBUGGING);
+
+    private static List<@NotNull KeyMapping> keyMappings;
+
+    private static @NotNull KeyMapping registerKey(@NotNull KeyMapping keyMapping) {
+        if (keyMappings == null) {
+            keyMappings = new ArrayList<>();
+        }
+        keyMappings.add(keyMapping);
+        return keyMapping;
+    }
+
+    public static void registerKeys() {
+        for (KeyMapping keyMapping : keyMappings) {
+            ClientModPlatformProvider.get().keyMappingRegistrar().registerKeyMapping(keyMapping);
+        }
     }
 }

--- a/neoforge/src/main/java/yesman/epicfight/data/loot/function/SetSkillFunction.java
+++ b/neoforge/src/main/java/yesman/epicfight/data/loot/function/SetSkillFunction.java
@@ -1,13 +1,9 @@
 package yesman.epicfight.data.loot.function;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-
 import it.unimi.dsi.fastutil.floats.FloatObjectPair;
 import net.minecraft.core.Holder;
 import net.minecraft.util.RandomSource;
@@ -17,10 +13,13 @@ import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunct
 import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
-import net.neoforged.fml.ModList;
+import yesman.epicfight.platform.ModPlatformProvider;
 import yesman.epicfight.registry.entries.EpicFightDataComponentTypes;
 import yesman.epicfight.registry.entries.EpicFightLootItemFunctions;
 import yesman.epicfight.skill.Skill;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SetSkillFunction extends LootItemConditionalFunction {
 	/**
@@ -75,7 +74,7 @@ public class SetSkillFunction extends LootItemConditionalFunction {
 	
 	@Override
 	protected ItemStack run(ItemStack itemstack, LootContext context) {
-		if (ModList.get().isLoaded("epicskills")) {
+		if (ModPlatformProvider.get().isModLoaded("epicskills")) {
 			return ItemStack.EMPTY;
 		}
 		

--- a/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -57,6 +57,7 @@ import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen;
 import yesman.epicfight.client.gui.widgets.AnchoredButton;
 import yesman.epicfight.client.gui.widgets.ColorDeterminator;
 import yesman.epicfight.client.gui.widgets.common.WidgetTheme;
+import yesman.epicfight.client.input.EpicFightKeyMappings;
 import yesman.epicfight.client.online.cosmetics.Emote;
 import yesman.epicfight.client.renderer.patched.item.EpicFightItemProperties;
 import yesman.epicfight.client.renderer.shader.compute.loader.ComputeShaderProvider;
@@ -171,6 +172,15 @@ public class EpicFightMod {
 		ModPlatformProvider.initialize(new NeoForgeModPlatform());
     	if (EpicFightSharedConstants.isPhysicalClient()) {
 			EpicFightClient.initialize(new NeoForgeClientModPlatform(modEventBus));
+			// TODO: (MULTI_LOADER) EpicFightKeyMappings must be in common and not neoforge,
+			//  and is temporarily kept here since CombatKeyMapping depends on ClientEngine,
+			//  which is not in common yet. https://github.com/Epic-Fight/epicfight/pull/2365
+			//  When ClientEngine#isEpicFightMode is migrated to common:
+			//  1. Move EpicFightKeyMappings and CombatKeyMapping to common (same package: yesman.epicfight.client.input)
+			//  2. Remove "EpicFightKeyMappings.registerKeys()" statement from here
+			//  3. Add it at the very end of "EpicFightClient.initialize()" method
+			EpicFightKeyMappings.registerKeys();
+
     		modContainer.registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
     		modContainer.registerExtensionPoint(IConfigScreenFactory.class, EpicFightSettingScreen::new);
     		IEventBasedEngine.init(NeoForge.EVENT_BUS, modEventBus);

--- a/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -35,6 +35,7 @@ import net.neoforged.neoforge.registries.DataPackRegistryEvent;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.EpicFight;
+import yesman.epicfight.EpicFightClient;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -72,6 +73,7 @@ import yesman.epicfight.network.EntityPairingPacketType;
 import yesman.epicfight.network.EntityPairingPacketTypes;
 import yesman.epicfight.platform.ModPlatformProvider;
 import yesman.epicfight.platform.neoforge.NeoForgeModPlatform;
+import yesman.epicfight.platform.neoforge.client.NeoForgeClientModPlatform;
 import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.registry.entries.*;
 import yesman.epicfight.server.commands.AnimatorCommand;
@@ -168,6 +170,7 @@ public class EpicFightMod {
     public EpicFightMod(IEventBus modEventBus, ModContainer modContainer) {
 		ModPlatformProvider.initialize(new NeoForgeModPlatform());
     	if (EpicFightSharedConstants.isPhysicalClient()) {
+			EpicFightClient.initialize(new NeoForgeClientModPlatform(modEventBus));
     		modContainer.registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
     		modContainer.registerExtensionPoint(IConfigScreenFactory.class, EpicFightSettingScreen::new);
     		IEventBasedEngine.init(NeoForge.EVENT_BUS, modEventBus);

--- a/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -32,9 +32,9 @@ import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.registries.DataPackRegistryEvent;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.EpicFight;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationRegistryEvent;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -70,6 +70,8 @@ import yesman.epicfight.gameasset.ColliderPreset;
 import yesman.epicfight.generated.LangKeys;
 import yesman.epicfight.network.EntityPairingPacketType;
 import yesman.epicfight.network.EntityPairingPacketTypes;
+import yesman.epicfight.platform.ModPlatformProvider;
+import yesman.epicfight.platform.neoforge.NeoForgeModPlatform;
 import yesman.epicfight.registry.EpicFightRegistries;
 import yesman.epicfight.registry.entries.*;
 import yesman.epicfight.server.commands.AnimatorCommand;
@@ -117,9 +119,21 @@ import java.util.function.Supplier;
  */
 @Mod(EpicFightMod.MODID)
 public class EpicFightMod {
-	public static final String MODID = "epicfight";
-	public static final String EPICSKINS_MODID = "epicskins";
-	public static final Logger LOGGER = LogManager.getLogger(MODID);
+
+	// TODO: Rename class to EpicFightNeoForge
+	// TODO: Avoid using the deprecated fields in neoforge Gradle project, and migrate to the new shared ones in EpicFight via IDE structural replacement
+
+	/// @deprecated Use [yesman.epicfight.EpicFight#MODID] instead
+	@Deprecated(forRemoval = true)
+	public static final String MODID = EpicFight.MODID;
+
+	/// @deprecated Use [yesman.epicfight.EpicFight#EPICSKINS_MODID] instead
+	@Deprecated(forRemoval = true)
+	public static final String EPICSKINS_MODID = EpicFight.EPICSKINS_MODID;
+
+	/// @deprecated Use [yesman.epicfight.EpicFight#LOGGER] instead
+	@Deprecated(forRemoval = true)
+	public static final Logger LOGGER = EpicFight.LOGGER;
 
 	public static String prefix(String s) {
 		return String.format("%s:%s", MODID, s);
@@ -152,6 +166,7 @@ public class EpicFightMod {
 	}
 
     public EpicFightMod(IEventBus modEventBus, ModContainer modContainer) {
+		ModPlatformProvider.initialize(new NeoForgeModPlatform());
     	if (EpicFightSharedConstants.isPhysicalClient()) {
     		modContainer.registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
     		modContainer.registerExtensionPoint(IConfigScreenFactory.class, EpicFightSettingScreen::new);
@@ -404,11 +419,10 @@ public class EpicFightMod {
 			});
 	}
 
-	/// Creates an identifier that points to an Epic Fight resource.
-	///
-	/// This was called `identifier` and not `resourceLocation` since [Mojang renamed `ResourceLocation` to `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).
+	/// @deprecated Use [yesman.epicfight.EpicFight#identifier(String)] instead
+	@Deprecated(forRemoval = true)
 	public static @NotNull ResourceLocation identifier(@NotNull String path) {
-        return ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, path);
+        return EpicFight.identifier(path);
 	}
 
 	/// @deprecated Use [#identifier(String)] instead. [Mojang renamed `ResourceLocation` to `Identifier` in 1.21.11](https://neoforged.net/news/21.11release/#renaming-of-resourcelocation-to-identifier).

--- a/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/neoforge/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -213,7 +213,7 @@ public class EpicFightMod {
 
     private List<? extends Class<? extends ICompatModule>> getCompatibilityModules(final boolean isClientSide) {
         return Arrays.stream(MinecraftMod.values())
-                .filter(mod -> ModList.get().isLoaded(mod.getModId()))
+                .filter(mod -> ModPlatformProvider.get().isModLoaded(mod.getModId()))
                 // Includes all mods on client. Skips client-only mods on server
                 .filter(mod -> isClientSide || !mod.isClientOnly())
                 .filter(mod -> {

--- a/neoforge/src/main/java/yesman/epicfight/platform/neoforge/NeoForgeModPlatform.java
+++ b/neoforge/src/main/java/yesman/epicfight/platform/neoforge/NeoForgeModPlatform.java
@@ -1,0 +1,18 @@
+package yesman.epicfight.platform.neoforge;
+
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLLoader;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.ModPlatform;
+
+public final class NeoForgeModPlatform implements ModPlatform {
+    @Override
+    public boolean isDevelopmentEnvironment() {
+        return !FMLLoader.isProduction();
+    }
+
+    @Override
+    public boolean isModLoaded(@NotNull final String id) {
+        return ModList.get().isLoaded(id);
+    }
+}

--- a/neoforge/src/main/java/yesman/epicfight/platform/neoforge/client/NeoForgeClientModPlatform.java
+++ b/neoforge/src/main/java/yesman/epicfight/platform/neoforge/client/NeoForgeClientModPlatform.java
@@ -1,0 +1,20 @@
+package yesman.epicfight.platform.neoforge.client;
+
+import net.neoforged.bus.api.IEventBus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.client.ClientModPlatform;
+import yesman.epicfight.platform.client.KeyMappingRegistrar;
+
+public final class NeoForgeClientModPlatform implements ClientModPlatform {
+
+    public NeoForgeClientModPlatform(IEventBus modEventBus) {
+        modEventBus.addListener(keyMappingRegistrar::onRegisterKeys);
+    }
+
+    private final NeoForgeKeyMappingRegistrar keyMappingRegistrar = new NeoForgeKeyMappingRegistrar();
+
+    @Override
+    public @NotNull KeyMappingRegistrar keyMappingRegistrar() {
+        return keyMappingRegistrar;
+    }
+}

--- a/neoforge/src/main/java/yesman/epicfight/platform/neoforge/client/NeoForgeKeyMappingRegistrar.java
+++ b/neoforge/src/main/java/yesman/epicfight/platform/neoforge/client/NeoForgeKeyMappingRegistrar.java
@@ -1,0 +1,33 @@
+package yesman.epicfight.platform.neoforge.client;
+
+import net.minecraft.client.KeyMapping;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.platform.client.KeyMappingRegistrar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NeoForgeKeyMappingRegistrar implements KeyMappingRegistrar {
+    private final List<@NotNull KeyMapping> pending = new ArrayList<>();
+    private boolean locked = false;
+
+    @Override
+    public void registerKeyMapping(@NotNull final KeyMapping keyMapping) {
+        if (locked) {
+            throw new IllegalStateException("Cannot register key mappings after the 'RegisterKeyMappingsEvent' has fired. " +
+                    "All key mappings must be registered during mod setup, before the event is processed.");
+        }
+        pending.add(keyMapping);
+    }
+
+    @ApiStatus.Internal
+    public void onRegisterKeys(RegisterKeyMappingsEvent event) {
+        for (KeyMapping keyMapping : pending) {
+            event.register(keyMapping);
+        }
+        locked = true;
+        pending.clear();
+    }
+}


### PR DESCRIPTION
Introduces `ModPlatform`, with two methods, `isDevelopmentEnvironment` and `isModLoaded`, as an example of what this interface does.

It shouldn't provide every mod-loader method directly in here; for example, we could introduce an interface `DeferredRegistrar` for anything related to deferred registration with all methods in there, and `ModPlatform` only maintains the instance of `DeferredRegistrar`. This design forces the platform modules to provide `DeferredRegistrar`.

This also introduces the `EpicFight` class, which is the common code, and adds TODOs for renaming `EpicFightMod` in `neoforge` to `EpicFightNeoForge`. That will be done in the next PR for an easier review.

`neoforge` and `fabric` must call `EpicFight#initialize()`, which calls `ModPlatformProvider.initialize()`, which requires a `ModPlatform` argument.

NeoForge provides `NeoForgeModPlatform`, and `fabric` provides `FabricModPlatform`.

### Design

**ModPlatform:**

```java
/// Provides access to mod-loader specific functionalities that cannot be achieved using vanilla classes otherwise.
public interface ModPlatform {
    boolean isDevelopmentEnvironment();

    boolean isModLoaded(@NotNull final String id);
}

public final class NeoForgeModPlatform implements ModPlatform {
    @Override
    public boolean isDevelopmentEnvironment() {
        return !FMLLoader.isProduction();
    }

    @Override
    public boolean isModLoaded(@NotNull final String id) {
        return ModList.get().isLoaded(id);
    }
}

public final class FabricModPlatform implements ModPlatform {
    @Override
    public boolean isDevelopmentEnvironment() {
        return FabricLoader.getInstance().isDevelopmentEnvironment();
    }

    @Override
    public boolean isModLoaded(@NotNull final String id) {
        return FabricLoader.getInstance().isModLoaded(id);
    }
}
```

**Common vanilla entrypoint:**

```java
/// Common functionalities shared between the platform entrypoints (EpicFightNeoForge and EpicFightFabric).
public final class EpicFight {
    private EpicFight() {
    }

    public static final String MODID = "epicfight";
    public static final Logger LOGGER = LogManager.getLogger(MODID);


    /// Initializes common functionalities.
    ///
    /// Provides the global [ModPlatform] instance given by the mod platform (e.g., NeoForge, Fabric)
    /// to common vanilla code for sharing.
    public static void initialize(@NotNull final ModPlatform platform) {
        ModPlatformProvider.initialize(platform);
    }
}
```

**Fabric platform entrypoint:**

```java
public final class EpicFightFabric implements ModInitializer {
    @Override
    public void onInitialize() {
        EpicFight.initialize(new FabricModPlatform());
    }
}
```

**NeoForge platform entrypoint:**

```java
// FYI: EpicFightNeoForge is currently named EpicFightMod, and there is a TODO to track renaming it in the next PR
@Mod(EpicFight.MODID)
public final class EpicFightNeoForge {
    public EpicFightNeoForge() {
        EpicFight.initialize(new NeoForgeModPlatform());
    }
}
```

**Usage in common vanilla code:**

```java
if (ModPlatformProvider.get().isModLoaded("epicskills")) {}
```

The same pattern applies with `ClientModPlatform` and `ClientModPlatformProvider`, and technically, client-only methods can be merged directly into `ModPlatform`, but this is not the recommended vanilla approach. Both NeoForge and Fabric encourage avoiding importing client-only classes in common side classes through a clear separation.

The stronger separation will blend well with [the upcoming NeoForge source sets separation](https://neoforged.net/news/21.5release/#split-sourcesets).
