### PR TITLE
Deprecate EntityPatchRegistryEvent#getTypeEntry()

### DIFF
--- a/neoforge/src/main/java/yesman/epicfight/api/event/types/registry/EntityPatchRegistryEvent.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/event/types/registry/EntityPatchRegistryEvent.java
@@ -2,6 +2,7 @@ package yesman.epicfight.api.event.types.registry;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.event.Event;
 import yesman.epicfight.world.capabilities.entitypatch.EntityPatch;
 import yesman.epicfight.world.capabilities.provider.CommonEntityPatchProvider;
@@ -12,11 +13,13 @@ import java.util.function.Function;
 public class EntityPatchRegistryEvent extends Event {
 	private final Map<EntityType<?>, Function<Entity, EntityPatch<?>>> typeEntry;
 
-	public EntityPatchRegistryEvent(Map<EntityType<?>, Function<Entity, EntityPatch<?>>> typeEntry) {
+	public EntityPatchRegistryEvent(@NotNull Map<EntityType<?>, Function<Entity, @NotNull EntityPatch<?>>> typeEntry) {
 		this.typeEntry = typeEntry;
 	}
 
-    /// Prefer using [#registerEntityPatch] or [#registerEntityPatchUnsafe] when registering entity patches for type-safety.
+    /// @deprecated Prefer using [#registerEntityPatch] or [#registerEntityPatchUnsafe] when registering entity patches for type-safety.
+    /// If you have a use case where the full [Map] is needed, please [file a GitHub issue](https://github.com/Epic-Fight/epicfight/issues/new?template=03_api.yml).
+    @Deprecated(forRemoval = true)
     public Map<EntityType<?>, Function<Entity, EntityPatch<?>>> getTypeEntry() {
         return this.typeEntry;
     }
@@ -31,8 +34,8 @@ public class EntityPatchRegistryEvent extends Event {
     /// @param entityPatchFactory a factory function that provides the original entity to create the entity patch.
     /// @param <T>                the entity type
     public <T extends Entity> void registerEntityPatch(
-            EntityType<T> entityType,
-            Function<T, EntityPatch<T>> entityPatchFactory
+            @NotNull EntityType<T> entityType,
+            @NotNull Function<T, EntityPatch<T>> entityPatchFactory
     ) {
         CommonEntityPatchProvider.registerEntityPatch(
                 typeEntry,
@@ -55,8 +58,8 @@ public class EntityPatchRegistryEvent extends Event {
     /// );
     /// ```
     public <T extends Entity> void registerEntityPatchUnsafe(
-            EntityType<T> entityType,
-            Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
+            @NotNull EntityType<T> entityType,
+            @NotNull Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
     ) {
         CommonEntityPatchProvider.registerEntityPatchUnsafe(
                 typeEntry,

--- a/neoforge/src/main/java/yesman/epicfight/world/capabilities/provider/CommonEntityPatchProvider.java
+++ b/neoforge/src/main/java/yesman/epicfight/world/capabilities/provider/CommonEntityPatchProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.projectile.AbstractArrow;
 import net.minecraft.world.entity.projectile.Projectile;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.api.event.EpicFightEventHooks;
 import yesman.epicfight.api.event.types.registry.EntityPatchRegistryEvent;
@@ -95,9 +96,9 @@ public final class CommonEntityPatchProvider {
     /// For more details, refer to [EntityPatchRegistryEvent#registerEntityPatch].
     @ApiStatus.Internal
     public static <T extends Entity> void registerEntityPatch(
-            Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
-            EntityType<T> entityType,
-            Function<T, EntityPatch<T>> entityPatchFactory
+            @NotNull Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
+            @NotNull EntityType<T> entityType,
+            @NotNull Function<T, EntityPatch<T>> entityPatchFactory
     ) {
         //noinspection unchecked
         registry.put(
@@ -110,9 +111,9 @@ public final class CommonEntityPatchProvider {
     /// For more details, refer to [EntityPatchRegistryEvent#registerEntityPatchUnsafe].
     @ApiStatus.Internal
     public static <T extends Entity> void registerEntityPatchUnsafe(
-            Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
-            EntityType<T> entityType,
-            Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
+            @NotNull Map<EntityType<?>, Function<Entity, EntityPatch<?>>> registry,
+            @NotNull EntityType<T> entityType,
+            @NotNull Function<? super T, ? extends EntityPatch<? extends T>> entityPatchFactory
     ) {
         //noinspection unchecked
         registry.put(


### PR DESCRIPTION
Deprecates `EntityPatchRegistryEvent#getTypeEntry()`, since `#registerEntityPatch` was introduced in #2352.

