### PR TITLE
[GitHub] Add Code Formatting Check Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,10 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Setup JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,21 @@
+name: Code Quality Checks
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check IntelliJ Formatting
+        uses: sidhant92/intellij-format-action@v1
+        with:
+          tool_name: 'IntelliJ Diff'
+          github_token: ${{ secrets.github_token }}
+          fail_on_changes: true
+          path: '.'
+          file_mask: '*.java'


### PR DESCRIPTION
Set up a GitHub workflow that will cause the CI to fail whenever there is a code formatting violation. Uses [IntelliJ Format Checker](https://github.com/marketplace/actions/intellij-format-checker) GitHub action.

This won't prevent merging PRs, but we should consider fixing violations before merging for consistent formatting.