### PR TITLE
Add required and optional dependencies when publishing the mod

### DIFF
--- a/gradle/build-logic/conventions/src/main/kotlin/SharedUtils.kt
+++ b/gradle/build-logic/conventions/src/main/kotlin/SharedUtils.kt
@@ -191,11 +191,28 @@ fun Project.configureModPublish(
         file.set(jarFile())
         additionalFiles.from(sourcesJar)
 
+        val requiredDependencies = buildList {
+            if (modLoader.isFabricLike) {
+                add("fabric-api")
+                add("forge-config-api-port")
+            }
+        }
+
+        val optionalDependencies =
+            buildList {
+                if (modLoader.isFabricLike) {
+                    add("modmenu")
+                }
+            }
+
         curseforge {
             accessToken.set(providers.environmentVariable("CURSEFORGE_TOKEN"))
             projectId.set("405076")
             minecraftVersions.add(mcVersion)
             projectSlug.set("epic-fight-mod")
+
+            requiredDependencies.forEach { requires(it) }
+            optionalDependencies.forEach { optional(it) }
         }
 
         modrinth {
@@ -207,6 +224,9 @@ fun Project.configureModPublish(
             projectDescription.set(
                 providers.fileContents(rootProject.layout.projectDirectory.file("README.md")).asText
             )
+
+            requiredDependencies.forEach { requires(it) }
+            optionalDependencies.forEach { optional(it) }
         }
 
         discord {


### PR DESCRIPTION
Adds the optional and required mod dependencies.
For now, NeoForge doesn't have any required mod dependencies. That may change if [Player Animation Library](https://modrinth.com/mod/player-animation-library) is used as an animation library for Epic Fight.