### PR TITLE
[1.21.1] Fix issue regarding BasicAttack's Air Attack being too lenient and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persistent Mapped Buffer (by @dfdyz)
     - Boosts frame rate by removing the uploading process of buffers to shader
     - Requires OpenGL version over 4.6
+- Added "swing_sound", "hit_sound", and "hit_particle" that is configurable in ItemCapability
+    - This is not supported by data pack editor, as we're going to refactor the data pack screen
 
 ### Changed
 

--- a/neoforge/src/main/java/yesman/epicfight/api/animation/types/AttackAnimation.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/animation/types/AttackAnimation.java
@@ -167,8 +167,14 @@ public class AttackAnimation extends ActionAnimation {
 	@Override
 	public void end(LivingEntityPatch<?> entitypatch, AssetAccessor<? extends DynamicAnimation> nextAnimation, boolean isEnd) {
 		super.end(entitypatch, nextAnimation, isEnd);
-		
-        float elapsedTime = entitypatch.getAnimator().getPlayerFor(this.getAccessor()).getElapsedTime();
+
+        AnimationPlayer player = entitypatch.getAnimator().getPlayerFor(this.getAccessor());
+
+        if (player == null) {
+            return;
+        }
+
+        float elapsedTime = player.getElapsedTime();
         EntityState state = this.getState(entitypatch, elapsedTime);
 
         if (!isEnd && state.attacking() && !entitypatch.isLogicalClient()) {
@@ -186,6 +192,11 @@ public class AttackAnimation extends ActionAnimation {
 	
 	protected void attackTick(LivingEntityPatch<?> entitypatch, AssetAccessor<? extends DynamicAnimation> animation) {
 		AnimationPlayer player = entitypatch.getAnimator().getPlayerFor(this.getAccessor());
+
+        if (player == null) {
+            return;
+        }
+
 		float prevElapsedTime = player.getPrevElapsedTime();
 		float elapsedTime = player.getElapsedTime();
 		EntityState prevState = animation.get().getState(entitypatch, prevElapsedTime);
@@ -295,42 +306,29 @@ public class AttackAnimation extends ActionAnimation {
 			epicfightSource = EpicFightDamageSources.fromVanillaDamageSource(originalSource).setAnimation(this.getAccessor());
 		}
 		
-		phase.getProperty(AttackPhaseProperty.DAMAGE_MODIFIER).ifPresent(opt -> {
-			epicfightSource.attachDamageModifier(opt);
-		});
+		phase.getProperty(AttackPhaseProperty.DAMAGE_MODIFIER).ifPresent(epicfightSource::attachDamageModifier);
 		
-		phase.getProperty(AttackPhaseProperty.ARMOR_NEGATION_MODIFIER).ifPresent(opt -> {
-			epicfightSource.attachArmorNegationModifier(opt);
-		});
+		phase.getProperty(AttackPhaseProperty.ARMOR_NEGATION_MODIFIER).ifPresent(epicfightSource::attachArmorNegationModifier);
 		
-		phase.getProperty(AttackPhaseProperty.IMPACT_MODIFIER).ifPresent(opt -> {
-			epicfightSource.attachImpactModifier(opt);
-		});
+		phase.getProperty(AttackPhaseProperty.IMPACT_MODIFIER).ifPresent(epicfightSource::attachImpactModifier);
 		
-		phase.getProperty(AttackPhaseProperty.STUN_TYPE).ifPresent(opt -> {
-			epicfightSource.setStunType(opt);
-		});
+		phase.getProperty(AttackPhaseProperty.STUN_TYPE).ifPresent(epicfightSource::setStunType);
 		
-		phase.getProperty(AttackPhaseProperty.SOURCE_TAG).ifPresent(opt -> {
-			opt.forEach(epicfightSource::addRuntimeTag);
-		});
+		phase.getProperty(AttackPhaseProperty.SOURCE_TAG).ifPresent(opt -> opt.forEach(epicfightSource::addRuntimeTag));
 		
-		phase.getProperty(AttackPhaseProperty.EXTRA_DAMAGE).ifPresent(opt -> {
-			opt.forEach(epicfightSource::addExtraDamage);
-		});
+		phase.getProperty(AttackPhaseProperty.EXTRA_DAMAGE).ifPresent(opt -> opt.forEach(epicfightSource::addExtraDamage));
 		
-		phase.getProperty(AttackPhaseProperty.SOURCE_LOCATION_PROVIDER).ifPresentOrElse(opt -> {
-			epicfightSource.setInitialPosition(opt.apply(entitypatch));
-		}, () -> {
-			epicfightSource.setInitialPosition(entitypatch.getOriginal().position());
-		});
+		phase.getProperty(AttackPhaseProperty.SOURCE_LOCATION_PROVIDER).ifPresentOrElse(
+            opt -> epicfightSource.setInitialPosition(opt.apply(entitypatch)),
+            () -> epicfightSource.setInitialPosition(entitypatch.getOriginal().position()))
+        ;
 		
 		return epicfightSource;
 	}
 	
 	protected void spawnHitParticle(ServerLevel world, LivingEntityPatch<?> attacker, Entity hit, Phase phase) {
 		Optional<DeferredHolder<ParticleType<?>, HitParticleType>> particleOptional = phase.getProperty(AttackPhaseProperty.PARTICLE);
-		HitParticleType particle = particleOptional.isPresent() ? particleOptional.get().get() : attacker.getWeaponHitParticle(phase.hand);
+		HitParticleType particle = particleOptional.map(DeferredHolder::get).orElseGet(() -> attacker.getWeaponHitParticle(phase.hand));
 		particle.spawnParticleWithArgument(world, null, null, hit, attacker.getOriginal());
 	}
 	
@@ -405,7 +403,11 @@ public class AttackAnimation extends ActionAnimation {
 	
 	@Override @ClientOnly
 	public void renderDebugging(PoseStack poseStack, MultiBufferSource buffer, LivingEntityPatch<?> entitypatch, float playbackTime, float partialTicks) {
-		AnimationPlayer animPlayer = entitypatch.getAnimator().getPlayerFor(this.getAccessor());
+        AnimationPlayer animPlayer = entitypatch.getAnimator().getPlayerFor(this.getAccessor());
+        if (animPlayer == null) {
+            return;
+        }
+
 		float prevElapsedTime = animPlayer.getPrevElapsedTime();
 		float elapsedTime = animPlayer.getElapsedTime();
 		Phase phase = this.getPhaseByTime(playbackTime);

--- a/neoforge/src/main/java/yesman/epicfight/api/data/reloader/ItemCapabilityReloadListener.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/data/reloader/ItemCapabilityReloadListener.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.Holder;
+import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -16,17 +17,20 @@ import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.collider.Collider;
 import yesman.epicfight.data.conditions.Condition;
 import yesman.epicfight.gameasset.ColliderPreset;
 import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.network.server.SPDatapackSync;
+import yesman.epicfight.particle.HitParticleType;
 import yesman.epicfight.registry.entries.EpicFightAttributes;
 import yesman.epicfight.registry.entries.EpicFightConditions;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
@@ -36,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -50,7 +55,7 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 	}
 	
 	@Override
-	protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profileIn) {
+	protected Map<ResourceLocation, JsonElement> prepare(@NotNull ResourceManager resourceManager, @NotNull ProfilerFiller profileIn) {
 		ARMOR_COMPOUNDS.clear();
 		WEAPON_COMPOUNDS.clear();
 		
@@ -58,7 +63,7 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 	}
 	
 	@Override
-	protected void apply(Map<ResourceLocation, JsonElement> objectIn, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
+	protected void apply(Map<ResourceLocation, JsonElement> objectIn, @NotNull ResourceManager resourceManagerIn, @NotNull ProfilerFiller profilerIn) {
 		for (Map.Entry<ResourceLocation, JsonElement> entry : objectIn.entrySet()) {
 			ResourceLocation rl = entry.getKey();
 			String path = rl.getPath();
@@ -68,7 +73,7 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 				ResourceLocation registryName = ResourceLocation.fromNamespaceAndPath(rl.getNamespace(), str[1]);
 				
 				if (!BuiltInRegistries.ITEM.containsKey(registryName)) {
-					EpicFightMod.LOGGER.warn("Item Capability Exception: No item named " + registryName);
+					EpicFightMod.LOGGER.warn("Item Capability Exception: No item named {}", registryName);
 					continue;
 				}
 				
@@ -78,7 +83,7 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 				try {
 					tag = TagParser.parseTag(entry.getValue().toString());
 				} catch (CommandSyntaxException e) {
-					EpicFightMod.LOGGER.warn("Error while deserializing datapack for " + registryName + ": " + e.getLocalizedMessage());
+                    warnDeserialize(registryName, e);
 					continue;
 				}
 				
@@ -93,14 +98,18 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 						WEAPON_COMPOUNDS.put(item, tag);
 					}
 				} catch (Exception e) {
-					EpicFightMod.LOGGER.warn("Error while deserializing datapack for " + registryName + ": " + e.getLocalizedMessage());
+                    warnDeserialize(registryName, e);
 				}
 			}
 		}
 		
 		EpicFightCapabilities.ITEM_CAPABILITY_PROVIDER.addDefaultItems();
 	}
-	
+
+    private static void warnDeserialize(ResourceLocation registryName, Exception e) {
+        EpicFightMod.LOGGER.warn("Error while deserializing datapack for {}: {}", registryName, e.getLocalizedMessage());
+    }
+
 	public static CapabilityItem deserializeArmor(Item item, CompoundTag tag) {
 		ArmorCapability.Builder builder = ArmorCapability.builder();
 		
@@ -113,7 +122,13 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 		
 		return builder.build();
 	}
-	
+
+    private static void setSound(String location, Function<SoundEvent, WeaponCapability.Builder> setter) {
+        ResourceLocation soundLocation = ResourceLocation.parse(location);
+        SoundEvent sound = BuiltInRegistries.SOUND_EVENT.get(soundLocation);
+        setter.apply(sound);
+    }
+
 	public static CapabilityItem deserializeWeapon(Item item, CompoundTag tag) {
 		CapabilityItem capability;
 		
@@ -158,7 +173,31 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 					}
 				}
 			}
-			
+
+            if (builder instanceof WeaponCapability.Builder weaponBuilder) {
+                if (tag.contains("swing_sound"))
+                {
+                    setSound(tag.getString("swing_sound"), weaponBuilder::swingSound);
+                }
+                if (tag.contains("hit_sound"))
+                {
+                    setSound(tag.getString("hit_sound"), weaponBuilder::hitSound);
+                }
+                if (tag.contains("hit_particle"))
+                {
+                    ResourceLocation hitParticleLocation = ResourceLocation.parse(tag.getString("hit_particle"));
+                    ParticleType<?> hitParticle = BuiltInRegistries.PARTICLE_TYPE.get(hitParticleLocation);
+                    if (hitParticle instanceof HitParticleType trueParticle)
+                    {
+                        weaponBuilder.hitParticle(trueParticle);
+                    }
+                    else
+                    {
+                        EpicFightMod.LOGGER.warn("Hit Particle Type not found: {}", hitParticleLocation);
+                    }
+                }
+            }
+
 			if (tag.contains("collider")) {
 				CompoundTag colliderTag = tag.getCompound("collider");
 				
@@ -166,7 +205,7 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 					Collider collider = ColliderPreset.deserializeSimpleCollider(colliderTag);
 					builder.collider(collider);
 				} catch (IllegalArgumentException e) {
-					EpicFightMod.LOGGER.warn("Can't deserialize collider of " + item + ": " + e.getMessage());
+                    EpicFightMod.LOGGER.warn("Can't deserialize collider of {}: {}", item, e.getMessage());
 				}
 			}
 			
@@ -197,22 +236,21 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 		
 		return modifierMap;
 	}
-	
-	public static Stream<CompoundTag> getArmorDataStream() {
-		Stream<CompoundTag> tagStream = ARMOR_COMPOUNDS.entrySet().stream().map((entry) -> {
-			entry.getValue().putInt("id", Item.getId(entry.getKey()));
-			return entry.getValue();
-		});
-		return tagStream;
-	}
-	
-	public static Stream<CompoundTag> getWeaponDataStream() {
-		Stream<CompoundTag> tagStream = WEAPON_COMPOUNDS.entrySet().stream().map((entry) -> {
-			entry.getValue().putInt("id", Item.getId(entry.getKey()));
-			return entry.getValue();
-		});
-		return tagStream;
-	}
+
+    private static Stream<CompoundTag> getStream(Map<Item, CompoundTag> map) {
+        return map.entrySet().stream().map((entry) -> {
+            entry.getValue().putInt("id", Item.getId(entry.getKey()));
+            return entry.getValue();
+        });
+    }
+
+    public static Stream<CompoundTag> getArmorDataStream() {
+        return getStream(ARMOR_COMPOUNDS);
+    }
+
+    public static Stream<CompoundTag> getWeaponDataStream() {
+        return getStream(WEAPON_COMPOUNDS);
+    }
 	
 	private static boolean armorReceived = false;
 	private static boolean weaponReceived = false;
@@ -254,9 +292,9 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 					CapabilityItem itemCap = deserializeArmor(item, tag);
 					EpicFightCapabilities.ITEM_CAPABILITY_PROVIDER.put(item, itemCap);
 				} catch (NoSuchElementException e) {
-					EpicFightMod.LOGGER.warn("Error while creating capability " + item + ": " + e.getLocalizedMessage());
+                    EpicFightMod.LOGGER.warn("Error while creating capability {}: {}", item, e.getLocalizedMessage());
 				} catch (Exception e) {
-					EpicFightMod.LOGGER.warn("Can't read item capability for " + item + ": " + e.getLocalizedMessage());
+                    EpicFightMod.LOGGER.warn("Can't read item capability for {}: {}", item, e.getLocalizedMessage());
 				}
 			});
 			
@@ -264,9 +302,9 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 				try {
 					CapabilityItem itemCap = deserializeWeapon(item, tag);
 					EpicFightCapabilities.ITEM_CAPABILITY_PROVIDER.put(item, itemCap);
-				} catch (NoSuchElementException e) {
+				} catch (NoSuchElementException ignored) {
 				} catch (Exception e) {
-					EpicFightMod.LOGGER.warn("Can't read item capability for " + item + ": " + e.getLocalizedMessage());
+					EpicFightMod.LOGGER.warn("Can't read item capability for {}: {}", item, e.getLocalizedMessage());
 				}
 			});
 			

--- a/neoforge/src/main/java/yesman/epicfight/skill/Skill.java
+++ b/neoforge/src/main/java/yesman/epicfight/skill/Skill.java
@@ -133,6 +133,8 @@ public abstract class Skill implements IdentifierProvider {
 		this.maxStackSize = parameters.contains("max_stacks") ? parameters.getInt("max_stacks") : 1;
 		this.attributes.clear();
 
+        AttributeModifier attributeModifier = AttributeModifier.CODEC.parse(NbtOps.INSTANCE, compoundTag).result().get();
+
 		if (parameters.contains("attribute_modifiers")) {
 			ListTag modifierListTag = parameters.getList("attribute_modifiers", Tag.TAG_COMPOUND);
 			ATTRIBUTE_ENTRY_CODEC.parse(NbtOps.INSTANCE, modifierListTag).result().ifPresent(modifiers -> modifiers.forEach(modifierEntry -> this.attributes.put(modifierEntry.attribute, modifierEntry.modifier)));

--- a/neoforge/src/main/java/yesman/epicfight/skill/common/ComboAttacks.java
+++ b/neoforge/src/main/java/yesman/epicfight/skill/common/ComboAttacks.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 
 public class ComboAttacks extends Skill {
+    private static final double MIN_AIR_ATTACK_Y_VELOCITY = -0.05D;
+
 	/// Decides if the animation used for combo attack
 	public static final IndependentVariableKey<Boolean> COMBO = AnimationVariables.unsyncIndependent(animator -> false, false);
 	
@@ -120,11 +122,11 @@ public class ComboAttacks extends Skill {
 		SkillDataManager dataManager = skillContainer.getDataManager();
 		int comboCounter = dataManager.getDataValue(EpicFightSkillDataKeys.COMBO_COUNTER);
         boolean dashAttack = player.isSprinting();
-        boolean airAttack = !skillContainer.getExecutor().getOriginal().onGround() && !skillContainer.getExecutor().getOriginal().isInWater();
+        boolean airAttack = !skillContainer.getExecutor().getOriginal().onGround() && !skillContainer.getExecutor().getOriginal().isInWater() && skillContainer.getExecutor().getOriginal().getDeltaMovement().y() > MIN_AIR_ATTACK_Y_VELOCITY;
 
         if (player.isPassenger()) {
 			Entity entity = player.getVehicle();
-			
+
 			if ((entity instanceof PlayerRideableJumping rideable && rideable.canJump()) && cap.availableOnHorse() && cap.getMountAttackMotion() != null) {
 				comboCounter %= cap.getMountAttackMotion().size();
 				attackMotion = cap.getMountAttackMotion().get(comboCounter);
@@ -132,7 +134,7 @@ public class ComboAttacks extends Skill {
 			}
 		} else {
 			List<AnimationAccessor<? extends AttackAnimation>> combo = cap.getAutoAttackMotion(executor);
-			
+
 			if (combo == null) {
 				return;
 			}

--- a/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/CapabilityItem.java
+++ b/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/CapabilityItem.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.enchantment.Enchantments;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.types.AttackAnimation;
@@ -91,7 +92,11 @@ public class CapabilityItem {
 		
 		return attributeModifiers;
 	}
-	
+
+    private static boolean validateAttribute(LivingEntityPatch<?> patch, Holder<Attribute> attributeHolder) {
+        return patch.getOriginal().getAttributes().hasAttribute(attributeHolder);
+    }
+
 	protected Map<Style, Map<Holder<Attribute>, AttributeModifier>> attributeMap;
 	protected Map<Style, ItemAttributeModifiers> modifiers;
 	protected Collider collider;
@@ -142,7 +147,7 @@ public class CapabilityItem {
 			Holder<Attribute> impact = EpicFightAttributes.IMPACT;
 			Holder<Attribute> maxStrikes = EpicFightAttributes.MAX_STRIKES;
 			
-			if (attribute.containsKey(armorNegation)) {
+			if (attribute.containsKey(armorNegation) && validateAttribute(entitypatch, armorNegation)) {
 				double value = attribute.get(armorNegation).amount() + entitypatch.getOriginal().getAttribute(armorNegation).getBaseValue();
 
 				if (value > 0.0D) {
@@ -150,7 +155,7 @@ public class CapabilityItem {
 				}
 			}
 			
-			if (attribute.containsKey(impact)) {
+			if (attribute.containsKey(impact) && validateAttribute(entitypatch, impact)) {
 				double value = attribute.get(impact).amount() + entitypatch.getOriginal().getAttribute(impact).getBaseValue();
 
 				if (value > 0.0D) {
@@ -160,7 +165,7 @@ public class CapabilityItem {
 				}
 			}
 			
-			if (attribute.containsKey(maxStrikes)) {
+			if (attribute.containsKey(maxStrikes) && validateAttribute(entitypatch, maxStrikes)) {
 				double value = attribute.get(maxStrikes).amount() + entitypatch.getOriginal().getAttribute(maxStrikes).getBaseValue();
 
 				if (value > 0.0D) {
@@ -325,7 +330,8 @@ public class CapabilityItem {
 	public Map<LivingMotion, AnimationAccessor<? extends StaticAnimation>> getLivingMotionModifier(LivingEntityPatch<?> playerpatch, InteractionHand hand) {
 		return Maps.newHashMap();
 	}
-	
+
+    @NotNull
 	public Style getStyle(LivingEntityPatch<?> entitypatch) {
 		return this.canBePlacedOffhand() ? Styles.ONE_HAND : Styles.TWO_HAND;
 	}

--- a/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/TridentCapability.java
+++ b/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/TridentCapability.java
@@ -1,14 +1,11 @@
 package yesman.epicfight.world.capabilities.item;
 
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.enchantment.Enchantments;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
@@ -22,6 +19,9 @@ import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 
+import javax.annotation.Nullable;
+import java.util.List;
+
 public class TridentCapability extends RangedWeaponCapability {
 	private List<AnimationAccessor<? extends AttackAnimation>> attackMotion;
 	private List<AnimationAccessor<? extends AttackAnimation>> mountAttackMotion;
@@ -33,7 +33,7 @@ public class TridentCapability extends RangedWeaponCapability {
 		this.mountAttackMotion = List.of(Animations.SPEAR_MOUNT_ATTACK);
 	}
 	
-	@Override
+	@Override @NotNull
 	public Style getStyle(LivingEntityPatch<?> entitypatch) {
 		return Styles.ONE_HAND;
 	}

--- a/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
+++ b/neoforge/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
@@ -1,17 +1,13 @@
 package yesman.epicfight.world.capabilities.item;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotion;
@@ -25,6 +21,10 @@ import yesman.epicfight.registry.entries.EpicFightSounds;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 public class WeaponCapability extends CapabilityItem {
 	protected final Function<LivingEntityPatch<?>, Style> stylegetter;
@@ -82,7 +82,7 @@ public class WeaponCapability extends CapabilityItem {
 		return this.autoAttackMotions.get(Styles.MOUNT);
 	}
 	
-	@Override
+	@Override @NotNull
 	public Style getStyle(LivingEntityPatch<?> entitypatch) {
 		return this.stylegetter.apply(entitypatch);
 	}
@@ -130,9 +130,9 @@ public class WeaponCapability extends CapabilityItem {
 	}
 	
 	@Override
-	public UseAnim getUseAnimation(LivingEntityPatch<?> playerpatch) {
+	public UseAnim getUseAnimation(LivingEntityPatch<?> entitypatch) {
 		if (this.livingMotionModifiers != null) {
-			Style style = this.getStyle(playerpatch);
+			Style style = this.getStyle(entitypatch);
 			
 			if (this.livingMotionModifiers.containsKey(style)) {
 				if (this.livingMotionModifiers.get(style).containsKey(LivingMotions.BLOCK)) {


### PR DESCRIPTION
> [!NOTE]
> Manually cherry-picked from #2347 (original author: @Forixaim)

**Changes:**

- Fixed some issues with BasicAttack's Air Attack being lenient, and added a couple of `null` checks to prevent some styles from instantly crashing the game
- Added a couple of DRY methods
- Added a neat feature that allows data-packers to specify their own hit sound based on the individual item instead of the weapon's capability.