### PR TITLE
Allow building the project with "Unreleased" mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [21.15.0.1] - 2025-12-28
+## [21.15.0.1] - Unreleased
 
 ### Added
 

--- a/gradle/build-logic/conventions/src/main/kotlin/SharedUtils.kt
+++ b/gradle/build-logic/conventions/src/main/kotlin/SharedUtils.kt
@@ -130,7 +130,7 @@ private fun Project.extractCurrentVersionChangelog(): String? {
 
     // Extracts the current version changelog without the version heading 2 and "For Devs" heading 3.
     val versionSectionRegex =
-        "(?s)## \\[$modVersion\\] - \\d{4}-\\d{2}-\\d{2}\\R(.*?)(?=\\R### For Devs|\\R## \\[.*?\\] |\\Z)"
+        "(?s)## \\[$modVersion\\] - (\\d{4}-\\d{2}-\\d{2}|Unreleased)\\R(.*?)(?=\\R### For Devs|\\R## \\[.*?\\] |\\Z)"
     val matcher = Regex(versionSectionRegex).find(fullChangelogText) ?: return null
 
     val versionChangelog = matcher.groupValues[1]


### PR DESCRIPTION
This is a problem when we want to share a build internally for the features that are incomplete. The mod publishing plugin searches for proper sentences in `CHANGELOG.md` by [version] - yyyy-mm-dd format but private builds doesn't have release date.

I modified regular expression that searches the changelog content from .md file so it can detect `Unreleased` mark instead of the date format. In that way we can build the project without modifying a random date for unreleased features.