### PR TITLE
Disallow implementing EpicFightEventHooks or EpicFightClientEventHooks

### DIFF
--- a/neoforge/src/main/java/yesman/epicfight/api/client/event/EpicFightClientEventHooks.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/client/event/EpicFightClientEventHooks.java
@@ -26,44 +26,69 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 /// only can register events that inherit [LivingEntityPatchEvent] for per entity events.
 ///
 /// For common event hooks for both client and server side, refer to [EpicFightEventHooks]
-public interface EpicFightClientEventHooks {
-    interface Camera {
-        CancelableEventHook<BuildCameraTransform.Pre> BUILD_TRANSFORM_PRE = CancelableEventHook.createCancelableEventHook();
-        EventHook<BuildCameraTransform.Post> BUILD_TRANSFORM_POST = EventHook.createEventHook();
-        EventHook<ItemUsedInDecoupledCamera> ITEM_USED_WHEN_DECOUPLED = EventHook.createEventHook();
-        EventHook<CoupleTPSCamera> COUPLE_CAMERA = EventHook.createEventHook();
-        EventHook<LockOnEvent.Start> LOCK_ON_START = CancelableEventHook.createCancelableEventHook();
-        EventHook<LockOnEvent.Tick> LOCK_ON_TICK = EventHook.createEventHook();
-        EventHook<LockOnEvent.Release> LOCK_ON_RELEASED = CancelableEventHook.createCancelableEventHook();
-        EventHook<ActivateTPSCamera> ACTIVATE_TPS_CAMERA = CancelableEventHook.createCancelableEventHook();
+public final class EpicFightClientEventHooks {
+    private EpicFightClientEventHooks() {
+
     }
 
-    interface Control {
-        EventHook<MappedMovementInputUpdateEvent> MAPPED_MOVEMENT_INPUT_UPDATE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    public final static class Camera {
+        private Camera() {
+
+        }
+
+        public static final CancelableEventHook<BuildCameraTransform.Pre> BUILD_TRANSFORM_PRE = CancelableEventHook.createCancelableEventHook();
+        public static final EventHook<BuildCameraTransform.Post> BUILD_TRANSFORM_POST = EventHook.createEventHook();
+        public static final EventHook<ItemUsedInDecoupledCamera> ITEM_USED_WHEN_DECOUPLED = EventHook.createEventHook();
+        public static final EventHook<CoupleTPSCamera> COUPLE_CAMERA = EventHook.createEventHook();
+        public static final EventHook<LockOnEvent.Start> LOCK_ON_START = CancelableEventHook.createCancelableEventHook();
+        public static final EventHook<LockOnEvent.Tick> LOCK_ON_TICK = EventHook.createEventHook();
+        public static final EventHook<LockOnEvent.Release> LOCK_ON_RELEASED = CancelableEventHook.createCancelableEventHook();
+        public static final EventHook<ActivateTPSCamera> ACTIVATE_TPS_CAMERA = CancelableEventHook.createCancelableEventHook();
     }
 
-    interface Entity {
-        EventHook<ProcessEntityPairingPacketEvent> HANDLE_ENTITY_PAIRING_PACKET = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.CLIENT);
-        EventHook<ModifyPlayerLivingMotionEvent.BaseLayer> MODIFY_PLAYER_LIVING_MOTION_BASE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<ModifyPlayerLivingMotionEvent.CompositeLayer> MODIFY_PLAYER_LIVING_MOTION_COMPOSITE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    public final static class Control {
+        private Control() {
+
+        }
+
+        public static final EventHook<MappedMovementInputUpdateEvent> MAPPED_MOVEMENT_INPUT_UPDATE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
     }
 
-    interface HUD {
-        EventHook<TickTargetIndicatorEvent> TARGET_INDICATOR_TICK = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    public final static class Entity {
+        private Entity() {
+
+        }
+
+        public static final EventHook<ProcessEntityPairingPacketEvent> HANDLE_ENTITY_PAIRING_PACKET = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.CLIENT);
+        public static final EventHook<ModifyPlayerLivingMotionEvent.BaseLayer> MODIFY_PLAYER_LIVING_MOTION_BASE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<ModifyPlayerLivingMotionEvent.CompositeLayer> MODIFY_PLAYER_LIVING_MOTION_COMPOSITE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
     }
 
-    interface Registry {
-        EventHook<RegisterAttributeIconEvent> ATTRIBUTE_ICON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<RegisterPatchedRenderersEvent.ModifyEntity> MODIFY_PATCHED_ENTITY = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<RegisterPatchedRenderersEvent.AddEntity> ADD_PATCHED_ENTITY = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<RegisterPatchedRenderersEvent.Item> PATCHED_ITEM = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<RegisterWeaponCategoryIconEvent> WEAPON_CATEGORY_ICON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    public final static class HUD {
+        private HUD() {
+        }
+
+        public static final EventHook<TickTargetIndicatorEvent> TARGET_INDICATOR_TICK = EventHook.createSidedEventHook(LogicalSide.CLIENT);
     }
 
-    interface Render {
-        EventHook<AnimatedArmorTextureEvent> ANIMATED_ARMOR_TEXTURE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<PrepareModelEvent> PREPARE_MODEL_TO_RENDER = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<RenderEnderDragonEvent> RENDER_ENDER_DRAGON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
-        EventHook<ValidatePlayerModelEvent> VALIDATE_PLAYER_MODEL_TO_RENDER = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    public final static class Registry {
+        private Registry() {
+        }
+
+        public static final EventHook<RegisterAttributeIconEvent> ATTRIBUTE_ICON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<RegisterPatchedRenderersEvent.ModifyEntity> MODIFY_PATCHED_ENTITY = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<RegisterPatchedRenderersEvent.AddEntity> ADD_PATCHED_ENTITY = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<RegisterPatchedRenderersEvent.Item> PATCHED_ITEM = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<RegisterWeaponCategoryIconEvent> WEAPON_CATEGORY_ICON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+    }
+
+    public final static class Render {
+        private Render() {
+        }
+
+        public static final EventHook<AnimatedArmorTextureEvent> ANIMATED_ARMOR_TEXTURE = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<PrepareModelEvent> PREPARE_MODEL_TO_RENDER = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<RenderEnderDragonEvent> RENDER_ENDER_DRAGON = EventHook.createSidedEventHook(LogicalSide.CLIENT);
+        public static final EventHook<ValidatePlayerModelEvent> VALIDATE_PLAYER_MODEL_TO_RENDER = EventHook.createSidedEventHook(LogicalSide.CLIENT);
     }
 }

--- a/neoforge/src/main/java/yesman/epicfight/api/event/EpicFightEventHooks.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/event/EpicFightEventHooks.java
@@ -18,51 +18,67 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 /// If you want to listen an event not globally, but per entity, call the exact same registering methods in
 /// [EntityEventListener], which you can access by [LivingEntityPatch#getEventListener]. Be aware that you
 /// only can register events that inherit [LivingEntityPatchEvent] for per entity events.
-public interface EpicFightEventHooks {
-    interface Animation {
-        EventHook<AnimationBeginEvent> BEGIN = EventHook.createEventHook();
-        EventHook<AnimationEndEvent> END = EventHook.createEventHook();
-        EventHook<AttackPhaseEndEvent> ATTACK_PHASE_END = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<InitAnimatorEvent> INIT_ANIMATOR = EventHook.createEventHook();
-        EventHook<StartActionEvent> START_ACTION = EventHook.createEventHook();
+public final class EpicFightEventHooks {
+    private EpicFightEventHooks() {
     }
 
-    interface Entity {
-        CancelableEventHook<DealDamageEvent.Income> DELIEVER_DAMAGE_INCOME = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        EventHook<DealDamageEvent.Pre> DELIEVER_DAMAGE_PRE = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<DealDamageEvent.Post> DELIEVER_DAMAGE_POST = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<DodgeEvent> ON_DODGE = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<FallEvent> ON_FALL = EventHook.createEventHook();
-        EventHook<HandleEntityDataEvent.Load> NBT_LOAD = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<HandleEntityDataEvent.Save> NBT_SAVE = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        CancelableEventHook<HitByProjectileEvent> HIT_BY_PROJECTILE = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        EventHook<KillEntityEvent> KILL_ENTITY = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<ModifyAttackSpeedEvent> MODIFY_ATTACK_SPEED = EventHook.createEventHook();
-        EventHook<ModifyBaseDamageEvent> MODIFY_ATTACK_DAMAGE = EventHook.createEventHook();
-        EventHook<EntityRemovedEvent> ON_REMOVED = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<StunnedEvent> ON_STUNNED = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        CancelableEventHook<TakeDamageEvent.Income> TAKE_DAMAGE_INCOME = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        EventHook<TakeDamageEvent.Pre> TAKE_DAMAGE_PRE = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        EventHook<TakeDamageEvent.Post> TAKE_DAMAGE_POST = EventHook.createSidedEventHook(LogicalSide.SERVER);
+    public static final class Animation {
+        private Animation() {
+        }
+
+        public static final EventHook<AnimationBeginEvent> BEGIN = EventHook.createEventHook();
+        public static final EventHook<AnimationEndEvent> END = EventHook.createEventHook();
+        public static final EventHook<AttackPhaseEndEvent> ATTACK_PHASE_END = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<InitAnimatorEvent> INIT_ANIMATOR = EventHook.createEventHook();
+        public static final EventHook<StartActionEvent> START_ACTION = EventHook.createEventHook();
     }
 
-    interface Player {
-        EventHook<ChangeInnateSkillEvent> CHANGE_INNATE_SKILL = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        CancelableEventHook<ComboAttackEvent> COMBO_ATTACK = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        CancelableEventHook<ModifyComboCounter> MODIFY_COMBO_COUNTER = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        CancelableEventHook<SetTargetEvent> SET_TARGET = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
-        EventHook<SkillCancelEvent> CANCEL_SKILL = EventHook.createSidedEventHook(LogicalSide.SERVER);
-        CancelableEventHook<SkillCastEvent> CAST_SKILL = CancelableEventHook.createCancelableEventHook();
-        CancelableEventHook<SkillConsumeEvent> CONSUME_SKILL = CancelableEventHook.createCancelableEventHook();
-        CancelableEventHook<TickPlayerEpicFightModeEvent> TICK_EPICFIGHT_MODE = CancelableEventHook.createCancelableEventHook();
-        EventHook<TogglePlayerModeEvent> TOGGLE_MODE = CancelableEventHook.createCancelableEventHook();
-        EventHook<StartUsingItemEvent> USE_ITEM = EventHook.createEventHook();
+    public static final class Entity {
+        private Entity() {
+        }
+
+        public static final CancelableEventHook<DealDamageEvent.Income> DELIEVER_DAMAGE_INCOME = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final EventHook<DealDamageEvent.Pre> DELIEVER_DAMAGE_PRE = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<DealDamageEvent.Post> DELIEVER_DAMAGE_POST = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<DodgeEvent> ON_DODGE = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<FallEvent> ON_FALL = EventHook.createEventHook();
+        public static final EventHook<HandleEntityDataEvent.Load> NBT_LOAD = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<HandleEntityDataEvent.Save> NBT_SAVE = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<HitByProjectileEvent> HIT_BY_PROJECTILE = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final EventHook<KillEntityEvent> KILL_ENTITY = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<ModifyAttackSpeedEvent> MODIFY_ATTACK_SPEED = EventHook.createEventHook();
+        public static final EventHook<ModifyBaseDamageEvent> MODIFY_ATTACK_DAMAGE = EventHook.createEventHook();
+        public static final EventHook<EntityRemovedEvent> ON_REMOVED = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<StunnedEvent> ON_STUNNED = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<TakeDamageEvent.Income> TAKE_DAMAGE_INCOME = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final EventHook<TakeDamageEvent.Pre> TAKE_DAMAGE_PRE = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final EventHook<TakeDamageEvent.Post> TAKE_DAMAGE_POST = EventHook.createSidedEventHook(LogicalSide.SERVER);
     }
 
-    interface Registry {
-        EventHook<EntityPatchRegistryEvent> ENTITY_PATCH = EventHook.createEventHook();
-        EventHook<SkillBuilderModificationEvent> MODIFY_SKILL_BUILDER = EventHook.createEventHook();
-        EventHook<RegisterMobSkillBookLootTableEvent> SKILLBOOK_LOOT_TABLE = EventHook.createEventHook();
-        EventHook<WeaponCapabilityPresetRegistryEvent> WEAPON_CAPABILITY_PRESET = EventHook.createEventHook();
+    public static final class Player {
+        private Player() {
+
+        }
+
+        public static final EventHook<ChangeInnateSkillEvent> CHANGE_INNATE_SKILL = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<ComboAttackEvent> COMBO_ATTACK = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<ModifyComboCounter> MODIFY_COMBO_COUNTER = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<SetTargetEvent> SET_TARGET = CancelableEventHook.createSidedCancelableEventHook(LogicalSide.SERVER);
+        public static final EventHook<SkillCancelEvent> CANCEL_SKILL = EventHook.createSidedEventHook(LogicalSide.SERVER);
+        public static final CancelableEventHook<SkillCastEvent> CAST_SKILL = CancelableEventHook.createCancelableEventHook();
+        public static final CancelableEventHook<SkillConsumeEvent> CONSUME_SKILL = CancelableEventHook.createCancelableEventHook();
+        public static final CancelableEventHook<TickPlayerEpicFightModeEvent> TICK_EPICFIGHT_MODE = CancelableEventHook.createCancelableEventHook();
+        public static final EventHook<TogglePlayerModeEvent> TOGGLE_MODE = CancelableEventHook.createCancelableEventHook();
+        public static final EventHook<StartUsingItemEvent> USE_ITEM = EventHook.createEventHook();
+    }
+
+    public static final class Registry {
+        private Registry() {
+        }
+
+        public static final EventHook<EntityPatchRegistryEvent> ENTITY_PATCH = EventHook.createEventHook();
+        public static final EventHook<SkillBuilderModificationEvent> MODIFY_SKILL_BUILDER = EventHook.createEventHook();
+        public static final EventHook<RegisterMobSkillBookLootTableEvent> SKILLBOOK_LOOT_TABLE = EventHook.createEventHook();
+        public static final EventHook<WeaponCapabilityPresetRegistryEvent> WEAPON_CAPABILITY_PRESET = EventHook.createEventHook();
     }
 }


### PR DESCRIPTION
Refactors `EpicFightEventHooks` and `EpicFightClientEventHooks` to use `public final class` with a private constructor and `public static final` for all fields.

This is **significantly** more verbose but **more Java idiomatic** since it disallows using `implements` for any of the interfaces.

Java's own classes already apply this pattern, and newer Fabric/NeoForge/Minecraft classes also adapt it:

<img width="951" height="656" alt="image" src="https://github.com/user-attachments/assets/7334d4a1-a8e1-4165-9749-0b6f625edc64" />

<img width="1060" height="408" alt="image" src="https://github.com/user-attachments/assets/45e8ea92-36bd-407a-9d85-9fb330611d0e" />

<img width="832" height="703" alt="image" src="https://github.com/user-attachments/assets/5f84dbaf-1ba5-4424-8a38-d14448b5ee8b" />

It's more efficient to use patterns that prevent what shouldn't be done at compile time, to give a stronger semantics and clearer intent.

`EpicFightEventHooks` is only used as a structure or holder for these fields, and it's not meant to be subclassed/extended or implemented, or instantiated.

This also changes the IDE icon to be clearer:

<details><summary>Before</summary>
<p>

<img width="685" height="34" alt="image" src="https://github.com/user-attachments/assets/ce496ff3-a48f-45bd-8162-5b81dbe69bfd" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="704" height="164" alt="image" src="https://github.com/user-attachments/assets/3150d845-9459-47aa-bd82-ba5686f6d2ac" />

</p>
</details> 