### PR TITLE
Added combo counter handler in CapabilityItem and fixed a crucial issue in combo attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [20.14.5] - 2025-01-09
+
+### Fixed
+- Fixed the player can't play the same attack animation, until it fully ends in the server side
+
+### For Devs
+- ComboCounterHandler
+    - A more modularized and parameter sensitive way to handle combo counter of `BasicAttack`
+    - CapabilityItem.shouldCancelCombo is now deprecated, as more parameter sensitive version introduced
+
 ## [20.14.4] - 2025-12-17
 
 ### Changed

--- a/src/main/java/yesman/epicfight/skill/BasicAttack.java
+++ b/src/main/java/yesman/epicfight/skill/BasicAttack.java
@@ -1,10 +1,10 @@
 package yesman.epicfight.skill;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.collect.Sets;
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -18,7 +18,7 @@ import yesman.epicfight.api.animation.AnimationVariables.IndependentAnimationVar
 import yesman.epicfight.api.animation.property.AnimationProperty.ActionAnimationProperty;
 import yesman.epicfight.api.animation.types.AttackAnimation;
 import yesman.epicfight.api.animation.types.EntityState;
-import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.animation.types.MainFrameAnimation;
 import yesman.epicfight.network.EpicFightNetworkManager;
 import yesman.epicfight.network.common.AnimatorControlPacket;
 import yesman.epicfight.network.server.SPAnimatorControl;
@@ -41,9 +41,20 @@ public class BasicAttack extends Skill {
 		return new SkillBuilder<BasicAttack>().setCategory(SkillCategories.BASIC_ATTACK).setActivateType(ActivateType.ONE_SHOT).setResource(Resource.NONE);
 	}
 	
-	public static void setComboCounterWithEvent(ComboCounterHandleEvent.Causal reason, ServerPlayerPatch playerpatch, SkillContainer container, AnimationAccessor<? extends StaticAnimation> causalAnimation, int value) {
+	public static void setComboCounterWithEvent(ComboCounterHandleEvent.Causal reason, ServerPlayerPatch playerpatch, SkillContainer container, @Nullable AnimationAccessor<? extends MainFrameAnimation> causalAnimation, int counter) {
+		if (reason != ComboCounterHandleEvent.Causal.TIME_EXPIRED && !causalAnimation.get().getProperty(ActionAnimationProperty.RESET_PLAYER_COMBO_COUNTER).orElse(true)) {
+			return;
+		}
+		
+		CapabilityItem itemCapability = playerpatch.getHoldingItemCapability(InteractionHand.MAIN_HAND);
+		
+		if (reason != ComboCounterHandleEvent.Causal.TIME_EXPIRED && !itemCapability.shouldCancelCombo(playerpatch)) {
+			return;
+		}
+		
+		int modifiedCombo = itemCapability.handleComboCounter(reason, playerpatch, causalAnimation, counter);
 		int prevValue = container.getDataManager().getDataValue(SkillDataKeys.COMBO_COUNTER.get());
-		ComboCounterHandleEvent comboResetEvent = new ComboCounterHandleEvent(reason, playerpatch, causalAnimation, prevValue, value);
+		ComboCounterHandleEvent comboResetEvent = new ComboCounterHandleEvent(reason, playerpatch, causalAnimation, prevValue, modifiedCombo);
 		container.getExecutor().getEventListener().triggerEvents(EventType.COMBO_COUNTER_HANDLE_EVENT, comboResetEvent);
 		container.getDataManager().setData(SkillDataKeys.COMBO_COUNTER.get(), comboResetEvent.getNextValue());
 	}
@@ -59,20 +70,8 @@ public class BasicAttack extends Skill {
 	@Override
 	public void onInitiate(SkillContainer container) {
 		container.getExecutor().getEventListener().addEventListener(EventType.ACTION_EVENT_SERVER, EVENT_UUID, (event) -> {
-			if (event.getAnimation().get().getProperty(ActionAnimationProperty.RESET_PLAYER_COMBO_COUNTER).orElse(true)) {
-				CapabilityItem itemCapability = event.getPlayerPatch().getHoldingItemCapability(InteractionHand.MAIN_HAND);
-				List<AnimationAccessor<? extends AttackAnimation>> comboAnimations = itemCapability.getAutoAttackMotion(container.getExecutor());
-				
-				if (comboAnimations == null) {
-					return;
-				}
-				
-				Set<AnimationAccessor<? extends AttackAnimation>> attackMotionSet = Set.copyOf(Sets.newHashSet(comboAnimations));
-				
-				if (!attackMotionSet.contains(event.getAnimation()) && itemCapability.shouldCancelCombo(event.getPlayerPatch())) {
-					setComboCounterWithEvent(ComboCounterHandleEvent.Causal.ANOTHER_ACTION_ANIMATION, event.getPlayerPatch(), container, event.getAnimation(), 0);
-				}
-			}
+			int comboCounter = container.getDataManager().getDataValue(SkillDataKeys.COMBO_COUNTER.get());
+			setComboCounterWithEvent(ComboCounterHandleEvent.Causal.ANOTHER_ACTION_ANIMATION, event.getPlayerPatch(), container, event.getAnimation(), comboCounter);
 		});
 	}
 	
@@ -116,7 +115,7 @@ public class BasicAttack extends Skill {
 		int comboCounter = dataManager.getDataValue(SkillDataKeys.COMBO_COUNTER.get());
         boolean dashAttack = player.isSprinting();
         boolean airAttack = !skillContainer.getExecutor().getOriginal().onGround() && !skillContainer.getExecutor().getOriginal().isInWater();
-		
+        
 		if (player.isPassenger()) {
 			Entity entity = player.getVehicle();
 			
@@ -135,23 +134,22 @@ public class BasicAttack extends Skill {
 			int comboSize = combo.size();
 
 			if (airAttack) {
-                comboCounter = comboSize - 1;
-            }
-            else if (dashAttack) {
-				comboCounter = comboSize - 2;
+				attackMotion = combo.get(comboSize - 1);
+            } else if (dashAttack) {
+            	attackMotion = combo.get(comboSize - 2);
 			} else {
-				comboCounter %= comboSize - 2;
+				attackMotion = combo.get(comboCounter);
+				
+				// Grows the combo counter when doing combo attacks
+				comboCounter = (comboCounter + 1) % (comboSize - 2);
 			}
-			
-			attackMotion = combo.get(comboCounter);
-			comboCounter = (dashAttack || airAttack) ? 0 : comboCounter + 1;
 		}
 		
 		setComboCounterWithEvent(ComboCounterHandleEvent.Causal.ANOTHER_ACTION_ANIMATION, executor, skillContainer, attackMotion, comboCounter);
 		
 		if (attackMotion != null && this.checkConsumption(skillContainer, dashAttack, airAttack)) {
-			executor.getAnimator().getVariables().put(COMBO, attackMotion, true);
 			executor.getAnimator().playAnimation(attackMotion, 0.0F);
+			executor.getAnimator().getVariables().put(COMBO, attackMotion, true);
 			
 			boolean stiffAttack = EpicFightGameRules.STIFF_COMBO_ATTACKS.getRuleValue(executor.getOriginal().level());
 			SPAnimatorControl animatorControlPacket;

--- a/src/main/java/yesman/epicfight/skill/BasicAttack.java
+++ b/src/main/java/yesman/epicfight/skill/BasicAttack.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 import org.jetbrains.annotations.Nullable;
 
-import dev.tr7zw.skinlayers.versionless.util.Mth;
+import net.minecraft.util.Mth;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/yesman/epicfight/skill/BasicAttack.java
+++ b/src/main/java/yesman/epicfight/skill/BasicAttack.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.jetbrains.annotations.Nullable;
 
+import dev.tr7zw.skinlayers.versionless.util.Mth;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -56,7 +57,7 @@ public class BasicAttack extends Skill {
 		int prevValue = container.getDataManager().getDataValue(SkillDataKeys.COMBO_COUNTER.get());
 		ComboCounterHandleEvent comboResetEvent = new ComboCounterHandleEvent(reason, playerpatch, causalAnimation, prevValue, modifiedCombo);
 		container.getExecutor().getEventListener().triggerEvents(EventType.COMBO_COUNTER_HANDLE_EVENT, comboResetEvent);
-		container.getDataManager().setData(SkillDataKeys.COMBO_COUNTER.get(), comboResetEvent.getNextValue());
+		container.getDataManager().setData(SkillDataKeys.COMBO_COUNTER.get(), Mth.clamp(comboResetEvent.getNextValue(), 0, itemCapability.getAutoAttackMotion(playerpatch).size() - 3));
 	}
 	
 	/// Consumption amount when basic attacks set to use stamina

--- a/src/main/java/yesman/epicfight/world/capabilities/item/CapabilityItem.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/CapabilityItem.java
@@ -31,6 +31,7 @@ import net.minecraft.world.item.enchantment.Enchantments;
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.types.AttackAnimation;
+import yesman.epicfight.api.animation.types.MainFrameAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.collider.Collider;
 import yesman.epicfight.gameasset.Animations;
@@ -52,6 +53,8 @@ import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 import yesman.epicfight.world.entity.ai.attribute.EpicFightAttributes;
+import yesman.epicfight.world.entity.eventlistener.ComboCounterHandleEvent;
+import yesman.epicfight.world.entity.eventlistener.ComboCounterHandleEvent.ComboCounterHandler;
 
 public class CapabilityItem {
 	public static CapabilityItem EMPTY = CapabilityItem.builder().build();
@@ -335,8 +338,19 @@ public class CapabilityItem {
 		return true;
 	}
 	
+	/**
+	 * Use {@link #handleComboCounter(PlayerPatch, AnimationAccessor)} with animation sensitive version
+	 */
+	@Deprecated(forRemoval = true)
 	public boolean shouldCancelCombo(LivingEntityPatch<?> entitypatch) {
 		return true;
+	}
+	
+	/**
+	 * @param nextAnimation null when causal == {@link ComboCounterHandleEvent.Causal#TIME_EXPIRED}
+	 */
+	public int handleComboCounter(ComboCounterHandleEvent.Causal causal, PlayerPatch<?> entitypatch, @Nullable AnimationAccessor<? extends MainFrameAnimation> nextAnimation, int original) {
+		return ComboCounterHandler.DEFAULT_COMBO_HANDLER.handleComboCounter(this, causal, entitypatch, nextAnimation, original);
 	}
 	
 	public boolean isEmpty() {

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -20,6 +22,7 @@ import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
 import yesman.epicfight.api.animation.LivingMotion;
 import yesman.epicfight.api.animation.LivingMotions;
 import yesman.epicfight.api.animation.types.AttackAnimation;
+import yesman.epicfight.api.animation.types.MainFrameAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.collider.Collider;
 import yesman.epicfight.gameasset.EpicFightSounds;
@@ -29,6 +32,8 @@ import yesman.epicfight.particle.HitParticleType;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+import yesman.epicfight.world.entity.eventlistener.ComboCounterHandleEvent;
+import yesman.epicfight.world.entity.eventlistener.ComboCounterHandleEvent.ComboCounterHandler;
 
 public class WeaponCapability extends CapabilityItem {
 	protected final Function<LivingEntityPatch<?>, Style> stylegetter;
@@ -41,7 +46,9 @@ public class WeaponCapability extends CapabilityItem {
 	protected final Map<Style, Function<ItemStack, Skill>> innateSkill;
 	protected final Map<Style, Map<LivingMotion, AnimationAccessor<? extends StaticAnimation>>> livingMotionModifiers;
 	protected final boolean canBePlacedOffhand;
+	@Deprecated
 	protected final Function<Style, Boolean> comboCancel;
+	protected final ComboCounterHandler comboCounterHandler;
 	protected final ZoomInType zoomInType;
 	protected final float reach;
 	
@@ -61,6 +68,7 @@ public class WeaponCapability extends CapabilityItem {
 		this.hitSound = weaponBuilder.hitSound;
 		this.canBePlacedOffhand = weaponBuilder.canBePlacedOffhand;
 		this.comboCancel = weaponBuilder.comboCancel;
+		this.comboCounterHandler = weaponBuilder.comboCounterHandler;
 		this.zoomInType = weaponBuilder.zoomInType;
 		this.reach = weaponBuilder.reach;
 	}
@@ -114,6 +122,11 @@ public class WeaponCapability extends CapabilityItem {
 	@Override
 	public boolean shouldCancelCombo(LivingEntityPatch<?> entitypatch) {
 		return this.comboCancel.apply(this.getStyle(entitypatch));
+	}
+	
+	@Override
+	public int handleComboCounter(ComboCounterHandleEvent.Causal causal, PlayerPatch<?> entitypatch, @Nullable AnimationAccessor<? extends MainFrameAnimation> nextAnimation, int original) {
+		return this.comboCounterHandler.handleComboCounter(this, causal, entitypatch, nextAnimation, original);
 	}
 	
 	@Override
@@ -183,6 +196,7 @@ public class WeaponCapability extends CapabilityItem {
 		Map<Style, Function<ItemStack, Skill>> innateSkillByStyle;
 		Map<Style, Map<LivingMotion, AnimationAccessor<? extends StaticAnimation>>> livingMotionModifiers;
 		Function<Style, Boolean> comboCancel;
+		ComboCounterHandler comboCounterHandler;
 		boolean canBePlacedOffhand;
 		ZoomInType zoomInType;
 		float reach;
@@ -200,6 +214,7 @@ public class WeaponCapability extends CapabilityItem {
 			this.livingMotionModifiers = null;
 			this.canBePlacedOffhand = true;
 			this.comboCancel = (style) -> true;
+			this.comboCounterHandler = ComboCounterHandler.DEFAULT_COMBO_HANDLER;
 			this.zoomInType = ZoomInType.NONE;
 			this.reach = 0.2F;
 		}
@@ -290,8 +305,17 @@ public class WeaponCapability extends CapabilityItem {
 			return this;
 		}
 		
+		/**
+		 * @Deprecated - Use more sensitive version {@link #comboCounterHandler}
+		 */
+		@Deprecated
 		public Builder comboCancel(Function<Style, Boolean> comboCancel) {
 			this.comboCancel = comboCancel;
+			return this;
+		}
+		
+		public Builder comboCounterHandler(ComboCounterHandler comboHandler) {
+			this.comboCounterHandler = comboHandler;
 			return this;
 		}
 		

--- a/src/main/java/yesman/epicfight/world/entity/eventlistener/ActionEvent.java
+++ b/src/main/java/yesman/epicfight/world/entity/eventlistener/ActionEvent.java
@@ -1,22 +1,22 @@
 package yesman.epicfight.world.entity.eventlistener;
 
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
-import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.api.animation.types.MainFrameAnimation;
 import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 
 public class ActionEvent<T extends PlayerPatch<?>> extends AbstractPlayerEvent<T> {
-	private final AnimationAccessor<? extends StaticAnimation> actionAnimation;
+	private final AnimationAccessor<? extends MainFrameAnimation> actionAnimation;
 	private boolean resetActionTick;
 	
 	@SuppressWarnings("unchecked")
-	public ActionEvent(PlayerPatch<?> playerdata, AnimationAccessor<? extends StaticAnimation> actionAnimation) {
+	public ActionEvent(PlayerPatch<?> playerdata, AnimationAccessor<? extends MainFrameAnimation> actionAnimation) {
 		super((T)playerdata, false);
 		
 		this.actionAnimation = actionAnimation;
 		this.resetActionTick = true;
 	}
 	
-	public AnimationAccessor<? extends StaticAnimation> getAnimation() {
+	public AnimationAccessor<? extends MainFrameAnimation> getAnimation() {
 		return this.actionAnimation;
 	}
 	

--- a/src/main/java/yesman/epicfight/world/entity/eventlistener/ComboCounterHandleEvent.java
+++ b/src/main/java/yesman/epicfight/world/entity/eventlistener/ComboCounterHandleEvent.java
@@ -1,8 +1,19 @@
 package yesman.epicfight.world.entity.eventlistener;
 
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Sets;
+
 import yesman.epicfight.api.animation.AnimationManager.AnimationAccessor;
+import yesman.epicfight.api.animation.types.AttackAnimation;
+import yesman.epicfight.api.animation.types.MainFrameAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
+import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
 
 public class ComboCounterHandleEvent extends AbstractPlayerEvent<ServerPlayerPatch> {
 	private final ComboCounterHandleEvent.Causal causal;
@@ -41,5 +52,41 @@ public class ComboCounterHandleEvent extends AbstractPlayerEvent<ServerPlayerPat
 	
 	public enum Causal {
 		ANOTHER_ACTION_ANIMATION, TIME_EXPIRED
+	}
+	
+	@FunctionalInterface
+	public interface ComboCounterHandler {
+		ComboCounterHandler DEFAULT_COMBO_HANDLER = (CapabilityItem itemCapability, ComboCounterHandleEvent.Causal causal, PlayerPatch<?> entitypatch, @Nullable AnimationAccessor<? extends MainFrameAnimation> nextAnimation, int comboCounter) -> {
+			// When causal is time expiration, reset the counter
+			if (causal == ComboCounterHandleEvent.Causal.TIME_EXPIRED) {
+				return 0;
+			}
+			
+			List<AnimationAccessor<? extends AttackAnimation>> comboAnimations = itemCapability.getAutoAttackMotion(entitypatch);
+			
+			if (comboAnimations == null) {
+				return 0;
+			}
+			
+			Set<AnimationAccessor<? extends AttackAnimation>> attackMotionSet = Sets.newHashSet(comboAnimations);
+			
+			// when the next animation is not included in weapon attack motion, reset the counter
+			if (!attackMotionSet.contains(nextAnimation)) {
+				return 0;
+			}
+			
+			int comboSize = comboAnimations.size();
+			
+			// When the next animation is dash or air attacks, reset combo counter
+			if (nextAnimation.equals(comboAnimations.get(comboSize - 1)) || nextAnimation.equals(comboAnimations.get(comboSize - 2))) {
+				return 0;
+			}
+			
+			return comboCounter;
+		};
+		
+		/// Control the combo counter with given parameters
+		/// @param nextAnimation null when ComboCounterHandleEvent.Causal is {@link ComboCounterHandleEvent.Causal#TIME_EXPIRED}
+		int handleComboCounter(CapabilityItem itemCapability, ComboCounterHandleEvent.Causal causal, PlayerPatch<?> entitypatch, @Nullable AnimationAccessor<? extends MainFrameAnimation> nextAnimation, int comboCounter);
 	}
 }


### PR DESCRIPTION
Feature requested by @Reascer, a unified and parameter-sensitive combo counter handler was required in development Weapons of Miracles.

The old API only provides a way to turn off combot counter reset feature when action animations are played.

```java
WeaponCapability.Builder builder = WeaponCapability.builder();
...
    builder.comboCancel(style -> false) // this completely turns off combo counter being reset when any action animation is played
...
```

Alternatively, the new API hands over various parameters that developers can use to handle the combo counter.
```java
WeaponCapability.Builder builder = WeaponCapability.builder();
...
    builder.comboCounterHandler((itemCapability, causal, entitypatch, nextAnimation, comboCounter) -> {
        // When causal is time expiration, reset the counter
        if (causal == ComboCounterHandleEvent.Causal.TIME_EXPIRED) {
            return 0;
        }
        
        List<AnimationAccessor<? extends AttackAnimation>> comboAnimations = itemCapability.getAutoAttackMotion(entitypatch);
        
        if (comboAnimations == null) {
            return 0;
        }
        
        Set<AnimationAccessor<? extends AttackAnimation>> attackMotionSet = Sets.newHashSet(comboAnimations);
        
        // when the next animation is not included in weapon attack motion, reset the counter
        if (!attackMotionSet.contains(nextAnimation)) {
            return 0;
        }
        
        int comboSize = comboAnimations.size();
        
        // When the next animation is dash or air attacks, reset combo counter
        if (nextAnimation.equals(comboAnimations.get(comboSize - 1)) || nextAnimation.equals(comboAnimations.get(comboSize - 2))) {
            return 0;
        }
        
        return comboCounter;
    })
...
```
By returning the modified combo counter, addons can select any combo animation in the sequence. This will open unlimited control of Basic Attack's combo counter.

### Fix for attack delaying when playing same animation from previous
This is a very simple fix, but the result was quite destructive so I leave the fix here.

Basic Attack uses an animation variable system where you can assign variables for specific animations. There is no problem in playing different animations sequentially, but it becomes a serious issue when playing the same one.

https://github.com/user-attachments/assets/7eef6863-0f09-4cfb-babf-563e6dc77dad

*note that I'm spamming attack key*

There is a significant delay until the next attack. This is more noticeable with animations that have longer recovery times especially heavy weapons in WoM. It was because of an unlogged exception, which never should be happened. You could see the exception by manually wrapping `try - catch`.

```
java.lang.UnsupportedOperationException: Can't modify a const variable
	at TRANSFORMER/epicfight@20.14.4/yesman.epicfight.api.animation.AnimationVariables.lambda$2(AnimationVariables.java:116)
	at java.base/java.util.HashMap.computeIfPresent(HashMap.java:1261)
	at TRANSFORMER/epicfight@20.14.4/yesman.epicfight.api.animation.AnimationVariables.put(AnimationVariables.java:112)
	at TRANSFORMER/epicfight@20.14.4/yesman.epicfight.api.animation.AnimationVariables.put(AnimationVariables.java:102)
...
```

This means you're trying to use an immutable animation variable because it detects the same variable key when the previous and next animations are the same.

The solution is swapping animation playing code and putting variable.

```diff
- executor.getAnimator().getVariables().put(COMBO, attackMotion, true);
- executor.getAnimator().playAnimation(attackMotion, 0.0F);
+ executor.getAnimator().playAnimation(attackMotion, 0.0F);
+ executor.getAnimator().getVariables().put(COMBO, attackMotion, true);
```

*Result:*


https://github.com/user-attachments/assets/3b60bfdd-c692-41ab-beb6-894219f4be08

You now see no delay between dash attacks.

(Additionally, I more like the bugged behavior, at least for spear😅 But I needed to correct misdesigned system)