### PR TITLE
Epic fight Docs API tweaks

### DIFF
--- a/docs/universal-docs/.nav.yml
+++ b/docs/universal-docs/.nav.yml
@@ -1,7 +1,8 @@
 title: API
 nav:
     - Getting started: Starting.md
-    - Utilities: API/Utilities.md
-    - Migration: API/Migration.md
-    - Input: API/Input.md
+    - Utilities: Utilities.md
+    - Migration: Migration.md
+    - Input: Input.md
+
     - "*"

--- a/docs/universal-docs/Entity-model.en.md
+++ b/docs/universal-docs/Entity-model.en.md
@@ -10,4 +10,3 @@ This document is a WIP that explains how the player and other entity models work
 ## References
 
 * [Nvidia Mesh Skinning](https://developer.download.nvidia.com/assets/gamedev/docs/skinning.pdf)
-* 

--- a/docs/universal-docs/Porting-from-1.20.1-to-1.21.1.en.md
+++ b/docs/universal-docs/Porting-from-1.20.1-to-1.21.1.en.md
@@ -1,4 +1,5 @@
 ---
+icon: material/vector-line
 hide:
   - announcement
 ---


### PR DESCRIPTION
# Changes
This PR basically fixes the links referenced inside the navigation configurator, fixing the duplicated nav references on the wiki. 

I've also went ahead and renamed ``Entity-model.md`` to ``Entity-model.en.md`` as to indicate the language being used on the file.

Finally, the last tweak this PR adds is the addition of the icon for the ``porting-from-1.20.1-to-1.21.1.en.md`` document & the capitalization of the file name from ``porting-from-1.20.1-to-1.21.1.en.md`` to ``Porting-from-1.20.1-to-1.21.1.en.md``. Epic Fight Docs built-in icon library can be searched [here](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/)
<img width="794" height="394" alt="image" src="https://github.com/user-attachments/assets/6d628d57-4c3e-4435-b9c9-85893406ebe9" />
