### PR TITLE
[1.21.1] API Change: Call BuildCameraTransform.Post in TPS mode.

### DIFF
--- a/neoforge/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/client/camera/EpicFightCameraAPI.java
@@ -883,6 +883,7 @@ public final class EpicFightCameraAPI {
             }
 
             buildCameraEventPre.setVanillaCameraSetupCanceled(true);
+            this.fireCameraBuildPost(camera, partialTick);
 
             return buildCameraEventPre;
         } else if (this.lockingOnTarget && this.focusingEntity != null) {
@@ -906,6 +907,7 @@ public final class EpicFightCameraAPI {
                 }
 
                 buildCameraEventPre.setVanillaCameraSetupCanceled(true);
+                this.fireCameraBuildPost(camera, partialTick);
 
                 return buildCameraEventPre;
             } else if (this.minecraft.options.getCameraType() == CameraType.FIRST_PERSON) {

--- a/neoforge/src/main/java/yesman/epicfight/api/client/event/types/camera/BuildCameraTransform.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/client/event/types/camera/BuildCameraTransform.java
@@ -44,6 +44,8 @@ public abstract class BuildCameraTransform extends CameraAPIEvent {
         }
     }
 
+    /// This replaces [net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles] event in NeoForge, allowing
+    /// developers to modify local rotation of the camera
     public static final class Post extends BuildCameraTransform {
         public Post(EpicFightCameraAPI cameraApi, Camera camera, float partialTick) {
             super(cameraApi, camera, partialTick);


### PR DESCRIPTION
The current camera event system doesn't allow modifying camera roll, pitch, yaw in TPS mode because the logic cancel the behind process of firing `CameraBuild.Post`. This means you can only modify vanilla camera transform, not in TPS mode or Lock-on state.

This PR simply calls `fireCameraBuildPost` before returning the event object so developers can subscribe `CameraBuild.Post` in TPS mode too. Tho I need to check the regression of existing compat modules, like SSR or Controlify.