### PR TITLE
[1.20.1] Revive `doVanillaAttack` game rule

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -13,6 +13,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.level.block.state.BlockState;
@@ -23,6 +24,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.event.InputEvent.InteractionKeyMappingTriggered;
 import net.minecraftforge.client.event.MovementInputUpdateEvent;
+import net.minecraftforge.entity.PartEntity;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -1009,24 +1011,39 @@ public class ControlEngine {
 				}
 			}
 			
+			LocalPlayerPatch playerpatch = EpicFightCapabilities.getEntityPatch(controlEngine.minecraft.player, LocalPlayerPatch.class);
+			
+			if (playerpatch == null) {
+				return;
+			}
+			
+			if (playerpatch.isVanillaMode() && triggeredAction == MinecraftInputAction.ATTACK_DESTROY) {
+				// Blocks vanilla attacks against living entities
+				if (
+					!EpicFightGameRules.ALLOW_VANILLA_MELEE.getRuleValue(playerpatch.getOriginal().level()) &&
+					controlEngine.minecraft.hitResult instanceof EntityHitResult entityHitResult &&
+					(entityHitResult.getEntity() instanceof LivingEntity || entityHitResult.getEntity() instanceof PartEntity)
+				) {
+					event.setSwingHand(false);
+					event.setCanceled(true);
+				}
+			}
+			
 			if (
                 triggeredAction == MinecraftInputAction.USE &&
                 InputManager.isBoundToSamePhysicalInput(MinecraftInputAction.USE, EpicFightInputAction.GUARD)
 			) {
 				MutableBoolean canGuard = new MutableBoolean(false);
 				MutableBoolean vanillaMode = new MutableBoolean(false);
+				SkillContainer skillcontainer = playerpatch.getSkill(SkillSlots.GUARD);
 				
-				EpicFightCapabilities.getUnparameterizedEntityPatch(controlEngine.minecraft.player, LocalPlayerPatch.class).ifPresent(playerpatch -> {
-					SkillContainer skillcontainer = playerpatch.getSkill(SkillSlots.GUARD);
-					
-					if (playerpatch.getPlayerMode() == PlayerPatch.PlayerMode.VANILLA) {
-						vanillaMode.setTrue();
-					}
-					
-					if (skillcontainer.getSkill() != null && skillcontainer.getSkill().canExecute(skillcontainer)) {
-						canGuard.setValue(true);
-					}
-				});
+				if (playerpatch.getPlayerMode() == PlayerPatch.PlayerMode.VANILLA) {
+					vanillaMode.setTrue();
+				}
+				
+				if (skillcontainer.getSkill() != null && skillcontainer.getSkill().canExecute(skillcontainer)) {
+					canGuard.setValue(true);
+				}
 				
 				if (!vanillaMode.getValue()) {
 					if (controlEngine.minecraft.hitResult.getType() == HitResult.Type.MISS) {

--- a/src/main/java/yesman/epicfight/world/gamerule/EpicFightGameRules.java
+++ b/src/main/java/yesman/epicfight/world/gamerule/EpicFightGameRules.java
@@ -105,6 +105,14 @@ public class EpicFightGameRules {
 			, true
 	);
 	
+	public static final ConfigurableGameRule<Boolean, ForgeConfigSpec.BooleanValue, GameRules.BooleanValue> ALLOW_VANILLA_MELEE = EpicFightGameRules.create(
+			  "allowVanillaMelee"
+			, GameRules.Category.PLAYER
+			, configBuilder -> configBuilder.define("default_gamerule.allow_vanilla_melee", true)
+			, RuleType.BOOLEAN
+			, true
+	);
+	
 	public static final Map<String, ConfigurableGameRule<?, ?, ?>> GAME_RULES = ImmutableMap.<String, ConfigurableGameRule<?, ?, ?>>builder()
 			.put("globalStun", GLOBAL_STUN)
 			.put("keepSkills", KEEP_SKILLS)
@@ -117,6 +125,7 @@ public class EpicFightGameRules {
 			.put("weightPenalty", WEIGHT_PENALTY)
 			.put("epicDrop", EPIC_DROP)
 			.put("skillReplaceCooldown", SKILL_REPLACE_COOLDOWN)
+			.put("allowVanillaMelee", ALLOW_VANILLA_MELEE)
 			.build();
 	
 	public static void registerGameRules() {

--- a/src/main/resources/assets/epicfight/lang/en_us.json
+++ b/src/main/resources/assets/epicfight/lang/en_us.json
@@ -163,7 +163,7 @@
 	"gameMode.epicfight.vanilla": "Vanilla",
 	"gameMode.epicfight.epicfight": "EpicFight",
 
-	"gamerule.doVanillaAttack": "Enable vanilla attack",
+	"gamerule.allowVanillaMelee": "Enable Vanilla Melee Attacks",
 	"gamerule.hasFallAnimation": "Enable landing animation",
 	"gamerule.keepSkills": "Keep skills after death",
 	"gamerule.weightPenalty": "Weight Penalty applied to Attack Speed.",


### PR DESCRIPTION
Simply revived `doVanillaAttack` game rule with a new name by the request from #2403

The game rule was originally removed due to merging the combat & mining modes but the change was rolled back.