### PR TITLE
[1.20.1] Added Eviscerate damage cap

### DIFF
--- a/src/main/java/yesman/epicfight/skill/weaponinnate/EviscerateSkill.java
+++ b/src/main/java/yesman/epicfight/skill/weaponinnate/EviscerateSkill.java
@@ -3,6 +3,7 @@ package yesman.epicfight.skill.weaponinnate;
 import java.util.List;
 import java.util.UUID;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
@@ -21,11 +22,20 @@ public class EviscerateSkill extends WeaponInnateSkill {
 	private AssetAccessor<? extends AttackAnimation> first;
 	private AssetAccessor<? extends AttackAnimation> second;
 	
+	private float damageCap;
+	
 	public EviscerateSkill(SkillBuilder<? extends WeaponInnateSkill> builder) {
 		super(builder);
 		
 		this.first = Animations.EVISCERATE_FIRST;
 		this.second = Animations.EVISCERATE_SECOND;
+	}
+	
+	@Override
+	public void setParams(CompoundTag parameters) {
+		super.setParams(parameters);
+		
+		this.damageCap = parameters.getFloat("damage_cap");
 	}
 	
 	@Override
@@ -70,5 +80,11 @@ public class EviscerateSkill extends WeaponInnateSkill {
 		this.second.get().phases[0].addProperties(this.properties.get(1).entrySet());
 		
 		return this;
+	}
+	
+	/// TODO: bad implementation but to avoid breaking changes
+	/// make [ExtraDamageInstance] configurable via skill parameters
+	public float getDamageCap() {
+		return this.damageCap;
 	}
 }

--- a/src/main/java/yesman/epicfight/world/damagesource/ExtraDamageInstance.java
+++ b/src/main/java/yesman/epicfight/world/damagesource/ExtraDamageInstance.java
@@ -20,8 +20,6 @@ public class ExtraDamageInstance {
 				tier += tieredItem.getTier().getLevel();
 			}
 			
-			System.out.println(((EviscerateSkill)EpicFightSkills.EVISCERATE).getDamageCap() +" "+ (target.getMaxHealth() - target.getHealth()) * (params[0] + 0.05F * tier));
-			
 			// Bad implementation: add parameter to ExtraDamageFunction to accept skill parameters
 			return Math.min((target.getMaxHealth() - target.getHealth()) * (params[0] + 0.05F * tier), ((EviscerateSkill)EpicFightSkills.EVISCERATE).getDamageCap());
 		},

--- a/src/main/java/yesman/epicfight/world/damagesource/ExtraDamageInstance.java
+++ b/src/main/java/yesman/epicfight/world/damagesource/ExtraDamageInstance.java
@@ -7,6 +7,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TieredItem;
 import net.minecraft.world.item.enchantment.Enchantments;
+import yesman.epicfight.gameasset.EpicFightSkills;
+import yesman.epicfight.skill.weaponinnate.EviscerateSkill;
 
 public class ExtraDamageInstance {
 	@SuppressWarnings("deprecation")
@@ -17,8 +19,11 @@ public class ExtraDamageInstance {
 			if (itemstack.getItem() instanceof TieredItem tieredItem) {
 				tier += tieredItem.getTier().getLevel();
 			}
-		
-			return (target.getMaxHealth() - target.getHealth()) * (params[0] + 0.05F * tier);
+			
+			System.out.println(((EviscerateSkill)EpicFightSkills.EVISCERATE).getDamageCap() +" "+ (target.getMaxHealth() - target.getHealth()) * (params[0] + 0.05F * tier));
+			
+			// Bad implementation: add parameter to ExtraDamageFunction to accept skill parameters
+			return Math.min((target.getMaxHealth() - target.getHealth()) * (params[0] + 0.05F * tier), ((EviscerateSkill)EpicFightSkills.EVISCERATE).getDamageCap());
 		},
 		(itemstack, tooltips, baseDamage, params) -> {
 			int tier = 0;

--- a/src/main/resources/data/epicfight/skill_parameters/eviscerate.json
+++ b/src/main/resources/data/epicfight/skill_parameters/eviscerate.json
@@ -1,3 +1,4 @@
 {
-	"consumption": 25.0
+	"consumption": 25.0,
+	"damage_cap": 20.0
 }


### PR DESCRIPTION
Suggested by #2364

Applied a damage cap to the Eviscerate skill so it doesn't inflict massive damage against bosses with high health.

(Note the implementation is not good, but no breaking changes)