### PR TITLE
[1.20.1] Fixed inconsistent "onFall" event call, causing phantom ascent unusable again

### DIFF
--- a/src/main/java/yesman/epicfight/events/EntityEvents.java
+++ b/src/main/java/yesman/epicfight/events/EntityEvents.java
@@ -36,12 +36,10 @@ import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
-import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.event.entity.living.MobEffectEvent;
 import net.minecraftforge.event.entity.living.ShieldBlockEvent;
-import net.minecraftforge.event.entity.player.PlayerFlyableFallEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import yesman.epicfight.api.animation.LivingMotions;
@@ -526,20 +524,6 @@ public class EntityEvents {
 					entitypatch.playAnimationInClientSide(jumpAnimation, 0.0F);
 				}
 			}
-		});
-	}
-
-	@SubscribeEvent
-	public static void fallEvent(LivingFallEvent event) {
-		EpicFightCapabilities.getUnparameterizedEntityPatch(event.getEntity(), LivingEntityPatch.class).ifPresent(entitypatch -> {
-			entitypatch.onFall(event);
-		});
-	}
-	
-	@SubscribeEvent
-	public static void playerFallEvent(PlayerFlyableFallEvent event) {
-		EpicFightCapabilities.getPlayerPatchAsOptional(event.getEntity()).ifPresent(entitypatch -> {
-			entitypatch.onFall(new LivingFallEvent(event.getEntity(), event.getDistance(), event.getMultiplier()));
 		});
 	}
 }

--- a/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
+++ b/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
@@ -108,7 +108,7 @@ public abstract class MixinEntity {
 		
 		if (!onGround && pOnGround) { // When a player touches a ground from air.
 			if (self.tickCount - lastOnGroundTick >= 4) { // 4 ticks are noise guard for floating point calculation error
-				EpicFightCapabilities.<LivingEntity, LivingEntityPatch<LivingEntity>>getParameterizedEntityPatch((LivingEntity)(Object)this, LivingEntity.class, LivingEntityPatch.class).ifPresent(entitypatch -> {
+				EpicFightCapabilities.<LivingEntity, LivingEntityPatch<LivingEntity>>getParameterizedEntityPatch(self, LivingEntity.class, LivingEntityPatch.class).ifPresent(entitypatch -> {
 					entitypatch.onFall(new LivingFallEvent(entitypatch.getOriginal(), entitypatch.getOriginal().fallDistance, 1.0F));
 				});
 			}

--- a/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
+++ b/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
@@ -1,12 +1,17 @@
 package yesman.epicfight.mixin.common;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.entity.living.LivingFallEvent;
 import yesman.epicfight.api.animation.property.AnimationProperty.ActionAnimationProperty;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.EntityPatch;
@@ -15,6 +20,25 @@ import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
 
 @Mixin(value = Entity.class)
 public abstract class MixinEntity {
+	@Shadow
+	private boolean onGround;
+	
+	/**
+	 * Stores when {@link #onGround} was lastly true
+	 * 
+	 * 'onGround' has a noise data while ticking, that it judges the entity is not on a ground
+	 * due to floating point errors. So the raw data is unreliable. Thankfully, I found
+	 * the "not-on-ground" noise wouldn't persist for 2 or even a tick so I could apply a guard ticks
+	 * to distinguish the value is caused by actual player jumps or the noise.
+	 * 
+	 * Normally, when a player jumps, the variable becomes false and persists for around 5-6 ticks.
+	 * I thought the reasonable compromise was 4 ticks. In internal tests, it worked as intended
+	 * but we need to gather more exclusive cases, or wait until Minecraft provides reliable
+	 * access when player touches a around after jumping
+	 */
+	@Unique
+	private int lastOnGroundTick;
+	
 	@Inject(at = @At(value = "HEAD"), method = "setOldPosAndRot()V", cancellable = true)
 	private void epicfight_setOldPosAndRot(CallbackInfo callbackInfo) {
 		Entity self = (Entity)((Object)this);
@@ -69,6 +93,26 @@ public abstract class MixinEntity {
 		}
 		
 		return xRot;
+	}
+	
+	/**
+	 * Called when setting {@link Entity#onGround} according to the player's movement
+	 * 
+	 * the onGround variable is synced from a server to a client. {@link ServerGamePacketListenerImpl#handleMovePlayer}
+	 */
+	@Inject(at = @At(value = "HEAD"), method = "setOnGroundWithKnownMovement(ZLnet/minecraft/world/phys/Vec3;)V")
+	public void epicfight$setOnGroundWithKnownMovement(boolean pOnGround, Vec3 pMovement, CallbackInfo callbackInfo) {
+		Entity self = (Entity)(Object)this;
+		
+		if (onGround) lastOnGroundTick = self.tickCount;
+		
+		if (!onGround && pOnGround) { // When a player touches a ground from air.
+			if (self.tickCount - lastOnGroundTick >= 4) { // 4 ticks are noise guard for floating point calculation error
+				EpicFightCapabilities.<LivingEntity, LivingEntityPatch<LivingEntity>>getParameterizedEntityPatch((LivingEntity)(Object)this, LivingEntity.class, LivingEntityPatch.class).ifPresent(entitypatch -> {
+					entitypatch.onFall(new LivingFallEvent(entitypatch.getOriginal(), entitypatch.getOriginal().fallDistance, 1.0F));
+				});
+			}
+		}
 	}
 	
 	/**

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/LivingEntityPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/LivingEntityPatch.java
@@ -247,6 +247,11 @@ public abstract class LivingEntityPatch<T extends LivingEntity> extends Hurtable
 		}
 	}
 	
+	/**
+	 * This method is not triggered by forge event hook since it has the problem that it's only triggered when an entity gets hurt
+	 * Due to the reasons mentioned above, {@link LivingFallEvent#getDamageMultiplier()} always returns 1.0F. @param event should
+	 * have been unboxed but left as is for the backward compatibility
+	 */
 	public void onFall(LivingFallEvent event) {
 		if (!this.getOriginal().level().isClientSide() && this.isAirborneState()) {
 			AssetAccessor<? extends StaticAnimation> fallAnimation = this.getAnimator().getLivingAnimation(LivingMotions.LANDING_RECOVERY, this.getHitAnimation(StunType.FALL));


### PR DESCRIPTION
Currently, `LivingEntityPatch#onFall` relies on event hooks provided by Forge, but these events are only called when players **get hurt** by fall damage. This concept clashes with the design of Phantom Ascent, a mover skill that allows double jumping, which should reset the jump count when a player touches the ground, regardless of whether it gets damaged.

https://github.com/user-attachments/assets/00d20bd0-9615-4289-aa87-aad471fad2f4

When I put the output message to `onFall` event, it prints nothing.

<img width="594" height="131" alt="image" src="https://github.com/user-attachments/assets/a93a0ff0-bb31-4627-8db2-e16686dc03a6" />

<img width="353" height="210" alt="onfall message insert" src="https://github.com/user-attachments/assets/b64864ea-af91-4f29-b086-f4c3f2f0bfd1" />

<img width="93" height="187" alt="debug_output" src="https://github.com/user-attachments/assets/0e4cf540-28f1-4fee-a981-5c9711980148" />

So I searched for another hook that provides a reliable timing when a player touches ground, and I decided to mixin `Entity#setOnGroundWithKnownMovement` that is being called to set `Entity#onGround` field both in server and client.

Some tricks are applied to resolve the issue that Minecraft's API has in `MixinEntity`

**Demonstration**

https://github.com/user-attachments/assets/cb6dcdeb-38ec-4d26-9b4c-fcaac372ab07

<img width="176" height="235" alt="debug_output_fixed" src="https://github.com/user-attachments/assets/ddfd7356-1b90-4174-a833-917f6f34ce89" />

_The debug message now printed out properly_

Sadly, I wasn't able to reproduce the issue specified in #2421 (where you can't trigger phantom ascent again until you get hurt again), so I need to wait for the reporter's reply.