### PR TITLE
[1.20.1] Avoided using global key state setters to prevent other mods' keybinds from being ignored

### DIFF
--- a/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
+++ b/src/main/java/yesman/epicfight/client/events/engine/ControlEngine.java
@@ -1,7 +1,16 @@
 package yesman.epicfight.client.events.engine;
 
+import java.util.Set;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.glfw.GLFW;
+
 import com.google.common.collect.Sets;
 import com.mojang.blaze3d.platform.InputConstants;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
@@ -29,11 +38,6 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 import yesman.epicfight.api.animation.types.EntityState;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.api.client.input.InputManager;
@@ -62,8 +66,6 @@ import yesman.epicfight.world.entity.eventlistener.MovementInputEvent;
 import yesman.epicfight.world.entity.eventlistener.PlayerEventListener.EventType;
 import yesman.epicfight.world.entity.eventlistener.SkillCastEvent;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
-
-import java.util.Set;
 
 public class ControlEngine {
 	private final Set<Object> packets = Sets.newHashSet();
@@ -671,7 +673,8 @@ public class ControlEngine {
     public static void makeUnpressed(KeyMapping keyMapping) {
         while (keyMapping.consumeClick()) {
         }
-        KeyMapping.set(keyMapping.getKey(), false);
+        
+        keyMapping.setDown(false);
     }
 
     /**
@@ -687,7 +690,7 @@ public class ControlEngine {
     @SuppressWarnings("JavadocReference")
     @Deprecated(forRemoval = true)
     public static void setKeyBind(KeyMapping key, boolean setter) {
-        KeyMapping.set(key.getKey(), setter);
+    	key.setDown(setter);
     }
 
     /**
@@ -703,7 +706,7 @@ public class ControlEngine {
      */
     @SuppressWarnings("JavadocReference")
     public static void setSprintingKeyStateNotDown() {
-        KeyMapping.set(MinecraftInputAction.SPRINT.keyMapping().getKey(), false);
+    	MinecraftInputAction.SPRINT.keyMapping().setDown(false);
     }
 
     /**


### PR DESCRIPTION
Reported by @supermerlin204. When Epic Fight and TaCZ are installed, players can't full-auto shoot when the epic fight's attack key is set to `LMB`.

[When Epic Fight attack key is set to `LMB`]

https://github.com/user-attachments/assets/53c91f02-beb7-409a-a9a3-378736a7e795

[When Epic Fight attack key is set to anything else]

https://github.com/user-attachments/assets/40003c1c-2d86-4a77-9191-10f51078a1a1

I found it was coming from Epic Fight's `ControlEngine` sets all key mappings unpressed by an input key. These three methods are a result of an old decision.

```java
public static void makeUnpressed(KeyMapping keyMapping) {
    while (keyMapping.consumeClick()) {
    }
    KeyMapping.set(keyMapping.getKey(), false);
}

public static void setKeyBind(KeyMapping key, boolean setter) {
    KeyMapping.set(key.getKey(), setter);
}

public static void setSprintingKeyStateNotDown() {
    KeyMapping.set(MinecraftInputAction.SPRINT.keyMapping().getKey(), false);
}
```

`KeyMapping.set` will disable **ALL** keybinds that have the same input ID. This led to disabling TaCZ's shooting key and stopping
the firings in the first shot. My previous decision was to disable the vanilla attack/destroy key in combat mode without considering compatibility, but it's now managed by `InteractionKeyMappingTriggered`.

This is a simple but significant change for API, so I leave it as a PR. I tested against these actions, but we still need to care about regressions from this change.

- Input blocking for hotbar switching keys while attacking
- Input blocking for swapping main and offhand items while attacking
- Input blocking for vanilla attacks in combat mode
- Input blocking for dropping items while attacking
- Disabling player sprints while guarding, charging, and activating Liechtenauer(longsword weapon ability)