### PR TITLE
Added Collider scaling based on InteractionRange Attribute

### DIFF
--- a/neoforge/src/main/java/yesman/epicfight/api/animation/types/AttackAnimation.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/animation/types/AttackAnimation.java
@@ -29,6 +29,7 @@ import yesman.epicfight.api.animation.property.MoveCoordFunctions;
 import yesman.epicfight.api.animation.types.EntityState.StateFactor;
 import yesman.epicfight.api.asset.AssetAccessor;
 import yesman.epicfight.api.collider.Collider;
+import yesman.epicfight.api.collider.WeaponReachHitboxUtil;
 import yesman.epicfight.api.event.EpicFightEventHooks;
 import yesman.epicfight.api.event.types.animation.AttackPhaseEndEvent;
 import yesman.epicfight.api.model.Armature;
@@ -424,6 +425,7 @@ public class AttackAnimation extends ActionAnimation {
 				collider = entitypatch.getColliderMatching(phase.hand);
 			}
 			
+			collider = WeaponReachHitboxUtil.copyColliderWithWeaponReach(entitypatch, phase.hand, collider);
 			collider.draw(poseStack, buffer, entitypatch, this, colliderInfo.getFirst(), prevElapsedTime, elapsedTime, partialTicks, this.getPlaySpeed(entitypatch, this));
 		}
 	}
@@ -529,6 +531,7 @@ public class AttackAnimation extends ActionAnimation {
 					collider = entitypatch.getColliderMatching(this.hand);
 				}
 				
+				collider = WeaponReachHitboxUtil.copyColliderWithWeaponReach(entitypatch, this.hand, collider);
 				entities.addAll(collider.updateAndSelectCollideEntity(entitypatch, animation, prevElapsedTime, elapsedTime, colliderInfo.getFirst(), attackSpeed));
 			}
 			

--- a/neoforge/src/main/java/yesman/epicfight/api/collider/MultiOBBCollider.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/collider/MultiOBBCollider.java
@@ -37,7 +37,27 @@ public class MultiOBBCollider extends MultiCollider<OBBCollider> {
 	public MultiOBBCollider(OBBCollider... colliders) {
 		super(colliders);
 	}
-	
+
+	@Override
+	public MultiOBBCollider deepCopy() {
+		OBBCollider[] copies = new OBBCollider[this.colliders.size()];
+		for (int i = 0; i < copies.length; i++) {
+			copies[i] = this.colliders.get(i).deepCopy();
+		}
+		return new MultiOBBCollider(copies);
+	}
+
+	public MultiOBBCollider withSymmetricLocalZExtension(double deltaLength) {
+		if (deltaLength <= 0.0D) {
+			return this.deepCopy();
+		}
+		OBBCollider[] resized = new OBBCollider[this.colliders.size()];
+		for (int i = 0; i < resized.length; i++) {
+			resized[i] = this.colliders.get(i).withSymmetricLocalZExtension(deltaLength);
+		}
+		return new MultiOBBCollider(resized);
+	}
+
 	@Override @ClientOnly
 	public void draw(PoseStack poseStack, MultiBufferSource buffer, LivingEntityPatch<?> entitypatch, AttackAnimation animation, Joint joint, float prevElapsedTime, float elapsedTime, float partialTicks, float attackSpeed) {
 		int colliderCount = Math.max(Math.round((this.numberOfColliders + animation.getProperty(AttackAnimationProperty.EXTRA_COLLIDERS).orElse(0)) * attackSpeed), this.numberOfColliders);

--- a/neoforge/src/main/java/yesman/epicfight/api/collider/OBBCollider.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/collider/OBBCollider.java
@@ -199,6 +199,15 @@ public class OBBCollider extends Collider {
 		Vec3 xyzVec = this.modelVertices[1];
 		return new OBBCollider(xyzVec.x, xyzVec.y, xyzVec.z, this.modelCenter.x, this.modelCenter.y, this.modelCenter.z);
 	}
+
+	public OBBCollider withSymmetricLocalZExtension(double deltaLength) {
+		if (deltaLength <= 0.0D || this.modelVertices == null || this.modelVertices.length != 4) {
+			return this.deepCopy();
+		}
+		double halfDelta = deltaLength * 0.5D;
+		Vec3 v = this.modelVertices[1];
+		return new OBBCollider(v.x, v.y, v.z + halfDelta, this.modelCenter.x, this.modelCenter.y, this.modelCenter.z);
+	}
 	
 	private static boolean checkSeparateAxisOverlap(Vec3 seperateAxis, Vec3 toOpponent, OBBCollider box1, OBBCollider box2) {
 		Vec3 maxProj1 = null, maxProj2 = null;//, distance;

--- a/neoforge/src/main/java/yesman/epicfight/api/collider/WeaponReachHitboxUtil.java
+++ b/neoforge/src/main/java/yesman/epicfight/api/collider/WeaponReachHitboxUtil.java
@@ -1,0 +1,63 @@
+package yesman.epicfight.api.collider;
+
+import net.minecraft.core.Holder;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import yesman.epicfight.EpicFight;
+import yesman.epicfight.config.CommonConfig;
+import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
+
+public final class WeaponReachHitboxUtil {
+	public static float getInteractionRangeBonusOverEntityBase(LivingEntityPatch<?> entitypatch) {
+		final boolean dbg = EpicFight.LOGGER.isDebugEnabled();
+		Holder<Attribute> reachHolder = Attributes.ENTITY_INTERACTION_RANGE;
+		var entity = entitypatch.getOriginal();
+		if (!entity.getAttributes().hasAttribute(reachHolder)) {
+			return 0.0F;
+		}
+		AttributeInstance inst = entity.getAttribute(reachHolder);
+		if (inst == null) {
+			if (dbg) {
+				EpicFight.LOGGER.debug("[ReachHitbox] ENTITY_INTERACTION_RANGE instance null -> bonus 0");
+			}
+			return 0.0F;
+		}
+		double base = inst.getBaseValue();
+		double current = inst.getValue();
+		float bonus = (float) (current - base);
+		float clamped = Mth.clamp(bonus, 0.0F, (float) CommonConfig.reachHitboxMaxBonus);
+		if (dbg) {
+			EpicFight.LOGGER.debug(
+				"[ReachHitbox] entity={} reach base={} current={} bonusRaw={} bonusClamped={}",
+				entity,
+				base,
+				current,
+				bonus,
+				clamped
+			);
+		}
+		return clamped;
+	}
+
+	public static Collider copyColliderWithWeaponReach(LivingEntityPatch<?> entitypatch, InteractionHand hand, Collider source) {
+		Collider copy = source.deepCopy();
+		if (copy == null) {
+			return source;
+		}
+		float bonus = getInteractionRangeBonusOverEntityBase(entitypatch);
+		if (bonus <= 0.0F) {
+			return copy;
+		}
+		double deltaLength = bonus * CommonConfig.reachHitboxBonusToColliderScale;
+		if (copy instanceof OBBCollider obb) {
+			return obb.withSymmetricLocalZExtension(deltaLength);
+		}
+		if (copy instanceof MultiOBBCollider multi) {
+			return multi.withSymmetricLocalZExtension(deltaLength);
+		}
+		return copy;
+	}
+}

--- a/neoforge/src/main/java/yesman/epicfight/config/CommonConfig.java
+++ b/neoforge/src/main/java/yesman/epicfight/config/CommonConfig.java
@@ -13,10 +13,23 @@ public class CommonConfig {
 	private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 	public static final ModConfigSpec.IntValue SKILL_BOOK_MOB_DROP_CHANCE_MODIFIER = BUILDER.defineInRange("loot.skill_book_mob_drop_chance_modifier", 0, -100, 100);
 	public static final ModConfigSpec.IntValue SKILL_BOOK_CHEST_LOOT_MODIFIER = BUILDER.defineInRange("loot.skill_book_chest_drop_chance_modifier", 0, -100, 100);
+
+	public static final ModConfigSpec.DoubleValue REACH_HITBOX_BONUS_SCALE = BUILDER
+		.comment(
+			"Multiplier that determines how much your extra reach buffs affect the swing distance of Epic Fight weapons"
+		)
+		.defineInRange("reach.bonus", 0.5D, 0.0D, 10.0D);
+
+	public static final ModConfigSpec.DoubleValue REACH_HITBOX_MAX_BONUS = BUILDER
+		.defineInRange("reach.max_bonus", 8.0D, 0.0D, 128.0D);
+
 	public static final ModConfigSpec SPEC;
 	
 	public static int skillBookMobDropChanceModifier;
 	public static int skillBookChestLootModifier;
+
+	public static double reachHitboxBonusToColliderScale = 0.5D;
+	public static double reachHitboxMaxBonus = 8.0D;
 	
 	static {
 		EpicFightGameRules.GAME_RULES.values().forEach(configurableGameRule -> configurableGameRule.defineConfig(BUILDER));
@@ -31,5 +44,7 @@ public class CommonConfig {
 		
 		skillBookMobDropChanceModifier = SKILL_BOOK_MOB_DROP_CHANCE_MODIFIER.get();
 		skillBookChestLootModifier = SKILL_BOOK_CHEST_LOOT_MODIFIER.get();
+		reachHitboxBonusToColliderScale = REACH_HITBOX_BONUS_SCALE.get();
+		reachHitboxMaxBonus = REACH_HITBOX_MAX_BONUS.get();
 	}
 }


### PR DESCRIPTION
This PR aims to add weapon collider scaling base on the ENTITY_INTERACTION_RANGE attribute, this would improve compatibility with mods providing a reach buff.
The scaling is calculated based on the base interaction range. 

Would resolve #2186 