### PR TITLE
[1.20.1] Added Custom Tag system to Weapon Capability

### DIFF
--- a/src/main/java/yesman/epicfight/api/data/reloader/ItemCapabilityReloadListener.java
+++ b/src/main/java/yesman/epicfight/api/data/reloader/ItemCapabilityReloadListener.java
@@ -42,6 +42,7 @@ import yesman.epicfight.world.capabilities.item.ArmorCapability;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.Style;
 import yesman.epicfight.world.capabilities.item.TagBasedSeparativeCapability;
+import yesman.epicfight.world.capabilities.item.WeaponCapability;
 import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 import yesman.epicfight.world.capabilities.provider.ExtraEntryProvider;
 import yesman.epicfight.world.capabilities.provider.ItemCapabilityProvider;
@@ -191,6 +192,12 @@ public class ItemCapabilityReloadListener extends SimpleJsonResourceReloadListen
 					EpicFightMod.LOGGER.warn("Can't deserialize collider of " + item + ": " + e.getMessage());
 				}
 			}
+			
+			if (builder instanceof WeaponCapability.Builder weaponBuilder && tag.contains("custom_tags")) {
+                for (Tag customTag : tag.getList("custom_tags", Tag.TAG_STRING)) {
+                    weaponBuilder.addTag(ResourceLocation.parse(customTag.getAsString()));
+                }
+            }
 			
 			capability = builder.build();
 		}

--- a/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/entitypatch/player/PlayerPatch.java
@@ -54,6 +54,7 @@ import yesman.epicfight.world.capabilities.entitypatch.Faction;
 import yesman.epicfight.world.capabilities.entitypatch.Factions;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
+import yesman.epicfight.world.capabilities.item.WeaponCapability;
 import yesman.epicfight.world.capabilities.skill.CapabilitySkill;
 import yesman.epicfight.world.damagesource.EpicFightDamageSource;
 import yesman.epicfight.world.damagesource.EpicFightDamageSources;
@@ -272,6 +273,8 @@ public abstract class PlayerPatch<T extends Player> extends LivingEntityPatch<T>
 		this.xo = this.original.getX();
 		this.yo = this.original.getY();
 		this.zo = this.original.getZ();
+		
+		if (this.getHoldingItemCapability(InteractionHand.MAIN_HAND) instanceof WeaponCapability weaponCapability) System.out.println(weaponCapability.getTags());
 	}
 	
 	/**

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
@@ -1,7 +1,10 @@
 package yesman.epicfight.world.capabilities.item;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -11,6 +14,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.mojang.datafixers.util.Pair;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -52,6 +56,11 @@ public class WeaponCapability extends CapabilityItem {
 	protected final ZoomInType zoomInType;
 	protected final float reach;
 	
+	/// A custom capability tag that ease identifying categories
+    ///
+    /// Weapon capabilities have registry name of their weapon type builder
+    protected Set<ResourceLocation> customTags;
+	
 	protected WeaponCapability(CapabilityItem.Builder builder) {
 		super(builder);
 		
@@ -71,6 +80,7 @@ public class WeaponCapability extends CapabilityItem {
 		this.comboCounterHandler = weaponBuilder.comboCounterHandler;
 		this.zoomInType = weaponBuilder.zoomInType;
 		this.reach = weaponBuilder.reach;
+		this.customTags = Collections.unmodifiableSet(weaponBuilder.customTags);
 	}
 	
 	@Override
@@ -181,6 +191,14 @@ public class WeaponCapability extends CapabilityItem {
 		return this.reach;
 	}
 	
+	public boolean hasMatchingTag(ResourceLocation rl) {
+        return customTags.contains(rl);
+    }
+
+    public Set<ResourceLocation> getTags() {
+        return customTags;
+    }
+	
 	public static WeaponCapability.Builder builder() {
 		return new WeaponCapability.Builder();
 	}
@@ -200,6 +218,7 @@ public class WeaponCapability extends CapabilityItem {
 		boolean canBePlacedOffhand;
 		ZoomInType zoomInType;
 		float reach;
+		Set<ResourceLocation> customTags = new HashSet<> ();
 		
 		protected Builder() {
 			this.constructor = WeaponCapability::new;
@@ -264,6 +283,11 @@ public class WeaponCapability extends CapabilityItem {
 			this.reach = reach;
 			return this;
 		}
+		
+		public Builder addTag(ResourceLocation customTag) {
+            this.customTags.add(customTag);
+            return this;
+        }
 		
 		public Builder livingMotionModifier(Style wieldStyle, LivingMotion livingMotion, AnimationAccessor<? extends StaticAnimation> animation) {
 			if (AnimationManager.checkNull(animation)) {

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapabilityPresets.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapabilityPresets.java
@@ -13,6 +13,7 @@ import yesman.epicfight.gameasset.Animations;
 import yesman.epicfight.gameasset.ColliderPreset;
 import yesman.epicfight.gameasset.EpicFightSkills;
 import yesman.epicfight.gameasset.EpicFightSounds;
+import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.particle.EpicFightParticles;
 import yesman.epicfight.skill.SkillDataKeys;
 import yesman.epicfight.skill.SkillSlots;
@@ -33,7 +34,8 @@ public class WeaponCapabilityPresets {
 			.newStyleCombo(Styles.ONE_HAND, Animations.AXE_AUTO1, Animations.AXE_AUTO2, Animations.AXE_DASH, Animations.AXE_AIRSLASH)
 			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK)
 			.innateSkill(Styles.ONE_HAND, (itemstack) -> EpicFightSkills.GUILLOTINE_AXE)
-			.livingMotionModifier(Styles.ONE_HAND, LivingMotions.BLOCK, Animations.SWORD_GUARD);
+			.livingMotionModifier(Styles.ONE_HAND, LivingMotions.BLOCK, Animations.SWORD_GUARD)
+			.addTag(EpicFightMod.identifier("axe"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			int harvestLevel = tieredItem.getTier().getLevel();
@@ -53,7 +55,8 @@ public class WeaponCapabilityPresets {
 			.category(WeaponCategories.HOE)
 			.hitSound(EpicFightSounds.BLADE_HIT.get())
 			.collider(ColliderPreset.TOOLS).newStyleCombo(Styles.ONE_HAND, Animations.TOOL_AUTO1, Animations.TOOL_AUTO2, Animations.TOOL_DASH, Animations.SWORD_AIR_SLASH)
-			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK);
+			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK)
+			.addTag(EpicFightMod.identifier("hoe"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			int harvestLevel = tieredItem.getTier().getLevel();
@@ -69,7 +72,8 @@ public class WeaponCapabilityPresets {
 			.hitSound(EpicFightSounds.BLADE_HIT.get())
 			.collider(ColliderPreset.TOOLS)
 			.newStyleCombo(Styles.ONE_HAND, Animations.AXE_AUTO1, Animations.AXE_AUTO2, Animations.AXE_DASH, Animations.AXE_AIRSLASH)
-			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK);
+			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK)
+			.addTag(EpicFightMod.identifier("pickaxe"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			int harvestLevel = tieredItem.getTier().getLevel();
@@ -89,7 +93,8 @@ public class WeaponCapabilityPresets {
 			.category(WeaponCategories.SHOVEL)
 			.collider(ColliderPreset.TOOLS)
 			.newStyleCombo(Styles.ONE_HAND, Animations.AXE_AUTO1, Animations.AXE_AUTO2, Animations.AXE_DASH, Animations.AXE_AIRSLASH)
-			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK);
+			.newStyleCombo(Styles.MOUNT, Animations.SWORD_MOUNT_ATTACK)
+			.addTag(EpicFightMod.identifier("shovel"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			int harvestLevel = tieredItem.getTier().getLevel();
@@ -120,7 +125,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.SWIM, Animations.BIPED_HOLD_DUAL_WEAPON)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FLOAT, Animations.BIPED_HOLD_DUAL_WEAPON)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FALL, Animations.BIPED_HOLD_DUAL_WEAPON)
-			.weaponCombinationPredicator((entitypatch) -> EpicFightCapabilities.getItemStackCapability(entitypatch.getOriginal().getOffhandItem()).getWeaponCategory() == WeaponCategories.SWORD);
+			.weaponCombinationPredicator((entitypatch) -> EpicFightCapabilities.getItemStackCapability(entitypatch.getOriginal().getOffhandItem()).getWeaponCategory() == WeaponCategories.SWORD)
+			.addTag(EpicFightMod.identifier("sword"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -148,7 +154,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.CHASE, Animations.BIPED_WALK_SPEAR)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.RUN, Animations.BIPED_RUN_SPEAR)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.SWIM, Animations.BIPED_HOLD_SPEAR)
-			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.SPEAR_GUARD);
+			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.SPEAR_GUARD)
+			.addTag(EpicFightMod.identifier("spear"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -179,7 +186,8 @@ public class WeaponCapabilityPresets {
 	    	.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FLY, Animations.BIPED_HOLD_GREATSWORD)
 	    	.livingMotionModifier(Styles.TWO_HAND, LivingMotions.CREATIVE_FLY, Animations.BIPED_HOLD_GREATSWORD)
 	    	.livingMotionModifier(Styles.TWO_HAND, LivingMotions.CREATIVE_IDLE, Animations.BIPED_HOLD_GREATSWORD)
-	    	.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.GREATSWORD_GUARD);
+	    	.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.GREATSWORD_GUARD)
+	    	.addTag(EpicFightMod.identifier("greatsword"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -226,7 +234,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.SHEATH, LivingMotions.SWIM, Animations.BIPED_HOLD_UCHIGATANA_SHEATHING)
 			.livingMotionModifier(Styles.SHEATH, LivingMotions.FLOAT, Animations.BIPED_HOLD_UCHIGATANA_SHEATHING)
 			.livingMotionModifier(Styles.SHEATH, LivingMotions.FALL, Animations.BIPED_HOLD_UCHIGATANA_SHEATHING)
-			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.UCHIGATANA_GUARD);
+			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.UCHIGATANA_GUARD)
+			.addTag(EpicFightMod.identifier("uchigatana"));
 
 	public static final Function<Item, CapabilityItem.Builder> TACHI = (item) -> {
 		WeaponCapability.Builder builder = WeaponCapability.builder()
@@ -246,7 +255,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.SWIM, Animations.BIPED_HOLD_TACHI)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FLOAT, Animations.BIPED_HOLD_TACHI)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FALL, Animations.BIPED_HOLD_TACHI)
-			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.LONGSWORD_GUARD);
+			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.LONGSWORD_GUARD)
+			.addTag(EpicFightMod.identifier("tachi"));
 	
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -295,7 +305,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.OCHS, LivingMotions.SWIM, Animations.BIPED_HOLD_LIECHTENAUER)
 			.livingMotionModifier(Styles.ONE_HAND, LivingMotions.BLOCK, Animations.SWORD_GUARD)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.BLOCK, Animations.LONGSWORD_GUARD)
-			.livingMotionModifier(Styles.OCHS, LivingMotions.BLOCK, Animations.LONGSWORD_GUARD);
+			.livingMotionModifier(Styles.OCHS, LivingMotions.BLOCK, Animations.LONGSWORD_GUARD)
+			.addTag(EpicFightMod.identifier("longsword"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -325,7 +336,8 @@ public class WeaponCapabilityPresets {
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.SNEAK, Animations.BIPED_HOLD_DUAL_WEAPON)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.SWIM, Animations.BIPED_HOLD_DUAL_WEAPON)
 			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FLOAT, Animations.BIPED_HOLD_DUAL_WEAPON)
-			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FALL, Animations.BIPED_HOLD_DUAL_WEAPON);
+			.livingMotionModifier(Styles.TWO_HAND, LivingMotions.FALL, Animations.BIPED_HOLD_DUAL_WEAPON)
+			.addTag(EpicFightMod.identifier("dagger"));
 		
 		if (item instanceof TieredItem tieredItem) {
 			builder.hitSound(tieredItem.getTier() == Tiers.WOOD ? EpicFightSounds.BLUNT_HIT.get() : EpicFightSounds.BLADE_HIT.get());
@@ -339,6 +351,7 @@ public class WeaponCapabilityPresets {
 			.newStyleCombo(Styles.ONE_HAND, Animations.FIST_AUTO1, Animations.FIST_AUTO2, Animations.FIST_AUTO3, Animations.FIST_DASH, Animations.FIST_AIR_SLASH)
 			.innateSkill(Styles.ONE_HAND, (itemstack) -> EpicFightSkills.RELENTLESS_COMBO)
 			.category(WeaponCategories.FIST)
+			.addTag(EpicFightMod.identifier("fist"))
 			.constructor(GloveCapability::new);
 	
 	public static final Function<Item, CapabilityItem.Builder> BOW =  (item) -> RangedWeaponCapability.builder()

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponTypeReloadListener.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponTypeReloadListener.java
@@ -295,6 +295,15 @@ public class WeaponTypeReloadListener extends SimpleJsonResourceReloadListener {
 			});
 		}
 		
+		if (tag.contains("custom_tags")) {
+            for (Tag customTag : tag.getList("custom_tags", Tag.TAG_STRING)) {
+                builder.addTag(ResourceLocation.parse(customTag.getAsString()));
+            }
+        }
+		
+		// Add data pack path as default tag
+		builder.addTag(rl);
+		
 		return builder;
 	}
 	


### PR DESCRIPTION
This tag system will help developers identify their weapon types. Currently, it is restricted to `WeaponCategory`, an enum that could be shared by multiple weapon types.

### Usage
---
Inside both the **weapon type** and **item capability** .json files,
```
{
    ...
    "custom_tags": ["epicfight:custom_tag1"]
}
```

This will generate tags for applicable items. Once you create tags, you can check them via `WeaponCapability#hasMatchingTag`

```java
if (this.getHoldingItemCapability(InteractionHand.MAIN_HAND) instanceof WeaponCapability weaponCapability) {
	System.out.println(
			"Has Matching Tag? : " + weaponCapability.hasMatchingTag(ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "custom_tag1"))
	);
}
```
_Output_
```
Has Matching Tag? : true
```

### Notable features:
---
- If you specify tags in **weapon type** data pack, it will generate to all item capabilities inherits the weapon type.
- Built-in weapon types have a tag with their registry name. Check the differences in `WeaponCapabilityPresets`
- Data pack weapon types have a tag with their registry name. Check the differences in `WeaponTypeReloadListener`