### PR TITLE
Use @WrapOperation instead of @Redirect 

### DIFF
--- a/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinGameRenderer.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinGameRenderer.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
@@ -13,7 +15,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.config.ClientConfig;
 
@@ -23,21 +24,19 @@ public abstract class MixinGameRenderer {
     private Camera mainCamera;
     @Shadow @Final
     Minecraft minecraft;
-    @Shadow
-    public abstract void pick(float partialTick);
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/GameRenderer;pick(F)V"
         ),
         method = "renderLevel(Lnet/minecraft/client/DeltaTracker;)V"
     )
-    private void epicfight$renderLevel(GameRenderer gameRenderer, float partialTick) {
+    private void epicfight$renderLevel(GameRenderer instance, float partialTicks, Operation<Void> original) {
         if (EpicFightCameraAPI.getInstance().isTPSMode()) {
             this.pickInTPSPerspective();
         } else {
-            this.pick(partialTick);
+            original.call(instance, partialTicks);
         }
     }
 

--- a/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinGui.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinGui.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.DeltaTracker;
@@ -15,7 +17,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.client.events.engine.RenderEngine;
@@ -43,14 +44,14 @@ public abstract class MixinGui {
 	private void renderCrosshairINJECT(GuiGraphics guiGraphics, DeltaTracker deltaTracker, CallbackInfo callback) {
 		// Draw crosshair in TPS mode, since vanilla crosshair aren't rendered in third person.
 		if (EpicFightCameraAPI.getInstance().isTPSMode()) {
-			this.epicfight$renderCrosshair(guiGraphics, true);
+			this.epicfight$renderCrosshair(guiGraphics, true, () -> guiGraphics.blitSprite(Gui.CROSSHAIR_SPRITE, (guiGraphics.guiWidth() - 15) / 2, (guiGraphics.guiHeight() - 15) / 2, 15, 15));
 		}
 	}
 	
 	/**
 	 * Replace the crosshair into mining indicator
 	 */
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/client/gui/GuiGraphics;blitSprite(Lnet/minecraft/resources/ResourceLocation;IIII)V",
@@ -58,12 +59,12 @@ public abstract class MixinGui {
 		),
 		method = "renderCrosshair(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V"
 	)
-	private void renderCrosshairREDIRECT(GuiGraphics guiGraphics, ResourceLocation sprite, int x, int y, int width, int height) {
-		this.epicfight$renderCrosshair(guiGraphics, false);
+	private void renderCrosshairREDIRECT(GuiGraphics guiGraphics, ResourceLocation sprite, int x, int y, int width, int height, Operation<Void> original) {
+		this.epicfight$renderCrosshair(guiGraphics, false, () -> original.call(guiGraphics, sprite, x, y, width, height));
 	}
 	
 	@Unique
-	private void epicfight$renderCrosshair(GuiGraphics guiGraphics, boolean setupBlend) {
+	private void epicfight$renderCrosshair(GuiGraphics guiGraphics, boolean setupBlend, Runnable vanillaCrosshairRenderer) {
 		if (setupBlend) {
             RenderSystem.enableBlend();
             RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.ONE_MINUS_DST_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
@@ -82,7 +83,7 @@ public abstract class MixinGui {
 		}
 		
 		if (drawVanillaCrosshair.booleanValue()) {
-            guiGraphics.blitSprite(Gui.CROSSHAIR_SPRITE, (guiGraphics.guiWidth() - 15) / 2, (guiGraphics.guiHeight() - 15) / 2, 15, 15);
+            vanillaCrosshairRenderer.run();
 		} else {
             guiGraphics.blit(EntityUI.BATTLE_ICON, (guiGraphics.guiWidth() - 15) / 2, (guiGraphics.guiHeight() - 15) / 2, 0, 240, 15, 15);
 		}

--- a/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinMinecraft.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinMinecraft.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -18,7 +20,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
@@ -81,18 +82,18 @@ public class MixinMinecraft {
         }
     }
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/GameRenderer;pick(F)V"
         ),
         method = "tick()V"
     )
-    private void epicfight$tick(GameRenderer gameRenderer, float partialTick) {
+    private void epicfight$tick(GameRenderer instance, float partialTicks, Operation<Void> original) {
         if (EpicFightCameraAPI.getInstance().isTPSMode()) {
             this.pickInTPSPerspectiveMode();
         } else {
-            this.gameRenderer.pick(partialTick);
+            original.call(instance, partialTicks);
         }
     }
 

--- a/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinMouseHandler.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/client/MixinMouseHandler.java
@@ -1,22 +1,23 @@
 package yesman.epicfight.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.player.LocalPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 
 @Mixin(value = MouseHandler.class)
 public abstract class MixinMouseHandler {
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"
         ),
         method = "turnPlayer(D)V"
     )
-    private void epicfight$turnPlayer(LocalPlayer player, double yRot, double xRot) {
-        if (!EpicFightCameraAPI.getInstance().turnCamera(yRot, xRot)) player.turn(yRot, xRot);
+    private void epicfight$turnPlayer(LocalPlayer instance, double yRot, double xRot, Operation<Void> original) {
+        if (!EpicFightCameraAPI.getInstance().turnCamera(yRot, xRot)) original.call(instance, yRot, xRot);
     }
 }

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinCrossbowAttack.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinCrossbowAttack.java
@@ -1,9 +1,9 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.behavior.CrossbowAttack;
@@ -13,16 +13,17 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
 @Mixin(value = CrossbowAttack.class)
 public abstract class MixinCrossbowAttack {
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/monster/RangedAttackMob;performRangedAttack(Lnet/minecraft/world/entity/LivingEntity;F)V"
 		),
 		method = "crossbowAttack"
 	)
-	private void epicfight$crossbowAttack(RangedAttackMob self, LivingEntity target, float velocity) {
-		self.performRangedAttack(target, velocity);
+	private void epicfight$crossbowAttack(RangedAttackMob self, LivingEntity target, float velocity, Operation<Void> original) {
+		original.call(self, target, velocity);
 		
-		EpicFightCapabilities.getUnparameterizedEntityPatch((Entity)self, LivingEntityPatch.class).ifPresent(LivingEntityPatch::playShootingAnimation);
+		EpicFightCapabilities.getUnparameterizedEntityPatch((Entity)self, LivingEntityPatch.class)
+				.ifPresent(LivingEntityPatch::playShootingAnimation);
 	}
 }

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinEntity.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.Entity;
@@ -11,7 +13,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import yesman.epicfight.api.animation.property.AnimationProperty.ActionAnimationProperty;
 import yesman.epicfight.api.event.EpicFightEventHooks;
@@ -104,30 +105,30 @@ public abstract class MixinEntity {
         }
     }
 	
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/Entity;addAdditionalSaveData(Lnet/minecraft/nbt/CompoundTag;)V"
 		),
 		method = "saveWithoutId(Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/nbt/CompoundTag;"
 	)
-	private void epicfight$saveWithoutId(Entity self, CompoundTag compoundTag) {
-		this.addAdditionalSaveData(compoundTag);
+	private void epicfight$saveWithoutId(Entity self, CompoundTag compoundTag, Operation<Void> original) {
+		original.call(self, compoundTag);
 		
 		EpicFightCapabilities.getUnparameterizedEntityPatch(self, EntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.writeData(compoundTag);
 		});
 	}
 	
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/Entity;readAdditionalSaveData(Lnet/minecraft/nbt/CompoundTag;)V"
 		),
 		method = "load(Lnet/minecraft/nbt/CompoundTag;)V"
 	)
-	private void epicfight$load(Entity self, CompoundTag compoundTag) {
-		this.readAdditionalSaveData(compoundTag);
+	private void epicfight$load(Entity self, CompoundTag compoundTag, Operation<Void> original) {
+		original.call(self, compoundTag);
 		
 		EpicFightCapabilities.getUnparameterizedEntityPatch(self, EntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.readData(compoundTag);

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinLivingEntity.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinLivingEntity.java
@@ -1,5 +1,7 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.CombatRules;
 import net.minecraft.world.damagesource.DamageSource;
@@ -14,7 +16,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
@@ -130,23 +131,23 @@ public abstract class MixinLivingEntity {
 		});
 	}
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/entity/LivingEntity;getYRot()F"
         ),
         method = "jumpFromGround()V"
     )
-    private float epicfight$jumpFromGround(LivingEntity livingEntity) {
+    private float epicfight$jumpFromGround(LivingEntity livingEntity, Operation<Float> original) {
         if (livingEntity instanceof Player player && player.isLocalPlayer()) {
             EpicFightCameraAPI cameraApi = EpicFightCameraAPI.getInstance();
-            return cameraApi.isTPSMode() ? cameraApi.getCameraYRot() : livingEntity.getYRot();
+            return cameraApi.isTPSMode() ? cameraApi.getCameraYRot() : original.call(livingEntity);
         }
 
-        return livingEntity.getYRot();
+        return original.call(livingEntity);
     }
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/entity/LivingEntity;getYRot()F",
@@ -154,28 +155,28 @@ public abstract class MixinLivingEntity {
         ),
         method = "tick()V"
     )
-    private float epicfight$tick(LivingEntity livingEntity) {
+    private float epicfight$tick(LivingEntity livingEntity, Operation<Float> original) {
         // returns the basis y rotation as camera in TPS mode
         if (livingEntity instanceof Player player && player.isLocalPlayer()) {
             return EpicFightCameraAPI.getInstance().getYRotForHead(player);
         }
 
-        return livingEntity.getYRot();
+        return original.call(livingEntity);
     }
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/entity/LivingEntity;getYRot()F"
         ),
         method = "tickHeadTurn(FF)F"
     )
-    protected float epicfight$tickHeadTurn(LivingEntity livingEntity) {
+    protected float epicfight$tickHeadTurn(LivingEntity livingEntity, Operation<Float> original) {
         // returns the basis y rotation as camera in TPS mode
         if (livingEntity instanceof Player player && player.isLocalPlayer()) {
             return EpicFightCameraAPI.getInstance().getYRotForHead(player);
         }
 
-        return livingEntity.getYRot();
+        return original.call(livingEntity);
     }
 }

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinPlayer.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinPlayer.java
@@ -1,44 +1,46 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.damagesource.CombatTracker;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+
 import yesman.epicfight.api.client.camera.EpicFightCameraAPI;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
 @Mixin(value = Player.class)
 public abstract class MixinPlayer {
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/damagesource/CombatTracker;recordDamage(Lnet/minecraft/world/damagesource/DamageSource;F)V"
 		),
 		method = "actuallyHurt(Lnet/minecraft/world/damagesource/DamageSource;F)V"
 	)
-	private void epicfight$recordDamage(CombatTracker self, DamageSource damagesource, float damage) {
+	private void epicfight$recordDamage(CombatTracker self, DamageSource damagesource, float damage, Operation<Void> original) {
 		EpicFightCapabilities.getUnparameterizedEntityPatch(damagesource.getEntity(), LivingEntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.setLastAttackEntity(self.mob);
 		});
 		
-		self.recordDamage(damagesource, damage);
+		original.call(self, damagesource, damage);
 	}
 
-    @Redirect(
+    @WrapOperation(
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/entity/player/Player;getYRot()F"
         ),
         method = "serverAiStep()V"
     )
-    private float epicfight$serverAiStep(Player player) {
+    private float epicfight$serverAiStep(Player player, Operation<Float> original) {
         if (player.isLocalPlayer()) {
             return EpicFightCameraAPI.getInstance().getYRotForHead(player);
         }
 
-        return player.getYRot();
+        return original.call(player);
     }
 }

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedAttackGoal.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedAttackGoal.java
@@ -1,9 +1,9 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.goal.RangedAttackGoal;
@@ -13,15 +13,15 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
 @Mixin(value = RangedAttackGoal.class)
 public class MixinRangedAttackGoal {
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/monster/RangedAttackMob;performRangedAttack(Lnet/minecraft/world/entity/LivingEntity;F)V"
 		),
 		method = "tick()V"
 	)
-	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity) {
-		self.performRangedAttack(target, velocity);
+	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity, Operation<Void> original) {
+		original.call(self, target, velocity);
 		
 		EpicFightCapabilities.getUnparameterizedEntityPatch((Entity)self, LivingEntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.playShootingAnimation();

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedBowAttackGoal.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedBowAttackGoal.java
@@ -1,9 +1,9 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.goal.RangedBowAttackGoal;
@@ -13,15 +13,15 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
 @Mixin(value = RangedBowAttackGoal.class)
 public class MixinRangedBowAttackGoal {
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/monster/RangedAttackMob;performRangedAttack(Lnet/minecraft/world/entity/LivingEntity;F)V"
 		),
 		method = "tick()V"
 	)
-	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity) {
-		self.performRangedAttack(target, velocity);
+	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity, Operation<Void> original) {
+		original.call(self, target, velocity);
 		
 		EpicFightCapabilities.getUnparameterizedEntityPatch((Entity)self, LivingEntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.playShootingAnimation();

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedCrossbowAttackGoal.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinRangedCrossbowAttackGoal.java
@@ -1,8 +1,10 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -13,15 +15,15 @@ import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
 
 @Mixin(value = RangedCrossbowAttackGoal.class)
 public class MixinRangedCrossbowAttackGoal {
-	@Redirect(
+	@WrapOperation(
 		at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/entity/monster/RangedAttackMob;performRangedAttack(Lnet/minecraft/world/entity/LivingEntity;F)V"
 		),
 		method = "tick()V"
 	)
-	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity) {
-		self.performRangedAttack(target, velocity);
+	private void epicfight$tick(RangedAttackMob self, LivingEntity target, float velocity, Operation<Void> original) {
+		original.call(self, target, velocity);
 		
 		EpicFightCapabilities.getUnparameterizedEntityPatch((Entity)self, LivingEntityPatch.class).ifPresent(entitypatch -> {
 			entitypatch.playShootingAnimation();

--- a/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinThrownTrident.java
+++ b/neoforge/src/main/java/yesman/epicfight/mixin/common/MixinThrownTrident.java
@@ -1,11 +1,11 @@
 package yesman.epicfight.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.AbstractArrow;
@@ -22,21 +22,21 @@ public abstract class MixinThrownTrident extends AbstractArrow {
 		super(p_36721_, p_36722_);
 	}
 	
-	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/ThrownTrident;setPosRaw(DDD)V"), method = "tick()V")
-	private void epicfight_setPosRawInTick(ThrownTrident entity, double x, double y, double z) {
+	@WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/ThrownTrident;setPosRaw(DDD)V"), method = "tick()V")
+	private void epicfight_setPosRawInTick(ThrownTrident entity, double x, double y, double z, Operation<Void> original) {
 		ThrownTridentPatch tridentPatch = EpicFightCapabilities.getEntityPatch(entity, ThrownTridentPatch.class);
 		
 		if (tridentPatch == null || !tridentPatch.isInnateActivated()) {
-			entity.setPosRaw(x, y, z);
+			original.call(entity, x, y, z);
 		}
 	}
 	
-	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/ThrownTrident;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"), method = "tick()V")
-	private void epicfight_setDeltaMovementInTick(ThrownTrident entity, Vec3 vec3) {
+	@WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/ThrownTrident;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"), method = "tick()V")
+	private void epicfight_setDeltaMovementInTick(ThrownTrident entity, Vec3 vec3, Operation<Void> original) {
 		ThrownTridentPatch tridentPatch = EpicFightCapabilities.getEntityPatch(entity, ThrownTridentPatch.class);
 		
 		if (tridentPatch == null || !tridentPatch.isInnateActivated()) {
-			entity.setDeltaMovement(vec3);
+			original.call(entity, vec3);
 		}
 	}
 	
@@ -49,9 +49,9 @@ public abstract class MixinThrownTrident extends AbstractArrow {
 		}
 	}
 	
-	@Redirect(     at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;playerTouch(Lnet/minecraft/world/entity/player/Player;)V")
+	@WrapOperation(     at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;playerTouch(Lnet/minecraft/world/entity/player/Player;)V")
 	         , method = "playerTouch(Lnet/minecraft/world/entity/player/Player;)V")
-	private void epicfight_playerTouch(AbstractArrow entity, Player player) {
+	private void epicfight_playerTouch(ThrownTrident entity, Player player, Operation<Void> original) {
 		ThrownTridentPatch tridentPatch = EpicFightCapabilities.getEntityPatch(entity, ThrownTridentPatch.class);
 		
 		if (tridentPatch != null && tridentPatch.isInnateActivated()) {
@@ -62,6 +62,6 @@ public abstract class MixinThrownTrident extends AbstractArrow {
 			}
 		}
 		
-		super.playerTouch(player);
+		original.call(entity, player);
 	}
 }

--- a/neoforge/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
+++ b/neoforge/src/main/java/yesman/epicfight/platform/neoforge/mixin/MixinClientLevel.java
@@ -1,23 +1,24 @@
 package yesman.epicfight.platform.neoforge.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.IEventBus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import yesman.epicfight.client.world.util.FakeLevel;
 
 @Mixin(value = ClientLevel.class)
 public abstract class MixinClientLevel {
-    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/bus/api/IEventBus;post(Lnet/neoforged/bus/api/Event;)Lnet/neoforged/bus/api/Event;"))
-    private Event epicfight$init(IEventBus instance, Event e) {
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/bus/api/IEventBus;post(Lnet/neoforged/bus/api/Event;)Lnet/neoforged/bus/api/Event;"))
+    private <T extends Event> T epicfight$init(IEventBus instance, T t, Operation<T> original) {
         if (((ClientLevel)(Object)this) instanceof FakeLevel) {
             // Prevents crashes that can occur when joining the world with certain mods.
             // See: https://github.com/Epic-Fight/epicfight/issues/2164
             return null;
         }
 
-        return instance.post(e);
+        return original.call(instance, t);
     }
 }


### PR DESCRIPTION
Even though they they're fine by themselves, redirects don't stack with other mods. This is an incompatibility just waiting to happen and it will be hard to debug once it does. 

Since your use of redirects is exactly what [@WrapOperation from mixin extras does](https://github.com/LlamaLad7/MixinExtras/wiki/WrapOperation), I've used it in their place. Everything should be the same with the except MixinGui.epicfight$renderCrosshair where I added runnable for the original crosshair (since its called from an inject too)

